### PR TITLE
Enable logging for tests

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Program.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Program.cs
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.UpgradeAssistant.Extensions;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 
@@ -65,23 +65,32 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             }
         }
 
-        public static Task RunUpgradeAsync(UpgradeOptions options, Action<HostBuilderContext, IServiceCollection> configure, CancellationToken token)
-            => RunCommandAsync(options, (ctx, services) =>
+        public static Task RunUpgradeAsync(UpgradeOptions options, Func<IHostBuilder, IHostBuilder> configure, CancellationToken token)
+            => RunCommandAsync(options, host => configure(host).ConfigureServices(services =>
             {
                 services.AddScoped<IAppCommand, ConsoleUpgrade>();
-                configure(ctx, services);
-            }, token);
+            }), token);
 
-        public static Task RunAnalysisAsync(UpgradeOptions options)
-            => RunCommandAsync(options, (ctx, services) =>
-            {
-                services.AddScoped<IAppCommand, ConsoleAnalyze>();
-                services.AddReports();
-                services.AddPortabilityAnalysis()
-                    .Bind(ctx.Configuration.GetSection("Portability"));
-            }, CancellationToken.None);
+        private static IHostBuilder EnableLogging(UpgradeOptions options, IHostBuilder host)
+        {
+            var logSettings = new LogSettings(options.Verbose);
 
-        private static Task RunCommandAsync(UpgradeOptions options, Action<HostBuilderContext, IServiceCollection> serviceConfiguration, CancellationToken token)
+            return host
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton(logSettings);
+                })
+                .UseSerilog((_, __, loggerConfiguration) => loggerConfiguration
+                    .Enrich.FromLogContext()
+                    .MinimumLevel.Is(Serilog.Events.LogEventLevel.Verbose)
+                    .WriteTo.Console(levelSwitch: logSettings.Console)
+                    .WriteTo.File(LogFilePath, levelSwitch: logSettings.File));
+        }
+
+        private static Task RunCommandAsync(
+            UpgradeOptions options,
+            Func<IHostBuilder, IHostBuilder> configure,
+            CancellationToken token)
         {
             ConsoleUtils.Clear();
 
@@ -91,8 +100,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             {
                 throw new ArgumentNullException(nameof(options));
             }
-
-            var logSettings = new LogSettings(options.Verbose);
 
             var host = Host.CreateDefaultBuilder()
                 .UseContentRoot(AppContext.BaseDirectory)
@@ -118,25 +125,17 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
                     services.AddSingleton(new InputOutputStreams(Console.In, Console.Out));
                     services.AddSingleton<CommandProvider>();
-                    services.AddSingleton(logSettings);
+                    services.TryAddSingleton(new LogSettings(true));
 
                     services.AddSingleton<IProcessRunner, ProcessRunner>();
 
                     services.AddStepManagement();
+                });
 
-                    serviceConfiguration(context, services);
-                })
-                .UseSerilog((_, __, loggerConfiguration) => loggerConfiguration
-                    .Enrich.FromLogContext()
-                    .MinimumLevel.Is(Serilog.Events.LogEventLevel.Verbose)
-                    .WriteTo.Console(levelSwitch: logSettings.Console)
-                    .WriteTo.File(LogFilePath, levelSwitch: logSettings.File))
-                .RunConsoleAsync(options =>
-                {
-                    options.SuppressStatusMessages = true;
-                }, token);
-
-            return host;
+            return configure(host).RunConsoleAsync(options =>
+            {
+                options.SuppressStatusMessages = true;
+            }, token);
         }
 
         private static void ShowHeader()
