### PR TITLE
Fix current project selection

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/FileUpgradeStateFactory.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/FileUpgradeStateFactory.cs
@@ -36,15 +36,18 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
             var state = await GetStateAsync(token).ConfigureAwait(false);
 
-            context.SetEntryPoint(FindProject(state.EntryPoint));
-            context.SetCurrentProject(FindProject(state.CurrentProject));
-            context.IsComplete = state.IsComplete;
+            if (state is not null)
+            {
+                context.SetEntryPoint(FindProject(state.EntryPoint));
+                context.SetCurrentProject(FindProject(state.CurrentProject));
+                context.IsComplete = state.IsComplete;
+            }
 
             IProject? FindProject(string? path)
                 => path is null ? null : context.Projects.FirstOrDefault(p => NormalizePath(p.FilePath) == path);
         }
 
-        private async ValueTask<UpgradeState> GetStateAsync(CancellationToken token)
+        private async ValueTask<UpgradeState?> GetStateAsync(CancellationToken token)
         {
             if (File.Exists(_path))
             {
@@ -69,7 +72,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
                 }
             }
 
-            return new UpgradeState();
+            return null;
         }
 
         public async Task SaveStateAsync(IUpgradeContext context, CancellationToken token)

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IUpgradeContext.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IUpgradeContext.cs
@@ -11,6 +11,8 @@ namespace Microsoft.DotNet.UpgradeAssistant
 {
     public interface IUpgradeContext : IDisposable
     {
+        string InputPath { get; }
+
         bool IsComplete { get; set; }
 
         IProject? EntryPoint { get; }
@@ -22,6 +24,8 @@ namespace Microsoft.DotNet.UpgradeAssistant
         void SetCurrentProject(IProject? project);
 
         IEnumerable<IProject> Projects { get; }
+
+        bool InputIsSolution { get; }
 
         bool UpdateSolution(Solution updatedSolution);
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
@@ -255,29 +255,26 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 if (IsSdk)
                 {
                     // Currently only supporting non-multi-targeting scenarios
-                    var targetFrameworkProperties = ProjectRoot.Properties.Where(e => e.Name.Equals("TargetFramework", StringComparison.Ordinal));
+                    return new TargetFrameworkMoniker(GetSingleTFMProperty("TargetFramework"));
+                }
+                else
+                {
+                    // Non-SDK projects should have exactly one TargetFrameworkVersion property
+                    return Context.TfmFactory.GetTFMForNetFxVersion(GetSingleTFMProperty("TargetFrameworkVersion"));
+                }
+
+                string GetSingleTFMProperty(string propertyName)
+                {
+                    var targetFrameworkProperties = ProjectRoot.Properties.Where(e => e.Name.Equals(propertyName, StringComparison.Ordinal));
                     var propCount = targetFrameworkProperties.Count();
 
                     if (propCount != 1)
                     {
-                        _logger.LogError("SDK projects being upgraded must have exactly one TargetFramework property. Found {TargetFrameworkCount} TargetFramework properties for project {Project}.", propCount, FilePath);
-                        throw new UpgradeException($"SDK projects being upgraded must have exactly one TargetFramework property. Found {propCount} TargetFramework properties for project {FilePath}.");
+                        _logger.LogError("Expected project to have exactly one {PropertyName} property. Found {TargetFrameworkCount} TargetFramework properties for project {Project}.", propertyName, propCount, FilePath);
+                        throw new UpgradeException($"Expected project to have exactly one {propertyName} property. Found {propCount} TargetFramework properties for project {FilePath}.");
                     }
 
-                    return new TargetFrameworkMoniker(targetFrameworkProperties.Single().Value);
-                }
-                else
-                {
-                    var targetFrameworkVersionProperties = ProjectRoot.Properties.Where(e => e.Name.Equals("TargetFrameworkVersion", StringComparison.Ordinal));
-                    var propCount = targetFrameworkVersionProperties.Count();
-
-                    if (propCount != 1)
-                    {
-                        _logger.LogError("Non-SDK projects being upgraded must have exactly one TargetFrameworkVersion property. Found {TargetFrameworkVersionCount} TargetFrameworkVerion properties for project {Project}.", propCount, FilePath);
-                        throw new UpgradeException($"SDK projects being upgraded must have exactly one TargetFrameworkVersion property. Found {propCount} TargetFrameworkVersion properties for project {FilePath}.");
-                    }
-
-                    return Context.TfmFactory.GetTFMForNetFxVersion(targetFrameworkVersionProperties.Single().Value);
+                    return targetFrameworkProperties.Single().Value;
                 }
             }
         }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
