### PR TITLE
Sets the default serializer to Newtonsoft for Web Apps to improve backward compatibility

### DIFF
--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default/DefaultExtensionServiceProvider.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default/DefaultExtensionServiceProvider.cs
@@ -94,6 +94,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default
             services.AddTransient<IPackageReferencesAnalyzer, TargetCompatibilityReferenceAnalyzer>();
             services.AddTransient<IPackageReferencesAnalyzer, UpgradeAssistantReferenceAnalyzer>();
             services.AddTransient<IPackageReferencesAnalyzer, WindowsCompatReferenceAnalyzer>();
+            services.AddTransient<IPackageReferencesAnalyzer, NewtonsoftReferenceAnalyzer>();
         }
     }
 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
@@ -47,17 +47,17 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
 
                 if (analyzerPackage is not null)
                 {
-                    _logger.LogInformation("Reference to .NET Upgrade Assistant Newtonsoft package ({NewtonsoftPackageName}, version {NewtonsoftPackageVersion}) needs added", NewtonsoftPackageName, analyzerPackage.Version);
+                    _logger.LogInformation("Reference to Newtonsoft package ({NewtonsoftPackageName}, version {NewtonsoftPackageVersion}) needs added", NewtonsoftPackageName, analyzerPackage.Version);
                     state.PackagesToAdd.Add(analyzerPackage with { PrivateAssets = "all" });
                 }
                 else
                 {
-                    _logger.LogWarning(".NET Upgrade Assistant Newtonsoft NuGet package reference cannot be added because the package cannot be found");
+                    _logger.LogWarning("Newtonsoft NuGet package reference cannot be added because the package cannot be found");
                 }
             }
             else
             {
-                _logger.LogDebug("Reference to .NET Upgrade Assistant Newtonsoft package ({NewtonsoftPackageName}) already exists", NewtonsoftPackageName);
+                _logger.LogDebug("Reference to Newtonsoft package ({NewtonsoftPackageName}) already exists", NewtonsoftPackageName);
             }
 
             return state;

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
@@ -40,15 +40,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 // If the web project doesn't include a reference to the Newtonsoft package, mark it for addition
                 && !packageReferences.Any(r => NewtonsoftPackageName.Equals(r.Name, StringComparison.OrdinalIgnoreCase)))
             {
-                // Use the analyzer package version from configuration if specified, otherwise get the latest version.
-                // When looking for the latest analyzer version, use the analyzer package source from configuration
-                // if one is specified, otherwise just use the package sources from the project being analyzed.
                 var analyzerPackage = await _packageLoader.GetLatestVersionAsync(NewtonsoftPackageName, false, null, token).ConfigureAwait(false);
 
                 if (analyzerPackage is not null)
                 {
                     _logger.LogInformation("Reference to Newtonsoft package ({NewtonsoftPackageName}, version {NewtonsoftPackageVersion}) needs added", NewtonsoftPackageName, analyzerPackage.Version);
-                    state.PackagesToAdd.Add(analyzerPackage with { PrivateAssets = "all" });
+                    state.PackagesToAdd.Add(analyzerPackage);
                 }
                 else
                 {

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
 
         public string Name => "Newtonsoft.Json reference analyzer";
 
-        public NewtonsoftReferenceAnalyzer(IOptions<PackageUpdaterOptions> updaterOptions, IPackageLoader packageLoader, ILogger<NewtonsoftReferenceAnalyzer> logger)
+        public NewtonsoftReferenceAnalyzer(IPackageLoader packageLoader, ILogger<NewtonsoftReferenceAnalyzer> logger)
         {
             _packageLoader = packageLoader ?? throw new ArgumentNullException(nameof(packageLoader));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
+{
+    public class NewtonsoftReferenceAnalyzer : IPackageReferencesAnalyzer
+    {
+        private const string NewtonsoftPackageName = "Microsoft.AspNetCore.Mvc.NewtonsoftJson";
+
+        private readonly IPackageLoader _packageLoader;
+        private readonly ILogger<NewtonsoftReferenceAnalyzer> _logger;
+
+        public string Name => "Newtonsoft.Json reference analyzer";
+
+        public NewtonsoftReferenceAnalyzer(IOptions<PackageUpdaterOptions> updaterOptions, IPackageLoader packageLoader, ILogger<NewtonsoftReferenceAnalyzer> logger)
+        {
+            _packageLoader = packageLoader ?? throw new ArgumentNullException(nameof(packageLoader));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<PackageAnalysisState> AnalyzeAsync(IProject project, PackageAnalysisState state, CancellationToken token)
+        {
+            if (state is null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
+            var packageReferences = project.Required().PackageReferences.Where(r => !state.PackagesToRemove.Contains(r));
+
+            if (project != null && (project.Components & ProjectComponents.Web) == ProjectComponents.Web
+
+                // If the web project doesn't include a reference to the Newtonsoft package, mark it for addition
+                && !packageReferences.Any(r => NewtonsoftPackageName.Equals(r.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                // Use the analyzer package version from configuration if specified, otherwise get the latest version.
+                // When looking for the latest analyzer version, use the analyzer package source from configuration
+                // if one is specified, otherwise just use the package sources from the project being analyzed.
+                var analyzerPackage = await _packageLoader.GetLatestVersionAsync(NewtonsoftPackageName, false, null, token).ConfigureAwait(false);
+
+                if (analyzerPackage is not null)
+                {
+                    _logger.LogInformation("Reference to .NET Upgrade Assistant Newtonsoft package ({NewtonsoftPackageName}, version {NewtonsoftPackageVersion}) needs added", NewtonsoftPackageName, analyzerPackage.Version);
+                    state.PackagesToAdd.Add(analyzerPackage with { PrivateAssets = "all" });
+                }
+                else
+                {
+                    _logger.LogWarning(".NET Upgrade Assistant Newtonsoft NuGet package reference cannot be added because the package cannot be found");
+                }
+            }
+            else
+            {
+                _logger.LogDebug("Reference to .NET Upgrade Assistant Newtonsoft package ({NewtonsoftPackageName}) already exists", NewtonsoftPackageName);
+            }
+
+            return state;
+        }
+    }
+}

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/Templates/DefaultTemplates/Startup.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/Templates/DefaultTemplates/Startup.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.NewtonsoftJson;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -28,7 +29,16 @@ namespace WebApplication1
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllersWithViews(ConfigureMvcOptions);
+            services.AddControllersWithViews(ConfigureMvcOptions)
+                // Newtonsoft.Json is added for compatibility reasons
+                // The recommended approach is to use System.Text.Json for serialization
+                // Visit the following link for more guidance about moving away from Newtonsoft.Json to System.Text.Json
+                // https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to?pivots=dotnet-5-0
+                .AddNewtonsoftJson(options =>
+                {
+                    options.UseMemberCasing();
+                });
+
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/Templates/DefaultTemplates/Startup.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/Templates/DefaultTemplates/Startup.cs
@@ -33,7 +33,7 @@ namespace WebApplication1
                 // Newtonsoft.Json is added for compatibility reasons
                 // The recommended approach is to use System.Text.Json for serialization
                 // Visit the following link for more guidance about moving away from Newtonsoft.Json to System.Text.Json
-                // https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to?pivots=dotnet-5-0
+                // https://docs.microsoft.com/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to
                 .AddNewtonsoftJson(options =>
                 {
                     options.UseMemberCasing();

--- a/tests/tool/Integration.Tests/E2ETest.cs
+++ b/tests/tool/Integration.Tests/E2ETest.cs
@@ -64,7 +64,22 @@ namespace Integration.Tests
                 .Where(t => !_ignoredFiles.Contains(Path.GetFileName(t)))
                 .ToArray();
 
-            Assert.Equal(expectedFiles, actualFiles);
+            var maxLength = expectedFiles.Length > actualFiles.Length ? expectedFiles.Length : actualFiles.Length;
+            for (var i = 0; i < maxLength; i++)
+            {
+                if (i == expectedFiles.Length)
+                {
+                    Assert.True(false, $"Was not expecting to find file '{actualFiles[i]}'");
+                }
+                else if (i == actualFiles.Length)
+                {
+                    Assert.True(false, $"Could not find expected file '{expectedFiles[i]}'");
+                }
+                else if (expectedFiles[i] != actualFiles[i])
+                {
+                    Assert.True(false, $"Was expecting to see the file '{expectedFiles[i]}' but found '{actualFiles[i]}' instead");
+                }
+            }
 
             foreach (var file in expectedFiles)
             {

--- a/tests/tool/Integration.Tests/IntegrationScenarios/AspNetMvcTemplate/Upgraded/Startup.cs
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/AspNetMvcTemplate/Upgraded/Startup.cs
@@ -1,4 +1,4 @@
-// This Startup file is based on ASP.NET Core new project templates and is included
+﻿// This Startup file is based on ASP.NET Core new project templates and is included
 // as a starting point for DI registration and HTTP request processing pipeline configuration.
 // This file will need updated according to the specific scenario of the application being upgraded.
 // For more information on ASP.NET Core startup files, see https://docs.microsoft.com/aspnet/core/fundamentals/startup
@@ -33,7 +33,7 @@ namespace TemplateMvc
                 // Newtonsoft.Json is added for compatibility reasons
                 // The recommended approach is to use System.Text.Json for serialization
                 // Visit the following link for more guidance about moving away from Newtonsoft.Json to System.Text.Json
-                // https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to?pivots=dotnet-5-0
+                // https://docs.microsoft.com/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to
                 .AddNewtonsoftJson(options =>
                 {
                     options.UseMemberCasing();

--- a/tests/tool/Integration.Tests/IntegrationScenarios/AspNetMvcTemplate/Upgraded/Startup.cs
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/AspNetMvcTemplate/Upgraded/Startup.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.NewtonsoftJson;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -28,7 +29,16 @@ namespace TemplateMvc
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllersWithViews(ConfigureMvcOptions);
+            services.AddControllersWithViews(ConfigureMvcOptions)
+                // Newtonsoft.Json is added for compatibility reasons
+                // The recommended approach is to use System.Text.Json for serialization
+                // Visit the following link for more guidance about moving away from Newtonsoft.Json to System.Text.Json
+                // https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to?pivots=dotnet-5-0
+                .AddNewtonsoftJson(options =>
+                {
+                    options.UseMemberCasing();
+                });
+
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/tests/tool/Integration.Tests/IntegrationScenarios/AspNetMvcTemplate/Upgraded/TemplateMvc.csproj
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/AspNetMvcTemplate/Upgraded/TemplateMvc.csproj
@@ -34,9 +34,7 @@
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.3" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="bootstrap" Version="3.4.1" />

--- a/tests/tool/Integration.Tests/IntegrationScenarios/AspNetMvcTemplate/Upgraded/TemplateMvc.csproj
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/AspNetMvcTemplate/Upgraded/TemplateMvc.csproj
@@ -28,11 +28,13 @@
     <Folder Include="Models\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="Antlr4" Version="4.6.6" />
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -42,6 +44,5 @@
     <PackageReference Include="jQuery.Validation" Version="1.17.0" />
     <PackageReference Include="Microsoft.jQuery.Unobtrusive.Validation" Version="3.2.11" />
     <PackageReference Include="Modernizr" Version="2.8.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Addresses feedback surfaced by #267

Legacy apps were most often written with PascalCase sensitive JSON notation because that was the default behavior. Newtonsoft serialization also provides additional features that are not available in System.Text.Json

https://docs.microsoft.com/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to#table-of-differences-between-newtonsoftjson-and-systemtextjson