### PR TITLE
Add a way to verify upgrade readiness

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/ConsoleRunner.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/ConsoleRunner.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             }
             catch (UpgradeException e)
             {
-                _logger.LogError("Unexpected error: {Message}", e.Message);
+                _logger.LogError("{Message}", e.Message);
             }
             catch (OperationCanceledException)
             {

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IUpgradeReadyCheck.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IUpgradeReadyCheck.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.UpgradeAssistant
+{
+    /// <summary>
+    /// Provides ability to verify that the project is available to be upgraded. This allows known issues to be caught and fixed before attempting an upgrade.
+    /// </summary>
+    public interface IUpgradeReadyCheck
+    {
+        /// <summary>
+        /// Gets an id that identifies this check.
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        /// Verifies that given the supplied context, an upgrade is possible.
+        /// </summary>
+        /// <param name="context">The current upgrade context.</param>
+        /// <param name="token">A cancellation token.</param>
+        /// <returns><c>true</c> if the project is ready, <c>false</c> if it is not.</returns>
+        Task<bool> IsReadyAsync(IUpgradeContext context, CancellationToken token);
+    }
+}

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/CentralPackageManagementCheck.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/CentralPackageManagementCheck.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Checks
+{
+    public class CentralPackageManagementCheck : IUpgradeReadyCheck
+    {
+        private readonly ILogger<CentralPackageManagementCheck> _logger;
+
+        public CentralPackageManagementCheck(ILogger<CentralPackageManagementCheck> logger)
+        {
+            _logger = logger;
+        }
+
+        public string Id => nameof(CentralPackageManagementCheck);
+
+        public Task<bool> IsReadyAsync(IUpgradeContext context, CancellationToken token)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var projects = context.Projects
+                .Where(p => bool.TryParse(p.GetFile().GetPropertyValue("EnableCentralPackageVersions"), out var result) ? result : false)
+                .ToList();
+
+            if (!projects.Any())
+            {
+                return Task.FromResult(true);
+            }
+
+            foreach (var project in projects)
+            {
+                _logger.LogCritical("Project {Name} uses EnableCentralPackageVersions which is not currently supported. Please see https://github.com/dotnet/upgrade-assistant/issues/252 to request this feature.", project.FilePath);
+            }
+
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/UpgraderExtensions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/UpgraderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.UpgradeAssistant.Checks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.DotNet.UpgradeAssistant
@@ -11,6 +12,12 @@ namespace Microsoft.DotNet.UpgradeAssistant
         {
             services.AddScoped<UpgraderManager>();
             services.AddTransient<IUpgradeStepOrderer, UpgradeStepOrderer>();
+            services.AddReadinessChecks();
+        }
+
+        public static void AddReadinessChecks(this IServiceCollection services)
+        {
+            services.AddTransient<IUpgradeReadyCheck, CentralPackageManagementCheck>();
         }
     }
 }

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/Checks/CentralPackageManagementCheckTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/Checks/CentralPackageManagementCheckTests.cs
@@ -1,14 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using Autofac;
 using Autofac.Extras.Moq;
-using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Checks.Tests

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/Checks/CentralPackageManagementCheckTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/Checks/CentralPackageManagementCheckTests.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Autofac.Extras.Moq;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Checks.Tests
+{
+    public class CentralPackageManagementCheckTests
+    {
+        [InlineData("true", false)]
+        [InlineData("True", false)]
+        [InlineData("false", true)]
+        [InlineData("False", true)]
+        [InlineData(null, true)]
+        [InlineData("", true)]
+        [Theory]
+        public async Task ChecksProperty(string isCentrallyManaged, bool isReady)
+        {
+            // Arrange
+            using var mock = AutoMock.GetLoose();
+
+            var file = mock.Mock<IProjectFile>();
+            file.Setup(f => f.GetPropertyValue("EnableCentralPackageVersions")).Returns(isCentrallyManaged);
+
+            var project = mock.Mock<IProject>();
+            project.Setup(f => f.GetFile()).Returns(file.Object);
+
+            var context = mock.Mock<IUpgradeContext>();
+            context.Setup(m => m.Projects).Returns(new[] { project.Object });
+
+            // Act
+            var result = await mock.Create<CentralPackageManagementCheck>().IsReadyAsync(context.Object, default).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal(isReady, result);
+        }
+    }
+}


### PR DESCRIPTION
This adds an interface IUpgradeReadyCheck that will be run at initialization to allow easy checks to block known problematic configurations. An initial check to block on CentralPackageVersion is added while we investigate adding support for this.

See #252 