@@ -179,7 +178,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
         private static void ConfigureUpgradeCommand(Command command)
         {
-            command.Handler = CommandHandler.Create<UpgradeOptions, CancellationToken>((options, token) => RunUpgradeAsync(options, (ctx, services) => { }, token));
+            command.Handler = CommandHandler.Create<UpgradeOptions, CancellationToken>((options, token) => RunUpgradeAsync(options, host => EnableLogging(options, host), token));
 
             command.AddArgument(new Argument<FileInfo>("project") { Arity = ArgumentArity.ExactlyOne }.ExistingOnly());
             command.AddOption(new Option<bool>(new[] { "--skip-backup" }, "Disables backing up the project. This is not recommended unless the project is in source control since this tool will make large changes to both the project and source files."));

--- a/tests/tool/Integration.Tests/E2ETest.cs
+++ b/tests/tool/Integration.Tests/E2ETest.cs
@@ -8,13 +8,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Integration.Tests
 {
     [Collection(IntegrationTestCollection.Name)]
     public class E2ETest
     {
-        // TODO : Make this configurable so the test can pass from other working dirs
         private const string IntegrationTestAssetsPath = "IntegrationScenarios";
         private const string OriginalProjectSubDir = "Original";
         private const string UpgradedProjectSubDir = "Upgraded";
@@ -26,6 +26,13 @@ namespace Integration.Tests
             ".upgrade-assistant"
         };
 
+        private readonly ITestOutputHelper _output;
+
+        public E2ETest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [InlineData("AspNetSample", "csharp", "TemplateMvc.csproj", "")]
         [InlineData("WpfSample", "csharp", "BeanTrader.sln", "BeanTraderClient.csproj")]
         [InlineData("WpfSample", "vb", "WpfApp1.sln", "")]
@@ -34,27 +41,23 @@ namespace Integration.Tests
         {
             // Create a temporary working directory
             var workingDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            try
+            var dir = Directory.CreateDirectory(workingDir);
+            Assert.True(dir.Exists);
+
+            // Copy the scenario files to the temporary directory
+            var scenarioDir = Path.Combine(IntegrationTestAssetsPath, scenarioName, language);
+            await CopyDirectoryAsync(Path.Combine(scenarioDir, OriginalProjectSubDir), workingDir).ConfigureAwait(false);
+
+            // Run upgrade
+            await UpgradeRunner.UpgradeAsync(Path.Combine(workingDir, inputFileName), entrypoint, _output, 300).ConfigureAwait(false);
+
+            CleanupBuildArtifacts(workingDir);
+
+            await AssertDirectoriesEqualAsync(Path.Combine(scenarioDir, UpgradedProjectSubDir), workingDir).ConfigureAwait(false);
+
+            if (Directory.Exists(workingDir))
             {
-                var dir = Directory.CreateDirectory(workingDir);
-                Assert.True(dir.Exists);
-
-                // Copy the scenario files to the temporary directory
-                var scenarioDir = Path.Combine(IntegrationTestAssetsPath, scenarioName, language);
-                await CopyDirectoryAsync(Path.Combine(scenarioDir, OriginalProjectSubDir), workingDir).ConfigureAwait(false);
-
-                // Run upgrade
-                await UpgradeRunner.UpgradeAsync(Path.Combine(workingDir, inputFileName), entrypoint, Console.Out, 300).ConfigureAwait(false);
-                CleanupBuildArtifacts(workingDir);
-
-                await AssertDirectoriesEqualAsync(Path.Combine(scenarioDir, UpgradedProjectSubDir), workingDir).ConfigureAwait(false);
-            }
-            finally
-            {
-                if (Directory.Exists(workingDir))
-                {
-                    Directory.Delete(workingDir, true);
-                }
+                Directory.Delete(workingDir, true);
             }
         }
 

--- a/tests/tool/Integration.Tests/Integration.Tests.csproj
+++ b/tests/tool/Integration.Tests/Integration.Tests.csproj
@@ -23,10 +23,6 @@
     <ProjectReference Include="..\..\..\src\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Packages\Microsoft.DotNet.UpgradeAssistant.Steps.Packages.csproj" />
     <ProjectReference Include="..\..\Microsoft.DotNet.UpgradeAssistant.TestHelpers\Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="IntegrationScenarios\AspNetSample\vb\" />
-    <Folder Include="IntegrationScenarios\WpfSample\vb\" />
-  </ItemGroup>
   <Target Name="MoveAnalyzersToSourceUpdatersDir" AfterTargets="Build">
     <PropertyGroup>
       <SourceUpdateFilePath>$(OutputPath)SourceUpdaters\</SourceUpdateFilePath>

--- a/tests/tool/Integration.Tests/TestOutputHelperLoggerProvider.cs
+++ b/tests/tool/Integration.Tests/TestOutputHelperLoggerProvider.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Integration.Tests
+{
+    internal class TestOutputHelperLoggerProvider : ILoggerProvider
+    {
+        private readonly ITestOutputHelper _output;
+
+        public TestOutputHelperLoggerProvider(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+            => new TestOutputHelperLogger(_output, categoryName);
+
+        public void Dispose()
+        {
+        }
+
+        private class TestOutputHelperLogger : ILogger, IDisposable
+        {
+            private readonly ITestOutputHelper _output;
+
+            public TestOutputHelperLogger(ITestOutputHelper output, string name)
+            {
+                _output = output;
+
+                Name = name;
+            }
+
+            public string Name { get; }
+
+            public IDisposable BeginScope<TState>(TState state)
+                => this;
+
+            public void Dispose()
+            {
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+                => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                var formatted = formatter(state, exception);
+
+                _output.WriteLine($"[{logLevel}] {formatted}");
+            }
+        }
+    }
+}

--- a/tests/tool/Integration.Tests/UpgradeRunner.cs
+++ b/tests/tool/Integration.Tests/UpgradeRunner.cs
@@ -9,12 +9,15 @@ using Microsoft.DotNet.UpgradeAssistant;
 using Microsoft.DotNet.UpgradeAssistant.Cli;
 using Microsoft.DotNet.UpgradeAssistant.Steps.Packages;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
 
 namespace Integration.Tests
 {
     public static class UpgradeRunner
     {
-        public static async Task UpgradeAsync(string inputPath, string entrypoint, TextWriter output, int timeoutSeconds = 300)
+        public static async Task UpgradeAsync(string inputPath, string entrypoint, ITestOutputHelper output, int timeoutSeconds = 300)
         {
             if (string.IsNullOrEmpty(inputPath))
             {
@@ -38,7 +41,21 @@ namespace Integration.Tests
                 EntryPoint = entrypoint,
             };
 
-            var upgradeTask = Program.RunUpgradeAsync(options, (context, services) => RegisterTestServices(services), cts.Token);
+            var upgradeTask = Program.RunUpgradeAsync(options, host => host
+                .ConfigureServices((_, services) =>
+                {
+                    services.AddOptions<PackageUpdaterOptions>().Configure(o =>
+                    {
+                        o.PackageMapPath = "PackageMaps";
+                        o.UpgradeAnalyzersPackageVersion = "1.0.0";
+                    });
+                })
+                .ConfigureLogging((ctx, logging) =>
+                {
+                    logging.SetMinimumLevel(LogLevel.Trace);
+                    logging.AddProvider(new TestOutputHelperLoggerProvider(output));
+                }), cts.Token);
+
             var timeoutTimer = Task.Delay(timeoutSeconds * 1000, cts.Token);
 
             await Task.WhenAny(upgradeTask, timeoutTimer).ConfigureAwait(false);
@@ -51,15 +68,6 @@ namespace Integration.Tests
             catch (OperationCanceledException)
             {
             }
-        }
-
-        private static void RegisterTestServices(IServiceCollection services)
-        {
-            services.AddOptions<PackageUpdaterOptions>().Configure(o =>
-            {
-                o.PackageMapPath = "PackageMaps";
-                o.UpgradeAnalyzersPackageVersion = "1.0.0";
-            });
         }
     }
 }


### PR DESCRIPTION
This change updates the tests to log output to test ITestOutputHelper XUnit provides. This allows test results to show all the logging output from the tests.

In order to do this, instead of just allowing configuration of services, we pass a delegate in that allows modifying the IHostBuilder itself.