### PR TITLE
Change TFM comparer to see framework as before core/standard

### DIFF
--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TargetFrameworkMoniker.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TargetFrameworkMoniker.cs
@@ -9,6 +9,8 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
         public override string ToString() => Name;
 
+        public bool IsFramework => !IsNetStandard && !IsNetCore;
+
         public bool IsNetStandard => Name.StartsWith(NetStandardNamePrefix, StringComparison.OrdinalIgnoreCase);
 
         public bool IsNetCore => Name.StartsWith(NetPrefix, StringComparison.OrdinalIgnoreCase) && Name.Contains('.');

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/TargetFrameworkMonikerComparer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/TargetFrameworkMonikerComparer.cs
@@ -47,6 +47,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
                 return 0;
             }
 
+            if (y.IsNetStandard && x.IsFramework)
+            {
+                return -1;
+            }
+
             var dependentToDependency = DefaultCompatibilityProvider.Instance.IsCompatible(dependent, dependency);
             var dependencyToDependent = DefaultCompatibilityProvider.Instance.IsCompatible(dependency, dependent);
 

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Test/TargetFrameworkIdentifierTests.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Test/TargetFrameworkIdentifierTests.cs
@@ -24,6 +24,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Test
         [InlineData("netcoreapp3.1", "net471", false)]
         [InlineData("netcoreapp3.1", "net47", false)]
         [InlineData("netcoreapp3.1", "net45", false)]
+        [InlineData("net48", "netcoreapp3.1", false)]
+        [InlineData("net471", "netcoreapp3.1", false)]
+        [InlineData("net471", "net5.0", false)]
+        [InlineData("net471", "netstandard2.0", false)]
+        [InlineData("net461", "netstandard2.0", false)]
+        [InlineData("net46", "netstandard2.0", false)]
         [Theory]
         public void IsCoreCompatibleSDKTargetFramework(string target, string tfm, bool isCompatible)
         {
@@ -54,6 +60,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Test
         [InlineData("netcoreapp3.1", "net471", -1)]
         [InlineData("netcoreapp3.1", "net47", -1)]
         [InlineData("netcoreapp3.1", "net45", -1)]
+        [InlineData("net48", "netcoreapp3.1", -1)]
+        [InlineData("net471", "netcoreapp3.1", -1)]
+        [InlineData("net471", "net5.0", -1)]
+        [InlineData("net471", "netstandard2.0", -1)]
+        [InlineData("net461", "netstandard2.0", -1)]
+        [InlineData("net46", "netstandard2.0", -1)]
         [Theory]
         public void TfmCompare(string target, string tfm, int expected)
         {


### PR DESCRIPTION
After identifying the most likely TFM, we check if we will be downgrading the current project. If a project was selected to target .NET Standard but was currently targeting .NET 4.7.2 (or any .NET framework that supports .NET Standard), it would be marked as downgrading and select .NET 4.7.2 as the final TFM. This special cases .NET Standard so that it will always be seen as after .NET Framework TFMs.