### PR TITLE
Only consider ordered projects in CurrentProjectSelection

### DIFF
--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
@@ -49,6 +49,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
         // This upgrade step is meant to be run fresh every time a new project needs selected
         protected override bool ShouldReset(IUpgradeContext context) => context?.CurrentProject is null && Status == UpgradeStepStatus.Complete;
 
+        public override UpgradeStepInitializeResult Reset()
+        {
+            _orderedProjects = null;
+            return base.Reset();
+        }
+
         protected override async Task<UpgradeStepInitializeResult> InitializeImplAsync(IUpgradeContext context, CancellationToken token)
         {
             if (context is null)

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
         private readonly IUserInput _input;
         private readonly ITargetFrameworkMonikerComparer _tfmComparer;
         private readonly ITargetTFMSelector _tfmSelector;
+        private IProject[] _orderedProjects;
 
         public override IEnumerable<string> DependsOn { get; } = new[]
         {
@@ -55,32 +56,43 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
                 throw new ArgumentNullException(nameof(context));
             }
 
+            if (context.EntryPoint is null)
+            {
+                throw new InvalidOperationException("Entrypoint must be set before using this step");
+            }
+
+            // If a current project is selected, then this step is done
             if (context.CurrentProject is not null)
             {
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "Current project is already selected.", BuildBreakRisk.None);
             }
 
-            var projects = context.Projects.ToList();
-            var completeChecks = projects.Select(async p => IsCompleted(context, p) || !await RunChecksAsync(p, token).ConfigureAwait(false));
+            // Get the projects we care about based on the entry point project
+            _orderedProjects = context.EntryPoint.PostOrderTraversal(p => p.ProjectReferences).ToArray();
+
+            // If all projects related to the entry point project are complete or invalid, then the upgrade is done
+            var completeChecks = _orderedProjects.Select(async p => IsCompleted(context, p) || !await RunChecksAsync(p, token).ConfigureAwait(false));
             if ((await Task.WhenAll(completeChecks).ConfigureAwait(false)).All(b => b))
             {
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "No projects need upgrade", BuildBreakRisk.None);
             }
 
+            // If no project is selected, and at least one still needs upgraded, identify the next project to upgrade
             IProject? newCurrentProject = null;
-
-            if (projects.Count == 1)
+            if (_orderedProjects.Length == 1)
             {
-                newCurrentProject = projects[0];
+                // If there is only one project, it is the current project
+                newCurrentProject = _orderedProjects[0];
                 Logger.LogDebug("Setting only project in solution as the current project: {Project}", newCurrentProject.FilePath);
             }
             else if (!context.InputIsSolution)
             {
                 // If the user has specified a particular project, only that should be the current project
-                newCurrentProject = projects.Where(i => Path.GetFileName(i.FilePath).Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase)).First();
+                newCurrentProject = _orderedProjects.Where(i => Path.GetFileName(i.FilePath).Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase)).First();
                 Logger.LogDebug("Setting user-selected project as the current project: {Project}", newCurrentProject.FilePath);
             }
 
+            // If no current project has been found, then this step is incomplete
             if (newCurrentProject is null)
             {
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, "No project is currently selected.", BuildBreakRisk.None);
@@ -132,17 +144,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
         {
             const string SelectProjectQuestion = "Here is the recommended order to upgrade. Select enter to follow this list, or input the project you want to start with.";
 
-            if (context.EntryPoint is null)
-            {
-                throw new InvalidOperationException("Entrypoint must be set before using this step");
-            }
-
-            var orderedProjects = context.EntryPoint.PostOrderTraversal(p => p.ProjectReferences);
-
             // No need for an IAsyncEnumerable here since the commands shouldn't be displayed until
             // all are available anyhow.
             var commands = new List<ProjectCommand>();
-            foreach (var project in orderedProjects)
+            foreach (var project in _orderedProjects)
             {
                 commands.Add(await CreateProjectCommandAsync(project).ConfigureAwait(false));
             }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
         private readonly IUserInput _input;
         private readonly ITargetFrameworkMonikerComparer _tfmComparer;
         private readonly ITargetTFMSelector _tfmSelector;
-        private IProject[] _orderedProjects;
+        private IProject[]? _orderedProjects;
 
         public override IEnumerable<string> DependsOn { get; } = new[]
         {
@@ -143,6 +143,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
         private async Task<IProject> GetProject(IUpgradeContext context, Func<IUpgradeContext, IProject, bool> isProjectCompleted, CancellationToken token)
         {
             const string SelectProjectQuestion = "Here is the recommended order to upgrade. Select enter to follow this list, or input the project you want to start with.";
+
+            if (_orderedProjects is null)
+            {
+                throw new UpgradeException("Project selection step must be initialized before it is applied (null _orderedProjects)");
+            }
 
             // No need for an IAsyncEnumerable here since the commands shouldn't be displayed until
             // all are available anyhow.


### PR DESCRIPTION
This fixes a bug where `CurrentProjectSelectionStep` would ask the user to pick a project but all of the projects would be complete and unselectable (since `CurrentProjectSelectionStep` looks at *all* projects to decide if upgrade is done or not but only shows the user *ordered* projects to pick from).

Fixes #284