### PR TITLE
Install try-convert if not available

### DIFF
--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/ProjectFormatStepsExtensions.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/ProjectFormatStepsExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
             services.AddUpgradeStep<TryConvertProjectConverterStep>();
             services.AddSingleton<ITryConvertTool, TryConvertTool>();
             services.AddTransient<ISectionGenerator, TryConvertReport>();
+            services.AddTransient<IUpgradeStartup, TryConvertToolStartup>();
 
             return services.AddOptions<TryConvertProjectConverterStepOptions>()
                 .ValidateDataAnnotations();

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertToolStartup.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertToolStartup.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq;
-using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertToolStartup.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertToolStartup.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Runtime.Loader;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
+{
+    public class TryConvertToolStartup : IUpgradeStartup
+    {
+        private readonly ILogger _logger;
+        private readonly IProcessRunner _runner;
+        private readonly ITryConvertTool _tryConvertTool;
+
+        public TryConvertToolStartup(ILogger<TryConvertToolStartup> logger,
+            IProcessRunner runner,
+            ITryConvertTool tryConvertTool)
+        {
+            _logger = logger;
+            _runner = runner;
+            _tryConvertTool = tryConvertTool;
+        }
+
+        public Task<bool> StartupAsync(CancellationToken token)
+        {
+            TryConvertToolInstance(token);
+            return Task.FromResult(true);
+        }
+
+        public bool TryConvertToolInstance(CancellationToken token)
+        {
+            if (!_tryConvertTool.IsAvailable)
+            {
+                _logger.LogInformation("Try-Convert not found. This tool depends on the Try-Convert CLI tool, installing now to the path : {path}", _tryConvertTool.Path);
+
+                return _runner.RunProcessAsync(new ProcessInfo
+                {
+                    Command = "dotnet",
+                    Arguments = " tool install -g try-convert"
+                }, token).ConfigureAwait(true).GetAwaiter().GetResult();
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertToolStartup.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertToolStartup.cs
@@ -24,24 +24,22 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
 
         public Task<bool> StartupAsync(CancellationToken token)
         {
-            TryConvertToolInstance(token);
+            if (!_tryConvertTool.IsAvailable)
+            {
+                TryConvertToolInstanceAsync(token);
+            }
+
             return Task.FromResult(true);
         }
 
-        public bool TryConvertToolInstance(CancellationToken token)
+        public Task<bool> TryConvertToolInstanceAsync(CancellationToken token)
         {
-            if (!_tryConvertTool.IsAvailable)
+            _logger.LogInformation("Try-Convert not found. This tool depends on the Try-Convert CLI tool, installing now to the path : {path}", _tryConvertTool.Path);
+            return _runner.RunProcessAsync(new ProcessInfo
             {
-                _logger.LogInformation("Try-Convert not found. This tool depends on the Try-Convert CLI tool, installing now to the path : {path}", _tryConvertTool.Path);
-
-                return _runner.RunProcessAsync(new ProcessInfo
-                {
-                    Command = "dotnet",
-                    Arguments = " tool install -g try-convert"
-                }, token).ConfigureAwait(true).GetAwaiter().GetResult();
-            }
-
-            return true;
+                Command = "dotnet",
+                Arguments = " tool install -g try-convert"
+            }, token);
         }
     }
 }


### PR DESCRIPTION
This change checks if try-convert tool is already present if not will install at the start of upgrade-assistant.