### PR TITLE
Expand PackageMapReferenceAnalyzer to also replace assembly references

### DIFF
--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IProjectFile.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IProjectFile.cs
@@ -15,9 +15,11 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
         string FilePath { get; }
 
-        void AddPackages(IEnumerable<NuGetReference> references);
+        void AddPackages(IEnumerable<NuGetReference> packages);
 
-        void RemovePackages(IEnumerable<NuGetReference> referenceItem);
+        void RemovePackages(IEnumerable<NuGetReference> packages);
+
+        void RemoveReferences(IEnumerable<Reference> references);
 
         ValueTask SaveAsync(CancellationToken token);
 

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Reference.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Reference.cs
@@ -3,5 +3,8 @@
 
 namespace Microsoft.DotNet.UpgradeAssistant
 {
-    public record Reference(string Name);
+    public record Reference(string Name)
+    {
+        public override string ToString() => Name;
+    }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildExtensions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildExtensions.cs
@@ -48,6 +48,17 @@ namespace Microsoft.DotNet.UpgradeAssistant
             }
         }
 
+        public static void RemoveReference(this ProjectRootElement projectRoot, Reference reference)
+        {
+            var element = projectRoot.GetAllReferences()
+                .FirstOrDefault(r => reference.Equals(r.AsReference()));
+
+            if (element is not null)
+            {
+                element.RemoveElement();
+            }
+        }
+
         public static IEnumerable<ProjectItemElement> GetAllReferences(this ProjectRootElement projectRoot)
             => projectRoot.Items.Where(i => i.ItemType.Equals(MSBuildConstants.ReferenceType, StringComparison.OrdinalIgnoreCase));
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
@@ -119,6 +119,18 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             }
         }
 
