### PR TITLE
Convert abstractions to target .NET Standard 2.0

### DIFF
--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/DeconstructExtensions.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/DeconstructExtensions.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.UpgradeAssistant
+{
+    internal static class DeconstructExtensions
+    {
+        public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> kvp, out TKey key, out TValue value)
+        {
+            key = kvp.Key;
+            value = kvp.Value;
+        }
+    }
+}

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IsExternalInit.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IsExternalInit.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit
+    {
+    }
+}

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/MaybeNullWhenAttribute.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/MaybeNullWhenAttribute.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class MaybeNullWhenAttribute : Attribute
+    {
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets a value indicating whether the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+}

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Microsoft.DotNet.UpgradeAssistant.Abstractions.csproj
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Microsoft.DotNet.UpgradeAssistant.Abstractions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.UpgradeAssistant</RootNamespace>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/ProcessRunner.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/ProcessRunner.cs
@@ -28,7 +28,8 @@ namespace Microsoft.DotNet.UpgradeAssistant
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true
-                }
+                },
+                EnableRaisingEvents = true
             };
 
             _logger.LogTrace("Starting process '{Command} {Arguments}'", args.Command, args.Arguments);

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/ProcessRunner.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/ProcessRunner.cs
@@ -47,14 +47,18 @@ namespace Microsoft.DotNet.UpgradeAssistant
             }
 
             var errorEncountered = false;
+            var tcs = new TaskCompletionSource<bool>();
 
+            using var registration = token.Register(() => tcs.SetCanceled());
+
+            process.Exited += (_, __) => tcs.SetResult(true);
             process.OutputDataReceived += args.Quiet ? QuietOutputReceived : OutputReceived;
             process.ErrorDataReceived += args.Quiet ? QuietOutputReceived : OutputReceived;
             process.Start();
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
-            await process.WaitForExitAsync(token).ConfigureAwait(false);
+            await tcs.Task.ConfigureAwait(false);
 
             if (process.ExitCode != args.SuccessCode)
             {

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TargetFrameworkMoniker.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TargetFrameworkMoniker.cs
@@ -16,8 +16,8 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
         public bool IsNetStandard => Name.StartsWith(NetStandardNamePrefix, StringComparison.OrdinalIgnoreCase);
 
-        public bool IsNetCore => Name.StartsWith(NetPrefix, StringComparison.OrdinalIgnoreCase) && Name.Contains('.');
+        public bool IsNetCore => Name.StartsWith(NetPrefix, StringComparison.OrdinalIgnoreCase) && Name.Contains(".");
 
-        public bool IsWindows => Name.Contains("windows", StringComparison.OrdinalIgnoreCase);
+        public bool IsWindows => Name.Contains("windows");
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/UpgradeCommand.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/UpgradeCommand.cs
@@ -39,7 +39,8 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
         public static IEnumerable<UpgradeCommand<T>> CreateFromEnum<T>()
             where T : struct, Enum
-            => Enum.GetValues<T>()
+            => Enum.GetValues(typeof(T))
+                .Cast<T>()
                 .Select(t => new EnumUpgradeCommand<T>
                 {
                     Value = t,

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/JsonStringProjectItemTypeConverter.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/JsonStringProjectItemTypeConverter.cs
@@ -7,7 +7,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.DotNet.UpgradeAssistant
 {
-    public class JsonStringProjectItemTypeConverter : JsonConverter<ProjectItemType>
+    internal class JsonStringProjectItemTypeConverter : JsonConverter<ProjectItemType>
     {
         public override ProjectItemType? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {


### PR DESCRIPTION
Since we may want to host in VS or elsewhere, ensuring extensions are targeting .NET Standard 2.0 will help with enabling those scenarios.