### PR TITLE
Add IComponentIdentifier and ProjectComponents.AspNetCore

### DIFF
--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IComponentIdentifier.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IComponentIdentifier.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.UpgradeAssistant
+{
+    public interface IComponentIdentifier
+    {
+        ProjectComponents GetComponents(IProject project);
+    }
+}

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IProjectFile.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IProjectFile.cs
@@ -36,5 +36,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
         void SetPropertyValue(string propertyName, string propertyValue);
 
         void SetTFM(TargetFrameworkMoniker targetTFM);
+
+        IEnumerable<string> Imports { get; }
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/ProjectComponents.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/ProjectComponents.cs
@@ -10,9 +10,10 @@ namespace Microsoft.DotNet.UpgradeAssistant
     {
         None = 0,
         WindowsDesktop = 1,
-        Web = 1 << 1,
+        AspNet = 1 << 1,
         WinRT = 1 << 2,
         Wpf = 1 << 3,
         WinForms = 1 << 4,
+        AspNetCore = 1 << 5,
     }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/ComponentIdentifier.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/ComponentIdentifier.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             var components = ProjectComponents.None;
             if (file.Sdk.Equals(MSBuildConstants.WebSdk, StringComparison.OrdinalIgnoreCase))
             {
-                components |= ProjectComponents.Web;
+                components |= ProjectComponents.AspNetCore;
             }
 
             if (file.GetPropertyValue("UseWPF").Equals("true", StringComparison.OrdinalIgnoreCase))
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             var frameworkReferenceNames = project.FrameworkReferences.Select(r => r.Name);
             if (frameworkReferenceNames.Any(f => MSBuildConstants.WebFrameworkReferences.Contains(f, StringComparer.OrdinalIgnoreCase)))
             {
-                components |= ProjectComponents.Web;
+                components |= ProjectComponents.AspNetCore;
             }
 
             if (frameworkReferenceNames.Any(f => MSBuildConstants.DesktopFrameworkReferences.Contains(f, StringComparer.OrdinalIgnoreCase)))
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             if (file.Imports.Contains(MSBuildConstants.WebApplicationTargets, StringComparer.OrdinalIgnoreCase) ||
                 references.Any(r => MSBuildConstants.WebReferences.Contains(r, StringComparer.OrdinalIgnoreCase)))
             {
-                components |= ProjectComponents.Web;
+                components |= ProjectComponents.AspNet;
             }
 
             if (references.Any(r => MSBuildConstants.WinFormsReferences.Contains(r, StringComparer.OrdinalIgnoreCase)))

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/ComponentIdentifier.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/ComponentIdentifier.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
+{
+    public class ComponentIdentifier : IComponentIdentifier
+    {
+        public ProjectComponents GetComponents(IProject project)
+        {
+            if (project is null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            var file = project.GetFile();
+            var components = file.IsSdk ? GetSDKProjectComponents(project, file) : GetOldProjectComponents(project, file);
+
+            if (project.TransitivePackageReferences.Any(f => MSBuildConstants.WinRTPackages.Contains(f.Name, StringComparer.OrdinalIgnoreCase)))
+            {
+                components |= ProjectComponents.WinRT;
+            }
+
+            return components;
+        }
+
+        // Gets project components based on SDK, properties, and FrameworkReferences
+        private static ProjectComponents GetSDKProjectComponents(IProject project, IProjectFile file)
+        {
+            var components = ProjectComponents.None;
+            if (file.Sdk.Equals(MSBuildConstants.WebSdk, StringComparison.OrdinalIgnoreCase))
+            {
+                components |= ProjectComponents.Web;
+            }
+
+            if (file.GetPropertyValue("UseWPF").Equals("true", StringComparison.OrdinalIgnoreCase))
+            {
+                components |= ProjectComponents.Wpf;
+                components |= ProjectComponents.WindowsDesktop;
+            }
+
+            if (file.GetPropertyValue("UseWindowsForms").Equals("true", StringComparison.OrdinalIgnoreCase))
+            {
+                components |= ProjectComponents.WinForms;
+                components |= ProjectComponents.WindowsDesktop;
+            }
+
+            if (file.Sdk.Equals(MSBuildConstants.DesktopSdk, StringComparison.OrdinalIgnoreCase))
+            {
+                components |= ProjectComponents.WindowsDesktop;
+            }
+
+            var frameworkReferenceNames = project.FrameworkReferences.Select(r => r.Name);
+            if (frameworkReferenceNames.Any(f => MSBuildConstants.WebFrameworkReferences.Contains(f, StringComparer.OrdinalIgnoreCase)))
+            {
+                components |= ProjectComponents.Web;
+            }
+
+            if (frameworkReferenceNames.Any(f => MSBuildConstants.DesktopFrameworkReferences.Contains(f, StringComparer.OrdinalIgnoreCase)))
+            {
+                components |= ProjectComponents.WindowsDesktop;
+            }
+
+            if (frameworkReferenceNames.Any(f => MSBuildConstants.WinFormsReferences.Contains(f, StringComparer.OrdinalIgnoreCase)))
+            {
+                components |= ProjectComponents.WinForms;
+            }
+
+            if (frameworkReferenceNames.Any(f => MSBuildConstants.WpfReferences.Contains(f, StringComparer.OrdinalIgnoreCase)))
+            {
+                components |= ProjectComponents.Wpf;
+            }
+
+            return components;
+        }
+
+        // Gets project components based on imports and References
+        private static ProjectComponents GetOldProjectComponents(IProject project, IProjectFile file)
+        {
+            var components = ProjectComponents.None;
+
+            // Check imports and references
+            var references = project.References.Select(r => r.Name);
+
+            if (file.Imports.Contains(MSBuildConstants.WebApplicationTargets, StringComparer.OrdinalIgnoreCase) ||
+                references.Any(r => MSBuildConstants.WebReferences.Contains(r, StringComparer.OrdinalIgnoreCase)))
+            {
+                components |= ProjectComponents.Web;
+            }
+
+            if (references.Any(r => MSBuildConstants.WinFormsReferences.Contains(r, StringComparer.OrdinalIgnoreCase)))
+            {
+                components |= ProjectComponents.WindowsDesktop;
+                components |= ProjectComponents.WinForms;
+            }
+
+            if (references.Any(r => MSBuildConstants.WpfReferences.Contains(r, StringComparer.OrdinalIgnoreCase)))
+            {
+                components |= ProjectComponents.WindowsDesktop;
+                components |= ProjectComponents.Wpf;
+            }
+
+            return components;
+        }
+    }
+}

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
@@ -52,6 +52,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
         public bool IsSdk =>
             ProjectRoot.Sdk is not null && ProjectRoot.Sdk.Contains(MSBuildConstants.DefaultSDK, StringComparison.OrdinalIgnoreCase);
 
+        public IEnumerable<string> Imports => ProjectRoot.Imports.Select(p => Path.GetFileName(p.Project));
+
         public void SetTFM(TargetFrameworkMoniker tfm)
         {
             if (IsSdk)

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildTargetTFMSelector.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildTargetTFMSelector.cs
@@ -44,15 +44,13 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             var tfmName = GetNetStandardTFM(project);
 
             // Projects with web components or an Exe output type should use app TFMs
-            if ((project.Components & ProjectComponents.Web) == ProjectComponents.Web
-                || project.OutputType == ProjectOutputType.Exe)
+            if (project.Components.HasFlag(ProjectComponents.AspNetCore) || project.OutputType == ProjectOutputType.Exe)
             {
                 tfmName = AppTFMBase;
             }
 
             // Projects with Windows Desktop components or a WinExe output type should use a -windows suffix
-            if ((project.Components & ProjectComponents.WindowsDesktop) == ProjectComponents.WindowsDesktop
-                || project.OutputType == ProjectOutputType.WinExe)
+            if (project.Components.HasFlag(ProjectComponents.WindowsDesktop) || project.OutputType == ProjectOutputType.WinExe)
             {
                 tfmName = $"{AppTFMBase}{WindowsSuffix}";
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 {
     internal sealed class MSBuildWorkspaceUpgradeContext : IUpgradeContext, IDisposable
     {
+        private readonly IComponentIdentifier _componentIdentifier;
         private readonly ILogger<MSBuildWorkspaceUpgradeContext> _logger;
         private readonly string? _vsPath;
         private readonly Dictionary<string, IProject> _projectCache;
@@ -49,6 +50,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             UpgradeOptions options,
             ITargetFrameworkMonikerFactory tfmFactory,
             IVisualStudioFinder vsFinder,
+            IComponentIdentifier componentIdentifier,
             ILogger<MSBuildWorkspaceUpgradeContext> logger)
         {
             if (options is null)
@@ -56,10 +58,16 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 throw new ArgumentNullException(nameof(options));
             }
 
+            if (vsFinder is null)
+            {
+                throw new ArgumentNullException(nameof(vsFinder));
+            }
+
             _projectCache = new Dictionary<string, IProject>(StringComparer.OrdinalIgnoreCase);
             InputPath = options.ProjectPath;
             TfmFactory = tfmFactory ?? throw new ArgumentNullException(nameof(tfmFactory));
-            _logger = logger;
+            _componentIdentifier = componentIdentifier ?? throw new ArgumentNullException(nameof(componentIdentifier));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             var vsPath = vsFinder.GetLatestVisualStudioPath();
 
@@ -90,7 +98,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 return cached;
             }
 
-            var project = new MSBuildProject(this, path, _logger);
+            var project = new MSBuildProject(this, _componentIdentifier, path, _logger);
 
             _projectCache.Add(path, project);
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/UpgraderMsBuildExtensions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/UpgraderMsBuildExtensions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
             services.AddTransient<IPackageRestorer, DotnetRestorePackageRestorer>();
             services.AddTransient<IUpgradeStartup, MSBuildRegistrationStartup>();
             services.AddSingleton<IUpgradeContextFactory, MSBuildUpgradeContextFactory>();
+            services.AddSingleton<IComponentIdentifier, ComponentIdentifier>();
 
             // Instantiate the upgrade context with a func to avoid needing MSBuild types prior to MSBuild registration
             services.AddTransient<MSBuildWorkspaceUpgradeContext>();

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/WebNamespaceConfigUpdater.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/WebNamespaceConfigUpdater.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     public class WebNamespaceConfigUpdater : IConfigUpdater
     {
         private const string NamespacesPath = "/configuration/system.web.webPages.razor/pages/namespaces";

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/AllowHtmlAttributeAnalyzer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/AllowHtmlAttributeAnalyzer.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class AllowHtmlAttributeAnalyzer : DiagnosticAnalyzer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/FilterAnalyzer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/FilterAnalyzer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class FilterAnalyzer : IdentifierUpgradeAnalyzer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/HelperResultAnalyzer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/HelperResultAnalyzer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class HelperResultAnalyzer : IdentifierUpgradeAnalyzer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/HtmlHelperAnalyzer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/HtmlHelperAnalyzer.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class HtmlHelperAnalyzer : DiagnosticAnalyzer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/HtmlStringAnalyzer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/HtmlStringAnalyzer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class HtmlStringAnalyzer : IdentifierUpgradeAnalyzer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/HttpContextCurrentAnalyzer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/HttpContextCurrentAnalyzer.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class HttpContextCurrentAnalyzer : DiagnosticAnalyzer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/HttpContextIsDebuggingEnabledAnalyzer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/HttpContextIsDebuggingEnabledAnalyzer.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class HttpContextIsDebuggingEnabledAnalyzer : DiagnosticAnalyzer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/ResultTypeAnalyzer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/ResultTypeAnalyzer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class ResultTypeAnalyzer : IdentifierUpgradeAnalyzer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/UrlHelperAnalyzer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/UrlHelperAnalyzer.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class UrlHelperAnalyzer : DiagnosticAnalyzer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/UsingSystemWebAnalyzer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers/UsingSystemWebAnalyzer.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class UsingSystemWebAnalyzer : DiagnosticAnalyzer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/AllowHtmlAttributeCodeFixer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/AllowHtmlAttributeCodeFixer.cs
@@ -15,7 +15,7 @@ using Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = "UA0010 CodeFix Provider")]
     public class AllowHtmlAttributeCodeFixer : CodeFixProvider
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/FilterCodeFixer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/FilterCodeFixer.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = "UA004 CodeFix Provider")]
     public class FilterCodeFixer : IdentifierUpgradeCodeFixer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/HelperResultCodeFixer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/HelperResultCodeFixer.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = "UA009 CodeFix Provider")]
     public class HelperResultCodeFixer : IdentifierUpgradeCodeFixer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/HtmlHelperCodeFixer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/HtmlHelperCodeFixer.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = "UA007 CodeFix Provider")]
     public class HtmlHelperCodeFixer : IdentifierUpgradeCodeFixer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/HtmlStringCodeFixer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/HtmlStringCodeFixer.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = "UA002 CodeFix Provider")]
     public class HtmlStringCodeFixer : IdentifierUpgradeCodeFixer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/HttpContextCurrentCodeFixer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/HttpContextCurrentCodeFixer.cs
