### PR TITLE
Remove  MSBuild from being included in projects

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,13 +11,4 @@
     <Compile Include="$(MSBuildThisFileDirectory)/shared/**/*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'!='netstandard2.0'">
-    <!-- Exclude MSBuild runtime assets from both src and test projects
-         as they shouldn't be present in this solution's output paths.
-         Instead, these dependencies should be loaded from the selected
-         MSBuild's location. -->
-    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
I think this is a remnant from earlier iterations, but doesn't appear needed anymore.