### PR TITLE
Skip preview MSBuild

### DIFF
--- a/src/components/Microsoft.UpgradeAssistant.MSBuild/MSBuildRegistrationStartup.cs
+++ b/src/components/Microsoft.UpgradeAssistant.MSBuild/MSBuildRegistrationStartup.cs
@@ -38,8 +38,11 @@ namespace Microsoft.UpgradeAssistant.MSBuild
                         _logger.LogDebug("Found candidate MSBuild instances: {Path}", instance.MSBuildPath);
                     }
 
-                    _msBuildInstance = msBuildInstances.First();
+                    _msBuildInstance = msBuildInstances
+                        .OrderByDescending(m => m.Version)
+                        .First(m => !m.MSBuildPath.Contains("preview", StringComparison.OrdinalIgnoreCase));
                     _logger.LogInformation("MSBuild registered from {MSBuildPath}", _msBuildInstance.MSBuildPath);
+
                     MSBuildLocator.RegisterInstance(_msBuildInstance);
                     AssemblyLoadContext.Default.Resolving += ResolveAssembly;
                 }


### PR DESCRIPTION
The ordering the locator gives us is apparently non-deterministic and will include previews. With the 5.0.200-preview series this is causing another NuGet.Frameworks load error, so for now, just forcing it to be the latest stable release fixes the issue.