+        public void RemoveReferences(IEnumerable<Reference> references)
+        {
+            foreach (var reference in references)
+            {
+                if (references.Contains(reference))
+                {
+                    _logger.LogInformation("Removing outdated assembly reference: {Reference}", reference);
+                    ProjectRoot.RemoveReference(reference);
+                }
+            }
+        }
+
         public void RenameFile(string filePath)
         {
             var fileName = Path.GetFileName(filePath);

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/PackageMapReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/PackageMapReferenceAnalyzer.cs
@@ -13,12 +13,14 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
     {
         private readonly ILogger<PackageMapReferenceAnalyzer> _logger;
         private readonly PackageMapProvider _packageMapProvider;
+        private readonly IPackageLoader _packageLoader;
 
         public string Name => "Package map reference analyzer";
 
-        public PackageMapReferenceAnalyzer(PackageMapProvider packageMapProvider, ILogger<PackageMapReferenceAnalyzer> logger)
+        public PackageMapReferenceAnalyzer(PackageMapProvider packageMapProvider, IPackageLoader packageLoader, ILogger<PackageMapReferenceAnalyzer> logger)
         {
             _packageMapProvider = packageMapProvider ?? throw new ArgumentNullException(nameof(packageMapProvider));
+            _packageLoader = packageLoader ?? throw new ArgumentNullException(nameof(packageLoader));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -31,25 +33,54 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
 
             // Get package maps as an array here so that they're only loaded once (as opposed to each iteration through the loop)
             var packageMaps = await _packageMapProvider.GetPackageMapsAsync(token).ToArrayAsync(token).ConfigureAwait(false);
-            var references = project.Required().PackageReferences;
-            foreach (var packageReference in references.Where(r => !state.PackagesToRemove.Contains(r)))
+
+            var packageReferences = project.Required().PackageReferences;
+            foreach (var packageReference in packageReferences.Where(r => !state.PackagesToRemove.Contains(r)))
             {
-                foreach (var map in packageMaps.Where(m => m.ContainsReference(packageReference.Name, packageReference.Version)))
+                foreach (var map in packageMaps.Where(m => m.ContainsPackageReference(packageReference.Name, packageReference.Version)))
                 {
-                    if (map != null)
-                    {
-                        state.PossibleBreakingChangeRecommended = true;
-                        _logger.LogInformation("Marking package {PackageName} for removal based on package mapping configuration {PackageMapSet}", packageReference.Name, map.PackageSetName);
-                        state.PackagesToRemove.Add(packageReference);
-                        foreach (var newPackage in map.NetCorePackages)
-                        {
-                            state.PackagesToAdd.Add(newPackage);
-                        }
-                    }
+                    state.PossibleBreakingChangeRecommended = true;
+                    _logger.LogInformation("Marking package {PackageName} for removal based on package mapping configuration {PackageMapSet}", packageReference.Name, map.PackageSetName);
+                    state.PackagesToRemove.Add(packageReference);
+                    await AddNetCorePackages(map, state, project, token).ConfigureAwait(false);
+                }
+            }
+
+            var assemblyReferences = project.References;
+            foreach (var reference in assemblyReferences.Where(r => !state.ReferencesToRemove.Contains(r)))
+            {
+                foreach (var map in packageMaps.Where(m => m.ContainsAssemblyReference(reference.Name)))
+                {
+                    state.PossibleBreakingChangeRecommended = true;
+                    _logger.LogInformation("Marking assembly reference {ReferenceName} for removal based on package mapping configuration {PackageMapSet}", reference.Name, map.PackageSetName);
+                    state.ReferencesToRemove.Add(reference);
+                    await AddNetCorePackages(map, state, project, token).ConfigureAwait(false);
                 }
             }
 
             return state;
+        }
+
+        private async Task AddNetCorePackages(NuGetPackageMap packageMap, PackageAnalysisState state, IProject project, CancellationToken token)
+        {
+            foreach (var newPackage in packageMap.NetCorePackages)
+            {
+                var packageToAdd = newPackage;
+                if (packageToAdd.HasWildcardVersion)
+                {
+                    var version = await _packageLoader.GetLatestVersionAsync(packageToAdd.Name, false, null, token).ConfigureAwait(false);
+                    if (version is not null)
+                    {
+                        packageToAdd = packageToAdd with { Version = version.ToNormalizedString() };
+                    }
+                }
+
+                if (!state.PackagesToAdd.Contains(packageToAdd) && !project.PackageReferences.Contains(packageToAdd))
+                {
+                    _logger.LogInformation("Adding package {PackageName} based on package mapping configuration {PackageMapSet}", packageToAdd.Name, packageMap.PackageSetName);
+                    state.PackagesToAdd.Add(packageToAdd);
+                }
+            }
         }
     }
 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/NuGetPackageMap.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/NuGetPackageMap.cs
@@ -12,6 +12,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
     {
         public string PackageSetName { get; set; } = string.Empty;
 
+        public IEnumerable<Reference> NetFrameworkAssemblies { get; set; } = Enumerable.Empty<Reference>();
+
         public IEnumerable<NuGetReference> NetFrameworkPackages { get; set; } = Enumerable.Empty<NuGetReference>();
 
         public IEnumerable<NuGetReference> NetCorePackages { get; set; } = Enumerable.Empty<NuGetReference>();
@@ -23,7 +25,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
         /// <param name="name">The package name to look for.</param>
         /// <param name="version">The package version to look for or null to match any version.</param>
         /// <returns>True if the package exists in NetFrameworkPackages with a version equal to or higher the version specified. Otherwise, false.</returns>
-        public bool ContainsReference(string name, string? version)
+        public bool ContainsPackageReference(string name, string? version)
         {
             // Check whether any NetFx packages have the right name
             var reference = NetFrameworkPackages.FirstOrDefault(r => r.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
@@ -51,5 +53,14 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
             var netFxVersion = reference.GetNuGetVersion();
             return parsedVersion <= netFxVersion;
         }
+
+        /// <summary>
+        /// Determines whether a package map's .NET Framework assemblies include a
+        /// given assembly reference.
+        /// </summary>
+        /// <param name="name">The assembly reference name to look for.</param>
+        /// <returns>True if the reference exists in the map's .NET Framework assembly references. Otherwise, false.</returns>
+        public bool ContainsAssemblyReference(string name) =>
+            NetFrameworkAssemblies.Any(r => r.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageAnalysisState.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageAnalysisState.cs
@@ -19,16 +19,19 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
 
         public IList<NuGetReference> PackagesToRemove { get; }
 
+        public IList<Reference> ReferencesToRemove { get; }
+
         public bool Failed { get; set; }
 
         public bool PossibleBreakingChangeRecommended { get; set; }
 
-        public bool ChangesRecommended => PackagesToAdd.Any() || PackagesToRemove.Any();
+        public bool ChangesRecommended => PackagesToAdd.Any() || PackagesToRemove.Any() || ReferencesToRemove.Any();
 
         private PackageAnalysisState()
         {
             PackagesToRemove = new List<NuGetReference>();
             PackagesToAdd = new List<NuGetReference>();
+            ReferencesToRemove = new List<Reference>();
             Failed = false;
             PossibleBreakingChangeRecommended = false;
         }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageMaps/AssemblyPackageMaps.json
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageMaps/AssemblyPackageMaps.json
@@ -1,0 +1,36 @@
+﻿[
+  {
+    "PackageSetName": "System.ServiceModel",
+    "NetFrameworkAssemblies": [
+      {
+        "Name": "System.ServiceModel"
+      }
+    ],
+    "NetCorePackages": [
+      {
+        "Name": "System.ServiceModel.Primitives",
+        "Version": "4.8.1"
+      },
+      {
+        "Name": "System.ServiceModel.Http",
+        "Version": "4.8.1"
+      },
+      {
+        "Name": "System.ServiceModel.Duplex",
+        "Version": "4.8.1"
+      },
+      {
+        "Name": "System.ServiceModel.NetTcp",
+        "Version": "4.8.1"
+      },
+      {
+        "Name": "System.ServiceModel.Security",
+        "Version": "4.8.1"
+      },
+      {
+        "Name": "System.ServiceModel.Federation",
+        "Version": "4.8.1"
+      }
+    ]
+  }
+]

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageUpdaterStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageUpdaterStep.cs
@@ -116,6 +116,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
             }
             else
             {
+                if (_analysisState.ReferencesToRemove.Count > 0)
+                {
+                    Logger.LogInformation($"References to be removed:\n{string.Join('\n', _analysisState.ReferencesToRemove.Distinct())}");
+                }
+
                 if (_analysisState.PackagesToRemove.Count > 0)
                 {
                     Logger.LogInformation($"Packages to be removed:\n{string.Join('\n', _analysisState.PackagesToRemove.Distinct())}");
@@ -126,7 +131,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
                     Logger.LogInformation($"Packages to be addded:\n{string.Join('\n', _analysisState.PackagesToAdd.Distinct())}");
                 }
 
-                return new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"{_analysisState.PackagesToRemove.Distinct().Count()} packages need removed and {_analysisState.PackagesToAdd.Distinct().Count()} packages need added", _analysisState.PossibleBreakingChangeRecommended ? BuildBreakRisk.Medium : BuildBreakRisk.Low);
+                return new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"{_analysisState.ReferencesToRemove.Distinct().Count()} references need removed, {_analysisState.PackagesToRemove.Distinct().Count()} packages need removed, and {_analysisState.PackagesToAdd.Distinct().Count()} packages need added", _analysisState.PossibleBreakingChangeRecommended ? BuildBreakRisk.Medium : BuildBreakRisk.Low);
             }
         }
 
@@ -166,6 +171,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
 
                     if (_analysisState is not null)
                     {
+                        projectFile.RemoveReferences(_analysisState.ReferencesToRemove.Distinct());
                         projectFile.RemovePackages(_analysisState.PackagesToRemove.Distinct());
                         projectFile.AddPackages(_analysisState.PackagesToAdd.Distinct());
 


### PR DESCRIPTION
This adds the ability to replace `<Reference>` elements with .NET 5-compatible NuGet packages in addition to `<PackageReference>` elements and adds mappings for System.ServiceModel.