### PR TITLE
Update MSBuildProject to give better error if TFM can't be read

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -279,3 +279,6 @@ dotnet_diagnostic.CA1711.severity = none
 # CA1716: Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace
 dotnet_diagnostic.CA1716.severity = none
 
+# SA1200: Using directives must be placed within namespace
+dotnet_diagnostic.SA1200.severity = none
+

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
@@ -255,19 +255,29 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 if (IsSdk)
                 {
                     // Currently only supporting non-multi-targeting scenarios
-                    var value = ProjectRoot.Properties
-                        .Single(e => e.Name == "TargetFramework")
-                        .Value;
+                    var targetFrameworkProperties = ProjectRoot.Properties.Where(e => e.Name.Equals("TargetFramework", StringComparison.Ordinal));
+                    var propCount = targetFrameworkProperties.Count();
 
-                    return new TargetFrameworkMoniker(value);
+                    if (propCount != 1)
+                    {
+                        _logger.LogCritical("SDK projects being upgraded must have exactly one TargetFramework property. Found {TargetFrameworkCount} TargetFramework properties.", propCount);
+                        throw new UpgradeException($"SDK projects being upgraded must have exactly one TargetFramework property. Found {propCount} TargetFramework properties.");
+                    }
+
+                    return new TargetFrameworkMoniker(targetFrameworkProperties.Single().Value);
                 }
                 else
                 {
-                    var value = ProjectRoot.Properties
-                        .Single(e => e.Name == "TargetFrameworkVersion")
-                        .Value;
+                    var targetFrameworkVersionProperties = ProjectRoot.Properties.Where(e => e.Name.Equals("TargetFrameworkVersion", StringComparison.Ordinal));
+                    var propCount = targetFrameworkVersionProperties.Count();
 
-                    return Context.TfmFactory.GetTFMForNetFxVersion(value);
+                    if (propCount != 1)
+                    {
+                        _logger.LogCritical("Non-SDK projects being upgraded must have exactly one TargetFrameworkVersion property. Found {TargetFrameworkVersionCount} TargetFrameworkVerion properties.", propCount);
+                        throw new UpgradeException($"SDK projects being upgraded must have exactly one TargetFrameworkVersion property. Found {propCount} TargetFrameworkVersion properties.");
+                    }
+
+                    return Context.TfmFactory.GetTFMForNetFxVersion(targetFrameworkVersionProperties.Single().Value);
                 }
             }
         }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/MultiTargetingCheck.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/MultiTargetingCheck.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Checks
+{
+    public class MultiTargetingCheck : IUpgradeReadyCheck
+    {
+        private readonly ILogger<MultiTargetingCheck> _logger;
+
+        public MultiTargetingCheck(ILogger<MultiTargetingCheck> logger)
+        {
+            _logger = logger;
+        }
+
+        public string Id => nameof(MultiTargetingCheck);
+
+        public Task<bool> IsReadyAsync(IUpgradeContext context, CancellationToken token)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            foreach (var project in context.Projects)
+            {
+                var projectRoot = project.GetFile();
+
+                try
+                {
+                    var tfm = project.TFM;
+                    _logger.LogTrace("Confirmed project {Project} has a valid TFM ({TFM})", project.FilePath, tfm);
+                }
+                catch (UpgradeException)
+                {
+                    _logger.LogCritical("Project {Project} cannot be upgraded. Input projects must have exactly one <TargetFramework> or <TargetFrameworkVersion> property. Multi-targeted projects are not yet supported.", project.FilePath);
+                    return Task.FromResult(false);
+                }
+            }
+
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/Checks/MultiTargetingCheckTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/Checks/MultiTargetingCheckTests.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.UpgradeAssistant.Checks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Tests.Checks
+{
+    public class MultiTargetingCheckTests
+    {
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public async Task OnlyValidTFMsPassCheck(IProject[] projects, bool isReady)
+        {
+            // Arrange
+            var context = new Mock<IUpgradeContext>();
+            context.Setup(c => c.Projects).Returns(projects);
+
+            var readyCheck = new MultiTargetingCheck(NullLogger<MultiTargetingCheck>.Instance);
+
+            // Act
+            var result = await readyCheck.IsReadyAsync(context.Object, CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal(isReady, result);
+        }
+
+        public static IEnumerable<object[]> TestData =>
+            new List<object[]>
+            {
+                    new object[] { new IProject[] { GetValidProject() }, true },
+                    new object[] { new IProject[] { GetValidProject(), GetValidProject() }, true },
+                    new object[] { new IProject[] { GetInvalidProject() }, false },
+                    new object[] { new IProject[] { GetValidProject(), GetInvalidProject(), GetValidProject() }, false },
+                    new object[] { Array.Empty<IProject>(), true },
+            };
+
+        private static IProject GetValidProject()
+        {
+            var project = new Mock<IProject>();
+            project.Setup(p => p.TFM).Returns(new TargetFrameworkMoniker("net5.0"));
+
+            return project.Object;
+        }
+
+        private static IProject GetInvalidProject()
+        {
+            var project = new Mock<IProject>();
+            project.Setup(p => p.TFM).Throws<UpgradeException>();
+
+            return project.Object;
+        }
+    }
+}

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WpfSample/Upgraded/BeanTraderClient/BeanTraderClient.csproj
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WpfSample/Upgraded/BeanTraderClient/BeanTraderClient.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.22" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.7" />
     <PackageReference Include="Hyak.Common" Version="1.2.2" />
-    <PackageReference Include="MahApps.Metro" Version="2.4.3" />
+    <PackageReference Include="MahApps.Metro" Version="2.4.4" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Also, adds a readiness check that confirms input projects have valid TFMs