### PR TITLE
Update ready checks to apply per-project instead of solution-wide

### DIFF
--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IUpgradeReadyCheck.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IUpgradeReadyCheck.cs
@@ -19,9 +19,9 @@ namespace Microsoft.DotNet.UpgradeAssistant
         /// <summary>
         /// Verifies that given the supplied project, an upgrade is possible.
         /// </summary>
-        /// <param name="context">The project to be upgraded.</param>
+        /// <param name="project">The project to be upgraded.</param>
         /// <param name="token">A cancellation token.</param>
         /// <returns><c>true</c> if the project is ready, <c>false</c> if it is not.</returns>
-        Task<bool> IsReadyAsync(IProject context, CancellationToken token);
+        Task<bool> IsReadyAsync(IProject project, CancellationToken token);
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IUpgradeReadyCheck.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IUpgradeReadyCheck.cs
@@ -17,11 +17,11 @@ namespace Microsoft.DotNet.UpgradeAssistant
         string Id { get; }
 
         /// <summary>
-        /// Verifies that given the supplied context, an upgrade is possible.
+        /// Verifies that given the supplied project, an upgrade is possible.
         /// </summary>
-        /// <param name="context">The current upgrade context.</param>
+        /// <param name="context">The project to be upgraded.</param>
         /// <param name="token">A cancellation token.</param>
         /// <returns><c>true</c> if the project is ready, <c>false</c> if it is not.</returns>
-        Task<bool> IsReadyAsync(IUpgradeContext context, CancellationToken token);
+        Task<bool> IsReadyAsync(IProject context, CancellationToken token);
     }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
@@ -260,7 +260,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
                     if (propCount != 1)
                     {
-                        _logger.LogCritical("SDK projects being upgraded must have exactly one TargetFramework property. Found {TargetFrameworkCount} TargetFramework properties.", propCount);
+                        _logger.LogError("SDK projects being upgraded must have exactly one TargetFramework property. Found {TargetFrameworkCount} TargetFramework properties.", propCount);
                         throw new UpgradeException($"SDK projects being upgraded must have exactly one TargetFramework property. Found {propCount} TargetFramework properties.");
                     }
 
@@ -273,7 +273,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
                     if (propCount != 1)
                     {
-                        _logger.LogCritical("Non-SDK projects being upgraded must have exactly one TargetFrameworkVersion property. Found {TargetFrameworkVersionCount} TargetFrameworkVerion properties.", propCount);
+                        _logger.LogError("Non-SDK projects being upgraded must have exactly one TargetFrameworkVersion property. Found {TargetFrameworkVersionCount} TargetFrameworkVerion properties.", propCount);
                         throw new UpgradeException($"SDK projects being upgraded must have exactly one TargetFrameworkVersion property. Found {propCount} TargetFrameworkVersion properties.");
                     }
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
@@ -16,7 +16,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
     internal sealed class MSBuildWorkspaceUpgradeContext : IUpgradeContext, IDisposable
     {
         private readonly string _path;
-        private readonly ITargetTFMSelector _tfmSelector;
         private readonly ILogger<MSBuildWorkspaceUpgradeContext> _logger;
         private readonly string? _vsPath;
         private readonly Dictionary<string, IProject> _projectCache;
@@ -57,7 +56,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
             _projectCache = new Dictionary<string, IProject>(StringComparer.OrdinalIgnoreCase);
             _path = options.ProjectPath;
-            _tfmSelector = tfmSelector ?? throw new ArgumentNullException(nameof(tfmSelector));
             TfmFactory = tfmFactory ?? throw new ArgumentNullException(nameof(tfmFactory));
             _logger = logger;
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
@@ -44,7 +44,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public MSBuildWorkspaceUpgradeContext(
             UpgradeOptions options,
-            ITargetTFMSelector tfmSelector,
             ITargetFrameworkMonikerFactory tfmFactory,
             IVisualStudioFinder vsFinder,
             ILogger<MSBuildWorkspaceUpgradeContext> logger)

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/MultiTargetingCheck.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/MultiTargetingCheck.cs
@@ -19,30 +19,24 @@ namespace Microsoft.DotNet.UpgradeAssistant.Checks
 
         public string Id => nameof(MultiTargetingCheck);
 
-        public Task<bool> IsReadyAsync(IUpgradeContext context, CancellationToken token)
+        public Task<bool> IsReadyAsync(IProject project, CancellationToken token)
         {
-            if (context is null)
+            if (project is null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(project));
             }
 
-            foreach (var project in context.Projects)
+            try
             {
-                var projectRoot = project.GetFile();
-
-                try
-                {
-                    var tfm = project.TFM;
-                    _logger.LogTrace("Confirmed project {Project} has a valid TFM ({TFM})", project.FilePath, tfm);
-                }
-                catch (UpgradeException)
-                {
-                    _logger.LogCritical("Project {Project} cannot be upgraded. Input projects must have exactly one <TargetFramework> or <TargetFrameworkVersion> property. Multi-targeted projects are not yet supported.", project.FilePath);
-                    return Task.FromResult(false);
-                }
+                var tfm = project.TFM;
+                _logger.LogTrace("Confirmed project {Project} has a valid TFM ({TFM})", project.FilePath, tfm);
+                return Task.FromResult(true);
             }
-
-            return Task.FromResult(true);
+            catch (UpgradeException)
+            {
+                _logger.LogError("Project {Project} cannot be upgraded. Input projects must have exactly one <TargetFramework> or <TargetFrameworkVersion> property. Multi-targeted projects are not yet supported.", project.FilePath);
+                return Task.FromResult(false);
+            }
         }
     }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/UpgraderExtensions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/UpgraderExtensions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
         public static void AddReadinessChecks(this IServiceCollection services)
         {
             services.AddTransient<IUpgradeReadyCheck, CentralPackageManagementCheck>();
+            services.AddTransient<IUpgradeReadyCheck, MultiTargetingCheck>();
         }
     }
 }

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/Checks/CentralPackageManagementCheckTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/Checks/CentralPackageManagementCheckTests.cs
@@ -27,11 +27,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Checks.Tests
             var project = mock.Mock<IProject>();
             project.Setup(f => f.GetFile()).Returns(file.Object);
 
