### PR TITLE
Add explicit exclusion for NuGet and MSBuild runtime assets in CLI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <PackageVersion Include="Automapper" Version="10.1.1" />
     <PackageVersion Include="coverlet.collector" Version="3.0.2" />
     <PackageVersion Include="Microsoft.Build" Version="16.8.0" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="16.8.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.4.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.3.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
@@ -27,8 +28,15 @@
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="2.3.2262-g94fae01e" />
     <PackageVersion Include="Moq" Version="4.16.0" />
     <PackageVersion Include="NSubstitute" Version="4.2.2" />
+    <PackageVersion Include="NuGet.Common" Version="5.8.0" />
+    <PackageVersion Include="NuGet.Configuration" Version="5.8.0" />
+    <PackageVersion Include="NuGet.DependencyResolver.Core" Version="5.8.0" />
+    <PackageVersion Include="NuGet.LibraryModel" Version="5.8.0" />
     <PackageVersion Include="NuGet.Frameworks" Version="5.8.0" />
+    <PackageVersion Include="NuGet.Packaging" Version="5.8.0" />
     <PackageVersion Include="NuGet.ProjectModel" Version="5.8.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="5.8.0" />
+    <PackageVersion Include="NuGet.Versioning" Version="5.8.0" />
     <PackageVersion Include="Serilog" Version="2.10.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="3.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/cli/Microsoft.UpgradeAssistant.Cli/Microsoft.UpgradeAssistant.Cli.csproj
+++ b/src/cli/Microsoft.UpgradeAssistant.Cli/Microsoft.UpgradeAssistant.Cli.csproj
@@ -26,6 +26,22 @@
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="System.CommandLine" />
+
+    <!-- Explicitly reference packages that we do *not* want included in our
+         bin folder in case transitive dependencies pull them in. These runtime
+         assets are excluded because they are loaded from the version of MSBuild
+         used by the tool, instead. -->
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.Common" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.Configuration" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.DependencyResolver.Core" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.LibraryModel" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.Packaging" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.ProjectModel" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.Protocol" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.Versioning" ExcludeAssets="runtime" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\common\Microsoft.UpgradeAssistant.Abstractions\Microsoft.UpgradeAssistant.Abstractions.csproj" />


### PR DESCRIPTION
We want to load NuGet and MSBuild binaries from the selected MSBuild install location so that they match what MSBuild is using. Unfortunately, transitive dependencies seem to be including NuGet and MSBuild runtime assets in the CLI output path.

This fix explicitly includes those packages with ExcludeAssets="runtime" so that they won't be included.