### PR TITLE
Package Microsoft.DotNet.UpgradeAssistant.Extensions as a NuGet package

### DIFF
--- a/src/extensions/Microsoft.DotNet.UpgradeAssistant.Extensions/Microsoft.DotNet.UpgradeAssistant.Extensions.csproj
+++ b/src/extensions/Microsoft.DotNet.UpgradeAssistant.Extensions/Microsoft.DotNet.UpgradeAssistant.Extensions.csproj
@@ -1,7 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
+  <PropertyGroup>
+    <PackageId>Microsoft.DotNet.UpgradeAssistant.Extensions</PackageId>
+    <Authors>Microsoft</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/dotnet/upgrade-assistant</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/dotnet/upgrade-assistant</RepositoryUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <Description>Types used in building extensions for the Microsoft .NET Upgrade Assistant</Description>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageTags>Upgrade Assistant</PackageTags>
+    <PackageIcon>icon.png</PackageIcon>
+  </PropertyGroup>  
   <ItemGroup>
     <PackageReference Include="Automapper" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />


### PR DESCRIPTION
When I made the PR to publish the abstractions project as a NuGet package I forgot that users building add-ons will need this one, too.

I considered making it target .NET Standard, but it uses AssemblyLoadContext and I don't think there's a compelling reason to go through the trouble of removing that dependency when the only thing this package will be used for is building extensions that will be consumed by a net5.0 tool.