@@ -260,8 +260,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
                     if (propCount != 1)
                     {
-                        _logger.LogError("SDK projects being upgraded must have exactly one TargetFramework property. Found {TargetFrameworkCount} TargetFramework properties.", propCount);
-                        throw new UpgradeException($"SDK projects being upgraded must have exactly one TargetFramework property. Found {propCount} TargetFramework properties.");
+                        _logger.LogError("SDK projects being upgraded must have exactly one TargetFramework property. Found {TargetFrameworkCount} TargetFramework properties for project {Project}.", propCount, FilePath);
+                        throw new UpgradeException($"SDK projects being upgraded must have exactly one TargetFramework property. Found {propCount} TargetFramework properties for project {FilePath}.");
                     }
 
                     return new TargetFrameworkMoniker(targetFrameworkProperties.Single().Value);
@@ -273,8 +273,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
                     if (propCount != 1)
                     {
-                        _logger.LogError("Non-SDK projects being upgraded must have exactly one TargetFrameworkVersion property. Found {TargetFrameworkVersionCount} TargetFrameworkVerion properties.", propCount);
-                        throw new UpgradeException($"SDK projects being upgraded must have exactly one TargetFrameworkVersion property. Found {propCount} TargetFrameworkVersion properties.");
+                        _logger.LogError("Non-SDK projects being upgraded must have exactly one TargetFrameworkVersion property. Found {TargetFrameworkVersionCount} TargetFrameworkVerion properties for project {Project}.", propCount, FilePath);
+                        throw new UpgradeException($"SDK projects being upgraded must have exactly one TargetFrameworkVersion property. Found {propCount} TargetFrameworkVersion properties for project {FilePath}.");
                     }
 
                     return Context.TfmFactory.GetTFMForNetFxVersion(targetFrameworkVersionProperties.Single().Value);

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildTargetTFMSelector.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildTargetTFMSelector.cs
@@ -70,15 +70,22 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             var tfm = new TargetFrameworkMoniker(tfmName);
             foreach (var dep in project.ProjectReferences)
             {
-                if (_tfmComparer.IsCompatible(tfm, dep.TFM))
+                try
                 {
-                    continue;
-                }
+                    if (_tfmComparer.IsCompatible(tfm, dep.TFM))
+                    {
+                        continue;
+                    }
 
-                if (dep.TFM.IsNetCore || dep.TFM.IsNetStandard)
+                    if (dep.TFM.IsNetCore || dep.TFM.IsNetStandard)
+                    {
+                        tfm = dep.TFM;
+                        _logger.LogDebug("Considering TFM {TFM} for project {Project} based on its dependency on {DepProject}", tfm, project.FilePath, dep.FilePath);
+                    }
+                }
+                catch (UpgradeException)
                 {
-                    tfm = dep.TFM;
-                    _logger.LogDebug("Considering TFM {TFM} for project {Project} based on its dependency on {DepProject}", tfm, project.FilePath, dep.FilePath);
+                    _logger.LogWarning($"Unable to determine TFM for dependency {dep.FilePath}; TFM for {project.FilePath} may not be correct.");
                 }
             }
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
@@ -166,7 +166,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 }
                 else
                 {
-                    var project = await workspace.OpenProjectAsync(InputPath, cancellationToken: token).ConfigureAwait(false);
+                    await workspace.OpenProjectAsync(InputPath, cancellationToken: token).ConfigureAwait(false);
                 }
 
                 _workspace = workspace;

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
@@ -46,10 +46,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
         // This upgrade step is meant to be run fresh every time a new project needs selected
         protected override bool ShouldReset(IUpgradeContext context) => context?.CurrentProject is null && Status == UpgradeStepStatus.Complete;
 