@@ -18,7 +18,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = "UA005 CodeFix Provider")]
     public class HttpContextCurrentCodeFixer : CodeFixProvider
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/HttpContextIsDebuggingEnabledCodeFixer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/HttpContextIsDebuggingEnabledCodeFixer.cs
@@ -15,7 +15,7 @@ using Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = "UA006 CodeFix Provider")]
     public class HttpContextIsDebuggingEnabledCodeFixer : CodeFixProvider
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/ResultTypeCodeFixer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/ResultTypeCodeFixer.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = "UA003 CodeFix Provider")]
     public class ResultTypeCodeFixer : IdentifierUpgradeCodeFixer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/UrlHelperCodeFixer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/UrlHelperCodeFixer.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = "UA008 CodeFix Provider")]
     public class UrlHelperCodeFixer : IdentifierUpgradeCodeFixer
     {

--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/UsingSystemWebCodeFixer.cs
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes/UsingSystemWebCodeFixer.cs
@@ -12,7 +12,7 @@ using Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.Analyzers;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CSharp.CodeFixes
 {
-    [ApplicableComponents(ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.AspNetCore)]
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = "UA001 CodeFix Provider")]
     public class UsingSystemWebCodeFixer : CodeFixProvider
     {

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using NuGet.Versioning;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
 {
@@ -28,17 +26,24 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
 
         public async Task<PackageAnalysisState> AnalyzeAsync(IProject project, PackageAnalysisState state, CancellationToken token)
         {
+            if (project is null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
             if (state is null)
             {
                 throw new ArgumentNullException(nameof(state));
             }
 
+            if (!project.Components.HasFlag(ProjectComponents.Web))
+            {
+                return state;
+            }
+
             var packageReferences = project.Required().PackageReferences.Where(r => !state.PackagesToRemove.Contains(r));
 
-            if (project != null && (project.Components & ProjectComponents.Web) == ProjectComponents.Web
-
-                // If the web project doesn't include a reference to the Newtonsoft package, mark it for addition
-                && !packageReferences.Any(r => NewtonsoftPackageName.Equals(r.Name, StringComparison.OrdinalIgnoreCase)))
+            if (!packageReferences.Any(r => NewtonsoftPackageName.Equals(r.Name, StringComparison.OrdinalIgnoreCase)))
             {
                 var analyzerPackage = await _packageLoader.GetLatestVersionAsync(NewtonsoftPackageName, false, null, token).ConfigureAwait(false);
 

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 throw new ArgumentNullException(nameof(state));
             }
 
-            if (!project.Components.HasFlag(ProjectComponents.Web))
+            if (!project.Components.HasFlag(ProjectComponents.AspNetCore))
             {
                 return state;
             }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertProjectConverterStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertProjectConverterStep.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
                     return new UpgradeStepInitializeResult(
                         UpgradeStepStatus.Incomplete,
                         $"Project {projectFile.FilePath} is not an SDK project. Applying this step will execute the following try-convert command line to convert the project to an SDK-style project: {_runner.GetCommandLine(project)}",
-                        (project.Components & ProjectComponents.Web) == ProjectComponents.Web ? BuildBreakRisk.High : BuildBreakRisk.Medium);
+                        project.Components.HasFlag(ProjectComponents.AspNetCore) ? BuildBreakRisk.High : BuildBreakRisk.Medium);
                 }
                 else
                 {

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/Templates/CSharpWebAppTemplates/TemplateConfig.json
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/Templates/CSharpWebAppTemplates/TemplateConfig.json
@@ -32,6 +32,6 @@
   ],
   "TemplateLanguage": "CSharp",
   "TemplateAppliesTo": [
-    "Web"
+    "AspNetCore"
   ]
 }

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/ComponentIdentifierTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/ComponentIdentifierTests.cs
@@ -1,0 +1,203 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using Autofac.Extras.Moq;
+using AutoFixture;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests
+{
+    public class ComponentIdentifierTests
+    {
+        [InlineData("UseWPF", "true", ProjectComponents.Wpf | ProjectComponents.WindowsDesktop)]
+        [InlineData("UseWPF", "True", ProjectComponents.Wpf | ProjectComponents.WindowsDesktop)]
+        [InlineData("UseWPF", "false", ProjectComponents.None)]
+        [InlineData("UseWindowsForms", "true", ProjectComponents.WinForms | ProjectComponents.WindowsDesktop)]
+        [InlineData("UseWindowsForms", "True", ProjectComponents.WinForms | ProjectComponents.WindowsDesktop)]
+        [InlineData("UseWindowsForms", "false", ProjectComponents.None)]
+        [Theory]
+        public void SdkProperties(string propertyName, string value, ProjectComponents expected)
+        {
+            // Arrange
+            using var mock = AutoMock.GetLoose();
+
+            var projectFile = mock.Mock<IProjectFile>();
+            projectFile.Setup(f => f.IsSdk).Returns(true);
+            projectFile.Setup(f => f.Sdk).Returns(string.Empty);
+            projectFile.Setup(f => f.GetPropertyValue(It.IsAny<string>())).Returns(string.Empty);
+            projectFile.Setup(f => f.GetPropertyValue(propertyName)).Returns(value);
+
+            var project = mock.Mock<IProject>();
+            project.Setup(p => p.GetFile()).Returns(projectFile.Object);
+
+            var componentIdentifier = mock.Create<ComponentIdentifier>();
+
+            // Act
+            var components = componentIdentifier.GetComponents(project.Object);
+
+            // Assert
+            Assert.Equal(expected, components);
+        }
+
+        [InlineData("", ProjectComponents.None)]
+        [InlineData("Microsoft.NET.Sdk.Web", ProjectComponents.Web)]
+        [InlineData("Microsoft.NET.Sdk.Desktop", ProjectComponents.WindowsDesktop)]
+        [Theory]
+        public void SdkTypes(string sdk, ProjectComponents expected)
+        {
+            // Arrange
+            using var mock = AutoMock.GetLoose();
+
+            var projectFile = mock.Mock<IProjectFile>();
+            projectFile.Setup(f => f.IsSdk).Returns(true);
+            projectFile.Setup(f => f.Sdk).Returns(sdk);
+            projectFile.Setup(f => f.GetPropertyValue(It.IsAny<string>())).Returns(string.Empty);
+
+            var project = mock.Mock<IProject>();
+            project.Setup(p => p.GetFile()).Returns(projectFile.Object);
+
+            var componentIdentifier = mock.Create<ComponentIdentifier>();
+
+            // Act
+            var components = componentIdentifier.GetComponents(project.Object);
+
+            // Assert
+            Assert.Equal(expected, components);
+        }
+
+        [InlineData("", ProjectComponents.None)]
+        [InlineData("Microsoft.AspNetCore.App", ProjectComponents.Web)]
+        [InlineData("Microsoft.WindowsDesktop.App", ProjectComponents.WindowsDesktop)]
+        [InlineData("Microsoft.WindowsDesktop.App.WindowsForms", ProjectComponents.WindowsDesktop)]
+        [InlineData("Microsoft.WindowsDesktop.App.WPF", ProjectComponents.WindowsDesktop)]
+        [InlineData("System.Windows.Forms", ProjectComponents.WinForms)]
+        [InlineData("System.Xaml", ProjectComponents.Wpf)]
+        [InlineData("PresentationCore", ProjectComponents.Wpf)]
+        [InlineData("PresentationFramework", ProjectComponents.Wpf)]
+        [InlineData("WindowsBase", ProjectComponents.Wpf)]
+        [Theory]
+        public void SdkFrameworkReferences(string frameworkReference, ProjectComponents expected)
+        {
+            // Arrange
+            const int Count = 10;
+            var fixture = new Fixture();
+            var frameworkReferences = fixture.CreateMany<Reference>(Count).ToList();
+            frameworkReferences.Insert(Count / 2, new Reference(frameworkReference));
+
+            using var mock = AutoMock.GetLoose();
+
+            var projectFile = mock.Mock<IProjectFile>();
+            projectFile.Setup(f => f.IsSdk).Returns(true);
+            projectFile.Setup(f => f.Sdk).Returns(string.Empty);
+            projectFile.Setup(f => f.GetPropertyValue(It.IsAny<string>())).Returns(string.Empty);
+
+            var project = mock.Mock<IProject>();
+            project.Setup(p => p.GetFile()).Returns(projectFile.Object);
+            project.Setup(p => p.FrameworkReferences).Returns(frameworkReferences);
+
+            var componentIdentifier = mock.Create<ComponentIdentifier>();
+
+            // Act
+            var components = componentIdentifier.GetComponents(project.Object);
+
+            // Assert
+            Assert.Equal(expected, components);
+        }
+
+        [InlineData("", ProjectComponents.None)]
+        [InlineData("System.Web", ProjectComponents.Web)]
+        [InlineData("System.Web.Abstractions", ProjectComponents.Web)]
+        [InlineData("System.Web.Routing", ProjectComponents.Web)]
+        [InlineData("System.Windows.Forms", ProjectComponents.WinForms | ProjectComponents.WindowsDesktop)]
+        [InlineData("System.Xaml", ProjectComponents.Wpf | ProjectComponents.WindowsDesktop)]
+        [InlineData("PresentationCore", ProjectComponents.Wpf | ProjectComponents.WindowsDesktop)]
+        [InlineData("PresentationFramework", ProjectComponents.Wpf | ProjectComponents.WindowsDesktop)]
+        [InlineData("WindowsBase", ProjectComponents.Wpf | ProjectComponents.WindowsDesktop)]
+        [Theory]
+        public void NonSdkReferences(string reference, ProjectComponents expected)
+        {
+            // Arrange
+            const int Count = 10;
+            var fixture = new Fixture();
+            var references = fixture.CreateMany<Reference>(Count).ToList();
+            references.Insert(Count / 2, new Reference(reference));
+
+            using var mock = AutoMock.GetLoose();
+
+            var projectFile = mock.Mock<IProjectFile>();
+            projectFile.Setup(f => f.IsSdk).Returns(false);
+
+            var project = mock.Mock<IProject>();
+            project.Setup(p => p.GetFile()).Returns(projectFile.Object);
+            project.Setup(p => p.References).Returns(references);
+
+            var componentIdentifier = mock.Create<ComponentIdentifier>();
+
+            // Act
+            var components = componentIdentifier.GetComponents(project.Object);
+
+            // Assert
+            Assert.Equal(expected, components);
+        }
+
+        [InlineData("", ProjectComponents.None)]
+        [InlineData("Microsoft.WebApplication.targets", ProjectComponents.Web)]
+        [Theory]
+        public void NonSdkImports(string import, ProjectComponents expected)
+        {
+            // Arrange
+            const int Count = 10;
+            var fixture = new Fixture();
+            var imports = fixture.CreateMany<string>(Count).ToList();
+            imports.Insert(Count / 2, import);
+
+            using var mock = AutoMock.GetLoose();
+
+            var projectFile = mock.Mock<IProjectFile>();
+            projectFile.Setup(f => f.IsSdk).Returns(false);
+            projectFile.Setup(p => p.Imports).Returns(imports);
+
+            var project = mock.Mock<IProject>();
+            project.Setup(p => p.GetFile()).Returns(projectFile.Object);
+
+            var componentIdentifier = mock.Create<ComponentIdentifier>();
+
+            // Act
+            var components = componentIdentifier.GetComponents(project.Object);
+
+            // Assert
+            Assert.Equal(expected, components);
+        }
+
+        [InlineData("", ProjectComponents.None)]
+        [InlineData("Microsoft.Windows.SDK.Contracts", ProjectComponents.WinRT)]
+        [Theory]
+        public void TransitiveDependencies(string name, ProjectComponents expected)
+        {
+            // Arrange
+            const int Count = 10;
+            var fixture = new Fixture();
+            var dependencies = fixture.CreateMany<NuGetReference>(Count).ToList();
+            dependencies.Insert(Count / 2, fixture.Create<NuGetReference>() with { Name = name });
+
+            using var mock = AutoMock.GetLoose();
+
+            var projectFile = mock.Mock<IProjectFile>();
+            projectFile.Setup(f => f.IsSdk).Returns(false);
+
+            var project = mock.Mock<IProject>();
+            project.Setup(p => p.GetFile()).Returns(projectFile.Object);
+            project.Setup(p => p.TransitivePackageReferences).Returns(dependencies);
+
+            var componentIdentifier = mock.Create<ComponentIdentifier>();
+
+            // Act
+            var components = componentIdentifier.GetComponents(project.Object);
+
+            // Assert
+            Assert.Equal(expected, components);
+        }
+    }
+}

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/ComponentIdentifierTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/ComponentIdentifierTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests
         }
 
         [InlineData("", ProjectComponents.None)]
