### PR TITLE
Don't save 'upgrade complete' in state file

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/FileUpgradeStateFactory.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/FileUpgradeStateFactory.cs
@@ -40,7 +40,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             {
                 context.SetEntryPoint(FindProject(state.EntryPoint));
                 context.SetCurrentProject(FindProject(state.CurrentProject));
-                context.IsComplete = state.IsComplete;
             }
 
             IProject? FindProject(string? path)
@@ -91,7 +90,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             {
                 EntryPoint = NormalizePath(context.EntryPoint?.FilePath),
                 CurrentProject = NormalizePath(context.CurrentProject?.FilePath),
-                IsComplete = context.IsComplete,
             };
 
             await JsonSerializer.SerializeAsync(stream, state, cancellationToken: token).ConfigureAwait(false);

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/SetTFMStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/SetTFMStep.cs
@@ -56,6 +56,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
             // With an updated TFM, we should restore packages
             await _restorer.RestorePackagesAsync(context, context.CurrentProject.Required(), token).ConfigureAwait(false);
 
+            Logger.LogInformation("Updated TFM to {TargetTFM}", targetTfm);
             return new UpgradeStepApplyResult(UpgradeStepStatus.Complete, $"Updated TFM to {targetTfm}");
         }
 
@@ -75,6 +76,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
             }
             else
             {
+                Logger.LogInformation("TFM needs updated to {TargetTFM}", targetTfm);
                 return Task.FromResult(new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"TFM needs to be updated to {targetTfm}", BuildBreakRisk.High));
             }
         }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
@@ -64,7 +64,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             var completeChecks = projects.Select(async p => IsCompleted(context, p) || !await RunChecksAsync(p, token).ConfigureAwait(false));
             if ((await Task.WhenAll(completeChecks).ConfigureAwait(false)).All(b => b))
             {
-                return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "No projects need upgrade", BuildBreakRisk.None);
+                Logger.LogInformation("No projects need upgraded for entry point {EntryPoint}", context.EntryPoint.FilePath);
+                return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "No projects need upgraded", BuildBreakRisk.None);
             }
 
             IProject? newCurrentProject = null;

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             var completeChecks = projects.Select(async p => IsCompleted(context, p) || !await RunChecksAsync(p, token).ConfigureAwait(false));
             if ((await Task.WhenAll(completeChecks).ConfigureAwait(false)).All(b => b))
             {
-                Logger.LogInformation("No projects need upgraded for entry point {EntryPoint}", context.EntryPoint.FilePath);
+                Logger.LogInformation("No projects need upgraded for entry point {EntryPoint}", context.EntryPoint?.FilePath);
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "No projects need upgraded", BuildBreakRisk.None);
             }
 

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/FinalizeSolutionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/FinalizeSolutionStep.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -20,7 +21,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             WellKnownStepIds.NextProjectStepId,
         };
 
-        public override string Title => "Finalize Solution";
+        public override string Title => "Finalize upgrade";
 
         public override string Description => "All projects have been upgraded. Please review any changes and test accordingly.";
 
@@ -30,18 +31,18 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
         {
             context.IsComplete = true;
             context.SetEntryPoint(null);
-            return Task.FromResult(new UpgradeStepApplyResult(UpgradeStepStatus.Complete, "Complete solution"));
+            return Task.FromResult(new UpgradeStepApplyResult(UpgradeStepStatus.Complete, "Upgrade complete"));
         }
 
         protected override Task<UpgradeStepInitializeResult> InitializeImplAsync(IUpgradeContext context, CancellationToken token)
         {
-            if (context.IsComplete)
+            if (context.EntryPoint is null)
             {
-                return Task.FromResult(new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "Solution completed", BuildBreakRisk.None));
+                return Task.FromResult(new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "Upgrade completed", BuildBreakRisk.None));
             }
             else
             {
-                return Task.FromResult(new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, "Complete solution", BuildBreakRisk.None));
+                return Task.FromResult(new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"Finalize upgrade of entry point {context.EntryPoint.FilePath}", BuildBreakRisk.None));
             }
         }
 


### PR DESCRIPTION
Saving that the upgrade was complete prevented users from re-running Upgrade Assistant on a large solution in which they wanted to upgrade multiple entry points.

With this change, completed solutions will still exist once an entry point is picked, but it allows re-running on solutions that have multiple interesting entry points.

I considered getting rid of IUpgradeContext.Complete all together so that users could run on multiple entry points with one execution of the tool, but I figure we'll start with this smaller change and see if there's any demand for that since I'm not sure which is the better user experience. Also, if we go that route, we'll need to update entry point selection step to check whether all projects are complete.