-        protected override Task<UpgradeStepInitializeResult> InitializeImplAsync(IUpgradeContext context, CancellationToken token)
-            => Task.FromResult(InitializeImpl(context));
-
-        private UpgradeStepInitializeResult InitializeImpl(IUpgradeContext context)
+        protected override async Task<UpgradeStepInitializeResult> InitializeImplAsync(IUpgradeContext context, CancellationToken token)
         {
             if (context is null)
             {
@@ -62,44 +59,47 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             }
 
             var projects = context.Projects.ToList();
-
-            if (projects.All(p => IsCompleted(context, p)))
+            var completeChecks = projects.Select(async p => IsCompleted(context, p) || !await RunChecksAsync(p, token).ConfigureAwait(false));
+            if ((await Task.WhenAll(completeChecks).ConfigureAwait(false)).All(b => b))
             {
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "No projects need upgrade", BuildBreakRisk.None);
             }
 
+            IProject? newCurrentProject = null;
+
             if (projects.Count == 1)
             {
-                var project = projects[0];
-                context.SetCurrentProject(project);
-
-                Logger.LogInformation("Setting only project in solution as the current project: {Project}", project.FilePath);
-
-                return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "Selected only project.", BuildBreakRisk.None);
+                newCurrentProject = projects[0];
+                Logger.LogDebug("Setting only project in solution as the current project: {Project}", newCurrentProject.FilePath);
             }
-
-            // If the user has specified a particular project, only that should be the current project
-            if (!context.InputIsSolution)
+            else if (!context.InputIsSolution)
             {
-                var project = projects.Where(i => Path.GetFileName(i.FilePath).Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-
-                if (project is not null)
-                {
-                    if (!IsCompleted(context, project))
-                    {
-                        context.SetCurrentProject(project);
-                        Logger.LogDebug("Setting user-selected project as the current project: {Project}", project.FilePath);
-                    }
-                    else
-                    {
-                        Logger.LogDebug("User-selected project is already upgraded.");
-                    }
-
-                    return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "Selected user-specified project.", BuildBreakRisk.None);
-                }
+                // If the user has specified a particular project, only that should be the current project
+                newCurrentProject = projects.Where(i => Path.GetFileName(i.FilePath).Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase)).First();
+                Logger.LogDebug("Setting user-selected project as the current project: {Project}", newCurrentProject.FilePath);
             }
 
-            return new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, "No project is currently selected.", BuildBreakRisk.None);
+            if (newCurrentProject is null)
+            {
+                return new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, "No project is currently selected.", BuildBreakRisk.None);
+            }
+            else
+            {
+                if (IsCompleted(context, newCurrentProject))
+                {
+                    Logger.LogDebug("Project {Project} does not need upgraded", newCurrentProject.FilePath);
+                }
+                else if (!(await RunChecksAsync(newCurrentProject, token).ConfigureAwait(false)))
+                {
+                    Logger.LogError("Unable to upgrade project {Project}", newCurrentProject.FilePath);
+                }
+                else
+                {
+                    context.SetCurrentProject(newCurrentProject);
+                }
+
+                return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, $"Project {newCurrentProject.GetRoslynProject().Name} was selected", BuildBreakRisk.None);
+            }
         }
 
         protected override async Task<UpgradeStepApplyResult> ApplyImplAsync(IUpgradeContext context, CancellationToken token)
@@ -153,20 +153,20 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             {
                 return new ProjectCommand(project, isProjectCompleted(context, project), await RunChecksAsync(project, token).ConfigureAwait(false));
             }
+        }
 
-            async Task<bool> RunChecksAsync(IProject project, CancellationToken token)
+        private async Task<bool> RunChecksAsync(IProject project, CancellationToken token)
+        {
+            var success = true;
+
+            foreach (var check in _checks)
             {
-                var success = true;
+                Logger.LogTrace("Running readiness check {Id}", check.Id);
 
-                foreach (var check in _checks)
-                {
-                    Logger.LogTrace("Running readiness check {Id}", check.Id);
-
-                    success &= await check.IsReadyAsync(project, token).ConfigureAwait(false);
-                }
-
-                return success;
+                success &= await check.IsReadyAsync(project, token).ConfigureAwait(false);
             }
+
+            return success;
         }
     }
 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             _tfmSelector = tfmSelector ?? throw new ArgumentNullException(nameof(tfmSelector));
         }
 