-        [InlineData("Microsoft.NET.Sdk.Web", ProjectComponents.Web)]
+        [InlineData("Microsoft.NET.Sdk.Web", ProjectComponents.AspNetCore)]
         [InlineData("Microsoft.NET.Sdk.Desktop", ProjectComponents.WindowsDesktop)]
         [Theory]
         public void SdkTypes(string sdk, ProjectComponents expected)
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests
         }
 
         [InlineData("", ProjectComponents.None)]
-        [InlineData("Microsoft.AspNetCore.App", ProjectComponents.Web)]
+        [InlineData("Microsoft.AspNetCore.App", ProjectComponents.AspNetCore)]
         [InlineData("Microsoft.WindowsDesktop.App", ProjectComponents.WindowsDesktop)]
         [InlineData("Microsoft.WindowsDesktop.App.WindowsForms", ProjectComponents.WindowsDesktop)]
         [InlineData("Microsoft.WindowsDesktop.App.WPF", ProjectComponents.WindowsDesktop)]
@@ -107,9 +107,9 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests
         }
 
         [InlineData("", ProjectComponents.None)]
-        [InlineData("System.Web", ProjectComponents.Web)]
-        [InlineData("System.Web.Abstractions", ProjectComponents.Web)]
-        [InlineData("System.Web.Routing", ProjectComponents.Web)]
+        [InlineData("System.Web", ProjectComponents.AspNet)]
+        [InlineData("System.Web.Abstractions", ProjectComponents.AspNet)]
+        [InlineData("System.Web.Routing", ProjectComponents.AspNet)]
         [InlineData("System.Windows.Forms", ProjectComponents.WinForms | ProjectComponents.WindowsDesktop)]
         [InlineData("System.Xaml", ProjectComponents.Wpf | ProjectComponents.WindowsDesktop)]
         [InlineData("PresentationCore", ProjectComponents.Wpf | ProjectComponents.WindowsDesktop)]
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests
         }
 
         [InlineData("", ProjectComponents.None)]