-            var context = mock.Mock<IUpgradeContext>();
-            context.Setup(m => m.Projects).Returns(new[] { project.Object });
-
             // Act
-            var result = await mock.Create<CentralPackageManagementCheck>().IsReadyAsync(context.Object, default).ConfigureAwait(false);
+            var result = await mock.Create<CentralPackageManagementCheck>().IsReadyAsync(project.Object, default).ConfigureAwait(false);
 
             // Assert
             Assert.Equal(isReady, result);

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/Checks/MultiTargetingCheckTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/Checks/MultiTargetingCheckTests.cs
@@ -1,13 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac.Extras.Moq;
 using Microsoft.DotNet.UpgradeAssistant.Checks;
-using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -18,27 +16,20 @@ namespace Microsoft.DotNet.UpgradeAssistant.Tests.Checks
         public static IEnumerable<object[]> TestData =>
             new List<object[]>
             {
-                            new object[] { new IProject[] { GetValidProject() }, true },
-                            new object[] { new IProject[] { GetValidProject(), GetValidProject() }, true },
-                            new object[] { new IProject[] { GetInvalidProject() }, false },
-                            new object[] { new IProject[] { GetValidProject(), GetInvalidProject(), GetValidProject() }, false },
-                            new object[] { Array.Empty<IProject>(), true },
+                new object[] { GetValidProject(), true },
+                new object[] { GetInvalidProject(), false },
             };
 
         [Theory]
         [MemberData(nameof(TestData))]
-        public async Task OnlyValidTFMsPassCheck(IProject[] projects, bool isReady)
+        public async Task OnlyValidTFMsPassCheck(IProject project, bool isReady)
         {
             // Arrange
             using var mock = AutoMock.GetLoose();
-
-            var context = mock.Mock<IUpgradeContext>();
-            context.Setup(c => c.Projects).Returns(projects);
-
             var readyCheck = mock.Create<MultiTargetingCheck>();
 
             // Act
-            var result = await readyCheck.IsReadyAsync(context.Object, CancellationToken.None).ConfigureAwait(false);
+            var result = await readyCheck.IsReadyAsync(project, CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.Equal(isReady, result);


### PR DESCRIPTION
Failed ready checks were preventing solutions from upgrading. This change instead blocks specific projects while allowing other projects in the solution (which pass the ready checks) to upgrade.

Fixes #308 
Fixes #268 