-        protected override bool IsApplicableImpl(IUpgradeContext context) => context is not null && context.CurrentProject is null && context.Projects.Any(p => !IsCompleted(context, p));
+        protected override bool IsApplicableImpl(IUpgradeContext context) => context is not null && context.CurrentProject is null && context.Projects.Any(p => !IsCompleted(context, p)) && !context.IsComplete;
 
         // This upgrade step is meant to be run fresh every time a new project needs selected
         protected override bool ShouldReset(IUpgradeContext context) => context?.CurrentProject is null && Status == UpgradeStepStatus.Complete;

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/EntrypointSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/EntrypointSelectionStep.cs
@@ -87,14 +87,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             // other dependencies were loaded along with it.
             if (!context.InputIsSolution)
             {
-                var entryPointProject = projects.Where(i => Path.GetFileName(i.FilePath).Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-                if (entryPointProject is not null)
-                {
-                    context.SetEntryPoint(entryPointProject);
-                    Logger.LogInformation("Setting entrypoint to user selected project in solution: {Project}", _entryPoint);
+                var project = projects.Where(i => Path.GetFileName(i.FilePath).Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase)).First();
+                context.SetEntryPoint(project);
 
-                    return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "Selected user's choice of entry point project.", BuildBreakRisk.None);
-                }
+                Logger.LogInformation("Setting entrypoint to user selected project: {Project}", project.FilePath);
+
+                return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "Selected user's choice of entry point project.", BuildBreakRisk.None);
             }
 
             if (!string.IsNullOrEmpty(_entryPoint))

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/EntrypointSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/EntrypointSelectionStep.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             // other dependencies were loaded along with it.
             if (!context.InputIsSolution)
             {
-                var project = projects.Where(i => Path.GetFileName(i.FilePath).Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase)).First();
+                var project = projects.First(i => Path.GetFileName(i.FilePath).Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase));
                 context.SetEntryPoint(project);
 
                 Logger.LogInformation("Setting entrypoint to user selected project: {Project}", project.FilePath);
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
 
             if (!string.IsNullOrEmpty(_entryPoint))
             {
-                var entryPointProject = projects.Where(i => Path.GetFileName(i.FilePath).Equals(_entryPoint, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                var entryPointProject = projects.FirstOrDefault(i => Path.GetFileName(i.FilePath).Equals(_entryPoint, StringComparison.OrdinalIgnoreCase));
                 if (entryPointProject is not null)
                 {
                     context.SetEntryPoint(entryPointProject);

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/EntrypointSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/EntrypointSelectionStep.cs
@@ -83,9 +83,23 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "Selected only project.", BuildBreakRisk.None);
             }
 
+            // If the user has specified a particular project, that project will be considered the entry point even if
+            // other dependencies were loaded along with it.
+            if (!context.InputIsSolution)
+            {
+                var entryPointProject = projects.Where(i => Path.GetFileName(i.FilePath).Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                if (entryPointProject is not null)
+                {
+                    context.SetEntryPoint(entryPointProject);
+                    Logger.LogInformation("Setting entrypoint to user selected project in solution: {Project}", _entryPoint);
+
+                    return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "Selected user's choice of entry point project.", BuildBreakRisk.None);
+                }
+            }
+
             if (!string.IsNullOrEmpty(_entryPoint))
             {
-                var entryPointProject = projects.Where(i => Path.GetFileName(i.FilePath) == _entryPoint).FirstOrDefault();
+                var entryPointProject = projects.Where(i => Path.GetFileName(i.FilePath).Equals(_entryPoint, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
                 if (entryPointProject is not null)
                 {
                     context.SetEntryPoint(entryPointProject);


### PR DESCRIPTION
This re-works project selection to address a couple issues:

1. This fixes issues that cropped up when users specified a particular csproj on the command line but the project pulled in other project-to-project dependencies.
2. This makes sure that upgrade ready checks are applied to projects even in the case where a user specifies a project file as input rather than a solution.