### PR TITLE
Add analyzer for System.Deployment

### DIFF
--- a/src/Analyzers/AspNetMigrator.Analyzers/DiagnosticAnalyzerExtensions.cs
+++ b/src/Analyzers/AspNetMigrator.Analyzers/DiagnosticAnalyzerExtensions.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace AspNetMigrator.Analyzers
+{
+    internal static class DiagnosticAnalyzerExtensions
+    {
+        public static bool NameEquals(this IAssemblySymbol? symbol, string name, bool startsWith = true)
+        {
+            if (symbol is null)
+            {
+                return false;
+            }
+
+            if (startsWith)
+            {
+                return symbol.Name.StartsWith(name, StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                return string.Equals(symbol.Name, name, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        public static void RegisterMemberAccess(this AnalysisContext context, Action<InvocationAnalysisContext> action)
+        {
+            var operationKinds = new[]
+            {
+                OperationKind.Invocation,
+                OperationKind.SimpleAssignment,
+                OperationKind.VariableDeclaration,
+                OperationKind.ObjectCreation,
+                OperationKind.FieldInitializer,
+                OperationKind.FieldReference,
+            };
+
+            context.RegisterOperationAction(ctx =>
+            {
+                ISymbol? symbol = ctx.Operation switch
+                {
+                    IInvocationOperation invocation => invocation.TargetMethod,
+                    IPropertyReferenceOperation property => property.Property.Type,
+                    IObjectCreationOperation creation => creation.Type,
+                    ISimpleAssignmentOperation assignment => assignment.Type,
+                    IFieldInitializerOperation fieldInitializer => fieldInitializer.Type,
+                    IFieldReferenceOperation fieldRef => fieldRef.Type,
+                    IVariableDeclarationOperation variableDeclaration => variableDeclaration.Type,
+                    _ => null,
+                };
+
+                if (symbol is null)
+                {
+                    return;
+                }
+
+                var location = ctx.Operation.Syntax.GetLocation();
+                var newCtx = new InvocationAnalysisContext(symbol, location, ctx.Compilation, ctx.Options, ctx.ReportDiagnostic, ctx.CancellationToken);
+
+                action(newCtx);
+            }, operationKinds);
+
+            context.RegisterSymbolAction(ctx =>
+            {
+                var symbol = ctx.Symbol switch
+                {
+                    IPropertySymbol property => property.Type,
+                    IParameterSymbol parameter => parameter.Type,
+                    IMethodSymbol method => method.ReturnsVoid ? null : method.ReturnType,
+                    IFieldSymbol field => field.Type,
+                    _ => null,
+                };
+
+                if (symbol is null)
+                {
+                    return;
+                }
+
+                var location = ctx.Symbol.Locations[0];
+                var newCtx = new InvocationAnalysisContext(symbol, location, ctx.Compilation, ctx.Options, ctx.ReportDiagnostic, ctx.CancellationToken);
+
+                action(newCtx);
+            }, SymbolKind.Property, SymbolKind.Method, SymbolKind.Parameter, SymbolKind.Field);
+        }
+
+        public readonly struct InvocationAnalysisContext
+        {
+            private readonly Action<Diagnostic> _reportDiagnostic;
+
+            public InvocationAnalysisContext(ISymbol symbol, Location location, Compilation compilation, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
+            {
+                Symbol = symbol;
+                Location = location;
+                Options = options;
+                Compilation = compilation;
+                CancellationToken = cancellationToken;
+
+                _reportDiagnostic = reportDiagnostic;
+            }
+
+            public Location Location { get; }
+
+            public AnalyzerOptions Options { get; }
+
+            public ISymbol Symbol { get; }
+
+            public Compilation Compilation { get; }
+
+            public CancellationToken CancellationToken { get; }
+
+            public void ReportDiagnostic(Diagnostic diagnostic) => _reportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/src/Analyzers/AspNetMigrator.Analyzers/Resources.Designer.cs
+++ b/src/Analyzers/AspNetMigrator.Analyzers/Resources.Designer.cs
@@ -304,6 +304,15 @@ namespace AspNetMigrator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to System.Deployment is not supported on .NET Core.
+        /// </summary>
+        internal static string UsingSystemDeployment {
+            get {
+                return ResourceManager.GetString("UsingSystemDeployment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ASP.NET Core projects should not reference System.Web or OWIN namespaces..
         /// </summary>
         internal static string UsingSystemWebDescription {

--- a/src/Analyzers/AspNetMigrator.Analyzers/Resources.resx
+++ b/src/Analyzers/AspNetMigrator.Analyzers/Resources.resx
@@ -198,6 +198,9 @@
   <data name="UrlHelperTitle" xml:space="preserve">
     <value>UrlHelper should be replaced with IUrlHelper</value>
   </data>
+  <data name="UsingSystemDeployment" xml:space="preserve">
+    <value>System.Deployment is not supported on .NET Core</value>
+  </data>
   <data name="UsingSystemWebDescription" xml:space="preserve">
     <value>ASP.NET Core projects should not reference System.Web or OWIN namespaces.</value>
     <comment>An optional longer localizable description of the diagnostic.</comment>

--- a/src/Analyzers/AspNetMigrator.Analyzers/SystemDeploymentAnalyzer.cs
+++ b/src/Analyzers/AspNetMigrator.Analyzers/SystemDeploymentAnalyzer.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace AspNetMigrator.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic, LanguageNames.FSharp)]
+    public class SystemDeploymentAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "AM0011";
+        private const string Category = "Migration";
+        private const string AssemblyName = "System.Deployment";
+
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.UsingSystemDeployment), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.UsingSystemDeployment), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.UsingSystemDeployment), Resources.ResourceManager, typeof(Resources));
+        private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+            context.RegisterMemberAccess(context =>
+            {
+                if (context.Symbol.ContainingAssembly.NameEquals(AssemblyName))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, context.Location));
+                }
+            });
+        }
+    }
+}

--- a/src/AspNetMigrator.Console/appsettings.json
+++ b/src/AspNetMigrator.Console/appsettings.json
@@ -9,7 +9,7 @@
   },
   "PackageUpdater": {
     "PackageMapPath": "PackageMaps",
-    "MigrationAnalyzersPackageSource": "https://trymigrate.blob.core.windows.net/feed/index.json"
+    "MigrationAnalyzersPackageSource": "https://upgradeassistant.blob.core.windows.net/feed/index.json"
   },
   "SourceUpdater": {
     "SourceUpdaterPath": "SourceUpdaters"


### PR DESCRIPTION
This adds an analyzer to flag usage of System.Deployment based on any assembly System.Deployment.*. This change also includes a VSIX to easily deploy the analyzers to try out in VS for quick debugging of solutions.

Of note here is the extension method `AnalysisContext.RegisterMemberAccess` which will simplify checks of any member access in a language-agnostic way by using symbols and operations.