-        [InlineData("Microsoft.WebApplication.targets", ProjectComponents.Web)]
+        [InlineData("Microsoft.WebApplication.targets", ProjectComponents.AspNet)]
         [Theory]
         public void NonSdkImports(string import, ProjectComponents expected)
         {

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests.csproj
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Moq" />
+    <PackageReference Include="AutoFixture" />
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests/ConfigUpdaterSubStepTests.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests/ConfigUpdaterSubStepTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests
                 new object?[] { true, ProjectComponents.WinRT | ProjectComponents.WinForms, new WebWinRTTestConfigUpdater(BuildBreakRisk.None, false), false },
 
                 // Components satisfied
-                new object?[] { true, ProjectComponents.WinRT | ProjectComponents.Web, new WebWinRTTestConfigUpdater(BuildBreakRisk.None, false), true },
+                new object?[] { true, ProjectComponents.WinRT | ProjectComponents.AspNetCore, new WebWinRTTestConfigUpdater(BuildBreakRisk.None, false), true },
 
                 // Invalid components
                 new object?[] { true, (ProjectComponents)2048, new WebWinRTTestConfigUpdater(BuildBreakRisk.None, false), false }

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests/TestUpdaters/WebWinRTTestConfigUpdater.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests/TestUpdaters/WebWinRTTestConfigUpdater.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests
 {
-    [ApplicableComponents(ProjectComponents.WinRT | ProjectComponents.Web)]
+    [ApplicableComponents(ProjectComponents.WinRT | ProjectComponents.AspNetCore)]
     public class WebWinRTTestConfigUpdater : IConfigUpdater
     {
         private readonly bool _isApplicable;


### PR DESCRIPTION
This change extracts the component identification out of the project
implementation, adds tests, and adds support for a new
ProjectComponent.AspNetCore flag.

Fixes #337 