### PR TITLE
Add check so ensure file can be loaded.

### DIFF
--- a/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/CanLoadProjectFile.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/CanLoadProjectFile.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Checks
+{
+    public class CanLoadProjectFile : IUpgradeReadyCheck
+    {
+        private readonly ILogger<CanLoadProjectFile> _logger;
+
+        public CanLoadProjectFile(ILogger<CanLoadProjectFile> logger)
+        {
+            _logger = logger;
+        }
+
+        public string Id => nameof(CanLoadProjectFile);
+
+        public Task<bool> IsReadyAsync(IProject project, CancellationToken token)
+        {
+            if (project is null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            try
+            {
+                // Just need to access some values in the file to see if it can be properly loaded.
+                _ = project.GetFile().GetPropertyValue("SomeValue");
+                return Task.FromResult(true);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                _logger.LogError("Project {Name} can not be loaded: {Message}", project.FilePath, e.Message);
+                return Task.FromResult(false);
+            }
+        }
+    }
+}

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/UpgraderExtensions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/UpgraderExtensions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
         public static void AddReadinessChecks(this IServiceCollection services)
         {
+            services.AddTransient<IUpgradeReadyCheck, CanLoadProjectFile>();
             services.AddTransient<IUpgradeReadyCheck, VisualBasicWpfCheck>();
             services.AddTransient<IUpgradeReadyCheck, CentralPackageManagementCheck>();
             services.AddTransient<IUpgradeReadyCheck, MultiTargetingCheck>();

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
@@ -159,16 +159,17 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
 
         private async Task<bool> RunChecksAsync(IProject project, CancellationToken token)
         {
-            var success = true;
-
             foreach (var check in _checks)
             {
                 Logger.LogTrace("Running readiness check {Id}", check.Id);
 
-                success &= await check.IsReadyAsync(project, token).ConfigureAwait(false);
+                if (!await check.IsReadyAsync(project, token).ConfigureAwait(false))
+                {
+                    return false;
+                }
             }
 
-            return success;
+            return true;
         }
     }
 }


### PR DESCRIPTION
For instance, if you don't the PCL workload installed, the integration test will fail (currently hang). Because this is required to pass or other checks fail and throw exceptions, this change changes the checks to fail at the first one.