### PR TITLE
Update web references in libraries

### DIFF
--- a/Microsoft.DotNet.UpgradeAssistant.sln
+++ b/Microsoft.DotNet.UpgradeAssistant.sln
@@ -1,4 +1,5 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30509.190
 MinimumVisualStudioVersion = 15.0.26124.0
@@ -20,7 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE.txt = LICENSE.txt
 		.github\workflows\publish.yml = .github\workflows\publish.yml
 		README.md = README.md
-		ToolsInstaller.targets = ToolsInstaller.targets
+		TryConvertInstaller.targets = TryConvertInstaller.targets
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat", "src\steps\Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat\Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.csproj", "{9D38A783-B8EE-44C9-825A-DCCCA972FF0B}"
@@ -97,7 +98,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "steps", "steps", "{421DCA6B
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.Tests", "tests\steps\Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.Tests\Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.Tests.csproj", "{F9BA18A4-53E7-4747-A55A-061ED26BA520}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests", "tests\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests\Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests.csproj", "{A58297FF-2276-415F-9A9C-75F9F1656E8C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests", "tests\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests\Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests.csproj", "{A58297FF-2276-415F-9A9C-75F9F1656E8C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Microsoft.DotNet.UpgradeAssistant.sln
+++ b/Microsoft.DotNet.UpgradeAssistant.sln
@@ -100,6 +100,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.UpgradeAss
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests", "tests\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests\Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests.csproj", "{A58297FF-2276-415F-9A9C-75F9F1656E8C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests", "tests\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests\Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests.csproj", "{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -422,6 +424,18 @@ Global
 		{A58297FF-2276-415F-9A9C-75F9F1656E8C}.Release|x64.Build.0 = Release|Any CPU
 		{A58297FF-2276-415F-9A9C-75F9F1656E8C}.Release|x86.ActiveCfg = Release|Any CPU
 		{A58297FF-2276-415F-9A9C-75F9F1656E8C}.Release|x86.Build.0 = Release|Any CPU
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}.Debug|x64.Build.0 = Debug|Any CPU
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}.Debug|x86.Build.0 = Debug|Any CPU
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}.Release|x64.ActiveCfg = Release|Any CPU
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}.Release|x64.Build.0 = Release|Any CPU
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}.Release|x86.ActiveCfg = Release|Any CPU
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -466,6 +480,7 @@ Global
 		{421DCA6B-467F-4CE3-AD9D-7B2001CFD299} = {60D2D4E3-E055-4A9C-BDB1-7328DAA9BD5C}
 		{F9BA18A4-53E7-4747-A55A-061ED26BA520} = {421DCA6B-467F-4CE3-AD9D-7B2001CFD299}
 		{A58297FF-2276-415F-9A9C-75F9F1656E8C} = {421DCA6B-467F-4CE3-AD9D-7B2001CFD299}
+		{FFB7401A-9AF6-4FCE-B305-B7BE2B1361D7} = {421DCA6B-467F-4CE3-AD9D-7B2001CFD299}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D02F665B-C14D-43C2-955C-9338A23836E0}

--- a/TryConvertInstaller.targets
+++ b/TryConvertInstaller.targets
@@ -9,7 +9,7 @@
       <!-- By default, NuGet will not include files starting with '.' or ending with '.nupkg'. Since we are including try-convert via dotnet tools, some of the files fit into this. -->
       <NoDefaultExcludes>true</NoDefaultExcludes>
       <ToolsDirectory>$(MSBuildThisFileDirectory).tools\</ToolsDirectory>
-      <TryConvertVersion>0.7.215802</TryConvertVersion>
+      <TryConvertVersion>0.7.216201</TryConvertVersion>
       <TryConvertDirectory>$(ToolsDirectory)try-convert\$(TryConvertVersion)\</TryConvertDirectory>
     </PropertyGroup>
 

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/appsettings.json
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/appsettings.json
@@ -11,7 +11,7 @@
   },
   "TemplateInserter": {
     "TemplateConfigFiles": [
-      "Templates\\CSharpWebAppTemplates\\TemplateConfig.json"
+      "Templates\\CSharpWebAppTemplates\\WebAppTemplates.json"
     ]
   },
   "TFMSelector": {

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IProjectFile.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IProjectFile.cs
@@ -15,6 +15,10 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
         string FilePath { get; }
 
+        void AddFrameworkReferences(IEnumerable<Reference> frameworkReferences);
+
+        void RemoveFrameworkReferences(IEnumerable<Reference> frameworkReferences);
+
         void AddPackages(IEnumerable<NuGetReference> packages);
 
         void RemovePackages(IEnumerable<NuGetReference> packages);

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/ComponentIdentifier.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/ComponentIdentifier.cs
@@ -20,15 +20,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
             // SDK-style projects can target .NET Framework and use GAC-referenced app models,
             // so old project components are checked regardless of SDK status
-            var components = GetOldProjectComponents(project, file);
+            var components = GetGeneralProjectComponents(project, file);
             if (file.IsSdk)
             {
                 components |= GetSDKProjectComponents(project, file);
-            }
-
-            if (project.TransitivePackageReferences.Any(f => MSBuildConstants.WinRTPackages.Contains(f.Name, StringComparer.OrdinalIgnoreCase)))
-            {
-                components |= ProjectComponents.WinRT;
             }
 
             return components;
@@ -85,9 +80,15 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
         }
 
         // Gets project components based on imports and References
-        private static ProjectComponents GetOldProjectComponents(IProject project, IProjectFile file)
+        private static ProjectComponents GetGeneralProjectComponents(IProject project, IProjectFile file)
         {
             var components = ProjectComponents.None;
+
+            // Check transitive dependencies
+            if (project.TransitivePackageReferences.Any(f => MSBuildConstants.WinRTPackages.Contains(f.Name, StringComparer.OrdinalIgnoreCase)))
+            {
+                components |= ProjectComponents.WinRT;
+            }
 
             // Check imports and references
             var references = project.References.Select(r => r.Name);

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/ComponentIdentifier.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/ComponentIdentifier.cs
@@ -17,7 +17,14 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             }
 
             var file = project.GetFile();
-            var components = file.IsSdk ? GetSDKProjectComponents(project, file) : GetOldProjectComponents(project, file);
+
+            // SDK-style projects can target .NET Framework and use GAC-referenced app models,
+            // so old project components are checked regardless of SDK status
+            var components = GetOldProjectComponents(project, file);
+            if (file.IsSdk)
+            {
+                components |= GetSDKProjectComponents(project, file);
+            }
 
             if (project.TransitivePackageReferences.Any(f => MSBuildConstants.WinRTPackages.Contains(f.Name, StringComparer.OrdinalIgnoreCase)))
             {

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildConstants.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildConstants.cs
@@ -56,7 +56,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
         {
             "System.Web",
             "System.Web.Abstractions",
-            "System.Web.Routing"
+            "System.Web.Mvc",
+            "System.Web.Razor",
+            "System.Web.Routing",
+            "System.Web.WebPages"
         };
 
         public static readonly string[] WinFormsReferences = new[]

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildExtensions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildExtensions.cs
@@ -27,11 +27,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             var element = projectRoot.GetAllPackageReferences()
                 .FirstOrDefault(p => package.Equals(p.AsNuGetReference()));
 
-            if (element is not null)
-            {
-                element.RemoveElement();
-            }
+            element?.RemoveElement();
         }
+
+        public static void AddFrameworkReference(this ProjectRootElement projectRoot, ProjectItemGroupElement itemGroup, Reference frameworkReference) =>
+            itemGroup.AppendChild(projectRoot.CreateItemElement(MSBuildConstants.FrameworkReferenceType, frameworkReference.Name));
 
         public static void AddPackageReference(this ProjectRootElement projectRoot, ProjectItemGroupElement itemGroup, NuGetReference packageReference)
         {
@@ -51,10 +51,15 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             var element = projectRoot.GetAllReferences()
                 .FirstOrDefault(r => reference.Equals(r.AsReference()));
 
-            if (element is not null)
-            {
-                element.RemoveElement();
-            }
+            element?.RemoveElement();
+        }
+
+        public static void RemoveFrameworkReference(this ProjectRootElement projectRoot, Reference frameworkReference)
+        {
+            var element = projectRoot.GetAllFrameworkReferences()
+                .FirstOrDefault(r => frameworkReference.Equals(r.AsReference()));
+
+            element?.RemoveElement();
         }
 
         public static IEnumerable<ProjectItemElement> GetAllReferences(this ProjectRootElement projectRoot)
@@ -76,6 +81,18 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 // If no element remain in the item group, remove it
                 itemGroup.Parent.RemoveChild(itemGroup);
             }
+        }
+
+        public static ProjectItemGroupElement GetOrCreateItemGroup(this ProjectRootElement projectRoot, string itemType)
+        {
+            var itemGroup = projectRoot.ItemGroups.FirstOrDefault(g => g.Items.Any(i => i.ItemType.Equals(itemType, StringComparison.OrdinalIgnoreCase)));
+            if (itemGroup is null)
+            {
+                itemGroup = projectRoot.CreateItemGroupElement();
+                projectRoot.AppendChild(itemGroup);
+            }
+
+            return itemGroup;
         }
     }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
@@ -71,11 +71,14 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public void AddPackages(IEnumerable<NuGetReference> references)
         {
-            var packageReferenceItemGroup = ProjectRoot.GetOrCreateItemGroup(MSBuildConstants.PackageReferenceType);
-            foreach (var reference in references)
+            if (references.Any())
             {
-                _logger.LogInformation("Adding package reference: {PackageReference}", reference);
-                ProjectRoot.AddPackageReference(packageReferenceItemGroup, reference);
+                var packageReferenceItemGroup = ProjectRoot.GetOrCreateItemGroup(MSBuildConstants.PackageReferenceType);
+                foreach (var reference in references)
+                {
+                    _logger.LogInformation("Adding package reference: {PackageReference}", reference);
+                    ProjectRoot.AddPackageReference(packageReferenceItemGroup, reference);
+                }
             }
         }
 
@@ -93,11 +96,14 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public void AddFrameworkReferences(IEnumerable<Reference> frameworkReferences)
         {
-            var frameworkReferenceItemGroup = ProjectRoot.GetOrCreateItemGroup(MSBuildConstants.FrameworkReferenceType);
-            foreach (var reference in frameworkReferences)
+            if (frameworkReferences.Any())
             {
-                _logger.LogInformation("Adding framework reference: {FrameworkReference}", reference);
-                ProjectRoot.AddFrameworkReference(frameworkReferenceItemGroup, reference);
+                var frameworkReferenceItemGroup = ProjectRoot.GetOrCreateItemGroup(MSBuildConstants.FrameworkReferenceType);
+                foreach (var reference in frameworkReferences)
+                {
+                    _logger.LogInformation("Adding framework reference: {FrameworkReference}", reference);
+                    ProjectRoot.AddFrameworkReference(frameworkReferenceItemGroup, reference);
+                }
             }
         }
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
@@ -71,25 +71,57 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public void AddPackages(IEnumerable<NuGetReference> references)
         {
-            const string PackageReferenceType = "PackageReference";
-
-            // Find a place to add new package references
-            var packageReferenceItemGroup = ProjectRoot.ItemGroups.FirstOrDefault(g => g.Items.Any(i => i.ItemType.Equals(PackageReferenceType, StringComparison.OrdinalIgnoreCase)));
-            if (packageReferenceItemGroup is null)
-            {
-                _logger.LogDebug("Creating a new ItemGroup for package references");
-                packageReferenceItemGroup = ProjectRoot.CreateItemGroupElement();
-                ProjectRoot.AppendChild(packageReferenceItemGroup);
-            }
-            else
-            {
-                _logger.LogDebug("Found ItemGroup for package references");
-            }
-
+            var packageReferenceItemGroup = ProjectRoot.GetOrCreateItemGroup(MSBuildConstants.PackageReferenceType);
             foreach (var reference in references)
             {
                 _logger.LogInformation("Adding package reference: {PackageReference}", reference);
                 ProjectRoot.AddPackageReference(packageReferenceItemGroup, reference);
+            }
+        }
+
+        public void RemovePackages(IEnumerable<NuGetReference> references)
+        {
+            foreach (var reference in PackageReferences)
+            {
+                if (references.Contains(reference))
+                {
+                    _logger.LogInformation("Removing outdated package reference: {PackageReference}", reference);
+                    ProjectRoot.RemovePackage(reference);
+                }
+            }
+        }
+
+        public void AddFrameworkReferences(IEnumerable<Reference> frameworkReferences)
+        {
+            var frameworkReferenceItemGroup = ProjectRoot.GetOrCreateItemGroup(MSBuildConstants.FrameworkReferenceType);
+            foreach (var reference in frameworkReferences)
+            {
+                _logger.LogInformation("Adding framework reference: {FrameworkReference}", reference);
+                ProjectRoot.AddFrameworkReference(frameworkReferenceItemGroup, reference);
+            }
+        }
+
+        public void RemoveFrameworkReferences(IEnumerable<Reference> frameworkReferences)
+        {
+            foreach (var reference in FrameworkReferences)
+            {
+                if (frameworkReferences.Contains(reference))
+                {
+                    _logger.LogInformation("Removing outdated framework reference: {FrameworkReference}", reference);
+                    ProjectRoot.RemoveFrameworkReference(reference);
+                }
+            }
+        }
+
+        public void RemoveReferences(IEnumerable<Reference> references)
+        {
+            foreach (var reference in References)
+            {
+                if (references.Contains(reference))
+                {
+                    _logger.LogInformation("Removing outdated assembly reference: {Reference}", reference);
+                    ProjectRoot.RemoveReference(reference);
+                }
             }
         }
 
@@ -107,30 +139,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
             // Reload the workspace since, at this point, the project may be different from what was loaded
             return Context.ReloadWorkspaceAsync(token);
-        }
-
-        public void RemovePackages(IEnumerable<NuGetReference> references)
-        {
-            foreach (var reference in PackageReferences)
-            {
-                if (references.Contains(reference))
-                {
-                    _logger.LogInformation("Removing outdated package reference: {PackageReference}", reference);
-                    ProjectRoot.RemovePackage(reference);
-                }
-            }
-        }
-
-        public void RemoveReferences(IEnumerable<Reference> references)
-        {
-            foreach (var reference in references)
-            {
-                if (references.Contains(reference))
-                {
-                    _logger.LogInformation("Removing outdated assembly reference: {Reference}", reference);
-                    ProjectRoot.RemoveReference(reference);
-                }
-            }
         }
 
         public void RenameFile(string filePath)

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildTargetTFMSelector.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildTargetTFMSelector.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             var tfmName = GetNetStandardTFM(project);
 
             // Projects with web components or an Exe output type should use app TFMs
-            if (project.Components.HasFlag(ProjectComponents.AspNetCore) || project.OutputType == ProjectOutputType.Exe)
+            if (project.Components.HasFlag(ProjectComponents.AspNet) || project.Components.HasFlag(ProjectComponents.AspNetCore) || project.OutputType == ProjectOutputType.Exe)
             {
                 tfmName = AppTFMBase;
             }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
             }
 
             // This reference only needs added to ASP.NET Core exes
-            if (!project.Components.HasFlag(ProjectComponents.AspNetCore) || project.OutputType != ProjectOutputType.Exe)
+            if (!(project.Components.HasFlag(ProjectComponents.AspNetCore) && project.OutputType == ProjectOutputType.Exe))
             {
                 return state;
             }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
@@ -36,8 +36,15 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 throw new ArgumentNullException(nameof(state));
             }
 
-            if (!project.Components.HasFlag(ProjectComponents.AspNetCore))
+            // This reference only needs added to ASP.NET Core exes
+            if (!project.Components.HasFlag(ProjectComponents.AspNetCore) || project.OutputType != ProjectOutputType.Exe)
             {
+                return state;
+            }
+
+            if (project.IsTransitivelyAvailable(NewtonsoftPackageName))
+            {
+                _logger.LogDebug("{PackageName} already referenced transitively", NewtonsoftPackageName);
                 return state;
             }
 
@@ -45,12 +52,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
 
             if (!packageReferences.Any(r => NewtonsoftPackageName.Equals(r.Name, StringComparison.OrdinalIgnoreCase)))
             {
-                var analyzerPackage = await _packageLoader.GetLatestVersionAsync(NewtonsoftPackageName, false, null, token).ConfigureAwait(false);
+                var newtonsoftPackage = await _packageLoader.GetLatestVersionAsync(NewtonsoftPackageName, false, null, token).ConfigureAwait(false);
 
-                if (analyzerPackage is not null)
+                if (newtonsoftPackage is not null)
                 {
-                    _logger.LogInformation("Reference to Newtonsoft package ({NewtonsoftPackageName}, version {NewtonsoftPackageVersion}) needs added", NewtonsoftPackageName, analyzerPackage.Version);
-                    state.PackagesToAdd.Add(analyzerPackage);
+                    _logger.LogInformation("Reference to Newtonsoft package ({NewtonsoftPackageName}, version {NewtonsoftPackageVersion}) needs added", NewtonsoftPackageName, newtonsoftPackage.Version);
+                    state.PackagesToAdd.Add(newtonsoftPackage);
                 }
                 else
                 {

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/PackageMapReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/PackageMapReferenceAnalyzer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                     state.PossibleBreakingChangeRecommended = true;
                     _logger.LogInformation("Marking package {PackageName} for removal based on package mapping configuration {PackageMapSet}", packageReference.Name, map.PackageSetName);
                     state.PackagesToRemove.Add(packageReference);
-                    await AddNetCorePackages(map, state, project, token).ConfigureAwait(false);
+                    await AddNetCoreReferences(map, state, project, token).ConfigureAwait(false);
                 }
             }
 
@@ -63,14 +63,14 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                     state.PossibleBreakingChangeRecommended = true;
                     _logger.LogInformation("Marking assembly reference {ReferenceName} for removal based on package mapping configuration {PackageMapSet}", reference.Name, map.PackageSetName);
                     state.ReferencesToRemove.Add(reference);
-                    await AddNetCorePackages(map, state, project, token).ConfigureAwait(false);
+                    await AddNetCoreReferences(map, state, project, token).ConfigureAwait(false);
                 }
             }
 
             return state;
         }
 
-        private async Task AddNetCorePackages(NuGetPackageMap packageMap, PackageAnalysisState state, IProject project, CancellationToken token)
+        private async Task AddNetCoreReferences(NuGetPackageMap packageMap, PackageAnalysisState state, IProject project, CancellationToken token)
         {
             foreach (var newPackage in packageMap.NetCorePackages)
             {
@@ -89,6 +89,15 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 {
                     _logger.LogInformation("Adding package {PackageName} based on package mapping configuration {PackageMapSet}", packageToAdd.Name, packageMap.PackageSetName);
                     state.PackagesToAdd.Add(packageToAdd);
+                }
+            }
+
+            foreach (var frameworkReference in packageMap.NetCoreFrameworkReferences)
+            {
+                if (!state.FrameworkReferencesToAdd.Contains(frameworkReference) && !project.FrameworkReferences.Contains(frameworkReference))
+                {
+                    _logger.LogInformation("Adding framework reference {FrameworkReference} based on package mapping configuration {PackageMapSet}", frameworkReference.Name, packageMap.PackageSetName);
+                    state.FrameworkReferencesToAdd.Add(frameworkReference);
                 }
             }
         }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/WebSdkCleanupAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/WebSdkCleanupAnalyzer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
 
         public WebSdkCleanupAnalyzer(ILogger<WebSdkCleanupAnalyzer> logger)
         {
-            _logger = logger;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public Task<PackageAnalysisState> AnalyzeAsync(IProject project, PackageAnalysisState state, CancellationToken token)
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 return Task.FromResult(state);
             }
 
-            var aspNetCoreReference = project.FrameworkReferences.FirstOrDefault(f => f.Name.Equals(AspNetCoreFrameworkReference, StringComparison.OrdinalIgnoreCase));
+            var aspNetCoreReference = project.FrameworkReferences?.FirstOrDefault(f => f.Name.Equals(AspNetCoreFrameworkReference, StringComparison.OrdinalIgnoreCase));
 
             if (aspNetCoreReference is not null)
             {

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/WebSdkCleanupAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/WebSdkCleanupAnalyzer.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
+{
+    public class WebSdkCleanupAnalyzer : IPackageReferencesAnalyzer
+    {
+        private const string AspNetCoreFrameworkReference = "Microsoft.AspNetCore.App";
+        private const string WebSdk = "Microsoft.NET.Sdk.Web";
+
+        private readonly ILogger<WebSdkCleanupAnalyzer> _logger;
+
+        public string Name => "Web SDK cleanup analyzer";
+
+        public WebSdkCleanupAnalyzer(ILogger<WebSdkCleanupAnalyzer> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task<PackageAnalysisState> AnalyzeAsync(IProject project, PackageAnalysisState state, CancellationToken token)
+        {
+            if (state is null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
+            project = project.Required();
+            var projectRoot = project.GetFile();
+
+            // Check SDK directly (instead of using project.Components) since having the FrameworkReference counts as
+            // having the AspNetCore component and this analyzer is specifically insterested in cases where both the SDK
+            // and the framework reference are present.
+            if (!projectRoot.IsSdk || !projectRoot.Sdk.Equals(WebSdk, StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(state);
+            }
+
+            var aspNetCoreReference = project.FrameworkReferences.FirstOrDefault(f => f.Name.Equals(AspNetCoreFrameworkReference, StringComparison.OrdinalIgnoreCase));
+
+            if (aspNetCoreReference is not null)
+            {
+                _logger.LogInformation("Removing framework reference Microsoft.AspNetCore.App it is already included as part of the Microsoft.NET.Sdk.Web SDK");
+                state.FrameworkReferencesToRemove.Add(aspNetCoreReference);
+            }
+
+            return Task.FromResult(state);
+        }
+    }
+}

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/NuGetPackageMap.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/NuGetPackageMap.cs
@@ -23,6 +23,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
 
         public IEnumerable<NuGetReference> NetCorePackages { get; set; } = Enumerable.Empty<NuGetReference>();
 
+        public IEnumerable<Reference> NetCoreFrameworkReferences { get; set; } = Enumerable.Empty<Reference>();
+
         /// <summary>
         /// Determines whether a package map's .NET Framework packages include a
         /// given package name and version.

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageAnalysisState.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageAnalysisState.cs
@@ -15,6 +15,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
 
         public string PackageCachePath { get; private set; } = default!;
 
+        public IList<Reference> FrameworkReferencesToAdd { get; }
+
+        public IList<Reference> FrameworkReferencesToRemove { get; }
+
         public IList<NuGetReference> PackagesToAdd { get; }
 
         public IList<NuGetReference> PackagesToRemove { get; }
@@ -25,10 +29,17 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
 
         public bool PossibleBreakingChangeRecommended { get; set; }
 
-        public bool ChangesRecommended => PackagesToAdd.Any() || PackagesToRemove.Any() || ReferencesToRemove.Any();
+        public bool ChangesRecommended =>
+            FrameworkReferencesToAdd.Any()
+            || FrameworkReferencesToRemove.Any()
+            || PackagesToAdd.Any()
+            || PackagesToRemove.Any()
+            || ReferencesToRemove.Any();
 
         private PackageAnalysisState()
         {
+            FrameworkReferencesToAdd = new List<Reference>();
+            FrameworkReferencesToRemove = new List<Reference>();
             PackagesToRemove = new List<NuGetReference>();
             PackagesToAdd = new List<NuGetReference>();
             ReferencesToRemove = new List<Reference>();

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageMaps/AspNetPackageMap.json
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageMaps/AspNetPackageMap.json
@@ -56,9 +56,6 @@
       },
       {
         "Name": "System.Web.WebPages.Razor"
-      },
-      {
-        "Name": "System.Net.Http.WebRequest"
       }
     ],
     "NetFrameworkPackages": [

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageMaps/AspNetPackageMap.json
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageMaps/AspNetPackageMap.json
@@ -1,0 +1,199 @@
+﻿[
+  {
+    "PackageSetName": "ASP.NET",
+    "NetCorePackagesWorkOnNetFx": false,
+    "NetFrameworkAssemblies": [
+      {
+        "Name": "System.Web"
+      },
+      {
+        "Name": "System.Web.Abstractions"
+      },
+      {
+        "Name": "System.Web.ApplicationServices"
+      },
+      {
+        "Name": "System.Web.DataVisualization"
+      },
+      {
+        "Name": "System.Web.DynamicData"
+      },
+      {
+        "Name": "System.Web.Entity"
+      },
+      {
+        "Name": "System.Web.Extensions"
+      },
+      {
+        "Name": "System.Web.Extensions.Design"
+      },
+      {
+        "Name": "System.Web.Helpers"
+      },
+      {
+        "Name": "System.Web.Mobile"
+      },
+      {
+        "Name": "System.Web.Mvc"
+      },
+      {
+        "Name": "System.Web.Optimization"
+      },
+      {
+        "Name": "System.Web.Razor"
+      },
+      {
+        "Name": "System.Web.Routing"
+      },
+      {
+        "Name": "System.Web.Services"
+      },
+      {
+        "Name": "System.Web.WebPages"
+      },
+      {
+        "Name": "System.Web.WebPages.Deployment"
+      },
+      {
+        "Name": "System.Web.WebPages.Razor"
+      },
+      {
+        "Name": "System.Net.Http.WebRequest"
+      }
+    ],
+    "NetFrameworkPackages": [
+      {
+        "Name": "Microsoft.AspNet.Mvc",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.AspNet.Razor",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.AspNet.Identity.Core",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.AspNet.Identity.EntityFramework",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.AspNet.Identity.Owin",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.AspNet.SessionState.CosmosDBSessionStateProviderAsync",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.AspNet.SessionState.SessionStateModule",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.AspNet.SessionState.SqlSessionStateProviderAsync",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.AspNet.Web.Optimization",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.AspNet.WebApi.Core",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.AspNet.WebApi.WebHost",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.AspNet.WebPages",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.CodeDom.Providers.DotNetCompilerPlatform",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.Owin",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.Owin.Host.SystemWeb",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.Owin.Security",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.Owin.Security.Cookies",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.Owin.Security.OAuth",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.Owin.Security.OpenIdConnect",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.Web.Infrastructure",
+        "Version": "*"
+      },
+      {
+        "Name": "Owin",
+        "Version": "*"
+      },
+      {
+        "Name": "Microsoft.AspNet.TelemetryCorrelation",
+        "Version": "*"
+      }
+    ],
+    "NetCoreFrameworkReferences": [
+      {
+        "Name": "Microsoft.AspNetCore.App"
+      }
+    ]
+  },
+  {
+    "PackageSetName": "StructureMap.Web",
+    "NetFrameworkPackages": [
+      {
+        "Name": "structuremap.web",
+        "Version": "*"
+      }
+    ],
+    "NetCorePackages": []
+  },
+  {
+    "PackageSetName": "Autofac.Mvc",
+    "NetFrameworkPackages": [
+      {
+        "Name": "Autofac.Mvc5",
+        "Version": "*"
+      }
+    ],
+    "NetCorePackages": []
+  },
+  {
+    "PackageSetName": "Antlr",
+    "NetFrameworkPackages": [
+      {
+        "Name": "Antlr",
+        "Version": "*"
+      },
+      {
+        "Name": "Antlr3.Runtime",
+        "Version": "*"
+      }
+    ],
+    "NetCorePackages": [
+      {
+        "Name": "Antlr4",
+        "Version": "4.6.6"
+      }
+    ]
+  }
+]

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageMaps/DefaultPackageMap.json
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageMaps/DefaultPackageMap.json
@@ -77,8 +77,13 @@
     ]
   },
   {
-    "PackageSetName": "Microsoft.Net.Http",
+    "PackageSetName": "HTTP packages",
     "NetCorePackagesWorkOnNetFx": true,
+    "NetFrameworkAssemblies": [
+      {
+        "Name": "System.Net.Http.WebRequest"
+      }
+    ],
     "NetFrameworkPackages": [
       {
         "Name": "Microsoft.Net.Http",

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageMaps/DefaultPackageMap.json
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageMaps/DefaultPackageMap.json
@@ -26,6 +26,7 @@
   },
   {
     "PackageSetName": "Microsoft.Toolkit.Wpf.UI.Controls.WebView",
+    "NetCorePackagesWorkOnNetFx": true,
     "NetFrameworkPackages": [
       {
         "Name": "Microsoft.Toolkit.Wpf.UI.Controls.WebView",
@@ -36,71 +37,6 @@
       {
         "Name": "Microsoft.Web.WebView2",
         "Version": "1.0.705.50"
-      }
-    ]
-  },
-  {
-    "PackageSetName": "StructureMap.Web",
-    "NetFrameworkPackages": [
-      {
-        "Name": "structuremap.web",
-        "Version": "*"
-      }
-    ],
-    "NetCorePackages": []
-  },
-  {
-    "PackageSetName": "Autofac.Mvc",
-    "NetFrameworkPackages": [
-      {
-        "Name": "Autofac.Mvc5",
-        "Version": "*"
-      }
-    ],
-    "NetCorePackages": []
-  },
-  {
-    "PackageSetName": "ASP.NET",
-    "NetCorePackages": [],
-    "NetFrameworkPackages": [
-      {
-        "Name": "Microsoft.AspNet.SessionState.SessionStateModule",
-        "Version": "*"
-      },
-      {
-        "Name": "Microsoft.AspNet.TelemetryCorrelation",
-        "Version": "*"
-      },
-      {
-        "Name": "Microsoft.AspNet.SessionState.SqlSessionStateProviderAsync",
-        "Version": "*"
-      },
-      {
-        "Name": "Microsoft.AspNet.SessionState.CosmosDBSessionStateProviderAsync",
-        "Version": "*"
-      },
-      {
-        "Name": "Microsoft.AspNet.Mvc",
-        "Version": "*"
-      }
-    ]
-  },
-  {
-    "PackageSetName": "Antlr",
-    "NetFrameworkPackages": [
-      {
-        "Name": "Antlr",
-        "Version": "*"
-      },
-      {
-        "Name": "Antlr3.Runtime",
-        "Version": "*"
-      }
-    ],
-    "NetCorePackages": [
-      {
-        "Name": "Antlr4",
-        "Version": "4.6.6"
       }
     ]
   },

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageUpdaterStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageUpdaterStep.cs
@@ -116,9 +116,19 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
                     Logger.LogInformation($"Packages to be removed:\n{string.Join("\n", _analysisState.PackagesToRemove.Distinct())}");
                 }
 
+                if (_analysisState.FrameworkReferencesToRemove.Count > 0)
+                {
+                    Logger.LogInformation($"Framework references to be removed:\n{string.Join("\n", _analysisState.FrameworkReferencesToRemove.Distinct())}");
+                }
+
                 if (_analysisState.PackagesToAdd.Count > 0)
                 {
                     Logger.LogInformation($"Packages to be addded:\n{string.Join("\n", _analysisState.PackagesToAdd.Distinct())}");
+                }
+
+                if (_analysisState.FrameworkReferencesToAdd.Count > 0)
+                {
+                    Logger.LogInformation($"Framework references to be addded:\n{string.Join("\n", _analysisState.FrameworkReferencesToAdd.Distinct())}");
                 }
 
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"{_analysisState.ReferencesToRemove.Distinct().Count()} references need removed, {_analysisState.PackagesToRemove.Distinct().Count()} packages need removed, and {_analysisState.PackagesToAdd.Distinct().Count()} packages need added", _analysisState.PossibleBreakingChangeRecommended ? BuildBreakRisk.Medium : BuildBreakRisk.Low);
@@ -151,7 +161,9 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
                     {
                         projectFile.RemoveReferences(_analysisState.ReferencesToRemove.Distinct());
                         projectFile.RemovePackages(_analysisState.PackagesToRemove.Distinct());
+                        projectFile.RemoveFrameworkReferences(_analysisState.FrameworkReferencesToRemove.Distinct());
                         projectFile.AddPackages(_analysisState.PackagesToAdd.Distinct());
+                        projectFile.AddFrameworkReferences(_analysisState.FrameworkReferencesToAdd.Distinct());
 
                         await projectFile.SaveAsync(token).ConfigureAwait(false);
                         count++;

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             var completeChecks = _orderedProjects.Select(async p => IsCompleted(context, p) || !await RunChecksAsync(p, token).ConfigureAwait(false));
             if ((await Task.WhenAll(completeChecks).ConfigureAwait(false)).All(b => b))
             {
-                Logger.LogInformation("No projects need upgraded for entry point {EntryPoint}", context.EntryPoint?.FilePath);
+                Logger.LogInformation("No projects need upgraded for entry point {EntryPoint}", context.EntryPoint.FilePath);
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "No projects need upgraded", BuildBreakRisk.None);
             }
 

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/TemplateConfiguration.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/TemplateConfiguration.cs
@@ -16,12 +16,19 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Templates
 
         public ItemSpec[]? TemplateItems { get; set; }
 
+        public ProjectOutputType[]? TemplateOutputType { get; set; }
+
         public ProjectComponents[]? TemplateAppliesTo { get; set; }
 
         public Language? TemplateLanguage { get; set; }
 
         internal bool AppliesToProject(IProject project)
         {
+            if (TemplateOutputType is not null && !TemplateOutputType.Contains(project.OutputType))
+            {
+                return false;
+            }
+
             if (TemplateAppliesTo is not null && !TemplateAppliesTo.All(flag => project.Components.HasFlag(flag)))
             {
                 return false;

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/TemplateProvider.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/TemplateProvider.cs
@@ -50,8 +50,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Templates
                     var configFilePath = Path.GetDirectoryName(configFile) ?? string.Empty;
                     var templateConfig = await LoadTemplateConfigurationAsync(extension, configFile, token).ConfigureAwait(false);
 
-                    // If there was a problem reading the configuration or the configuration only applies to web apps and the
-                    // current project isn't a web app, continue to the next config file.
+                    // If there was a problem reading the configuration or the configuration only applies to certain output types
+                    // or project types which don't match the project, then continue to the next configuration.
                     if (templateConfig?.TemplateItems is null || !templateConfig.AppliesToProject(project))
                     {
                         _logger.LogDebug("Skipping inapplicable template config file {TemplateConfigFile}", configFile);

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/Templates/CSharpWebAppTemplates/WebAppTemplates.json
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/Templates/CSharpWebAppTemplates/WebAppTemplates.json
@@ -30,6 +30,9 @@
       "Keywords": []
     }
   ],
+  "TemplateOutputType": [
+    "Exe"
+  ],
   "TemplateLanguage": "CSharp",
   "TemplateAppliesTo": [
     "AspNetCore"

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/Analyzers/WebSdkCleanupAnalyzerTests.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/Analyzers/WebSdkCleanupAnalyzerTests.cs
@@ -1,0 +1,110 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Autofac;
+using Autofac.Extras.Moq;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers.Tests
+{
+    public class WebSdkCleanupAnalyzerTests
+    {
+        [Fact]
+        public void CtorTests()
+        {
+            // Arrange
+            using var mock = AutoMock.GetLoose();
+
+            // Act
+            var analyzer = mock.Create<WebSdkCleanupAnalyzer>();
+
+            // Assert
+            Assert.Equal("Web SDK cleanup analyzer", analyzer.Name);
+        }
+
+        [Fact]
+        public void NegativeCtorTests()
+        {
+            Assert.Throws<ArgumentNullException>("logger", () => new WebSdkCleanupAnalyzer(null!));
+        }
+
+        [Theory]
+        [InlineData("Microsoft.NET.Sdk.Web", new[] { "Microsoft.AspNetCore.App" }, new[] { "Microsoft.AspNetCore.App" })] // Vanilla positive case
+        [InlineData("Microsoft.NET.Sdk.Web", new[] { "X", "Y", "Microsoft.AspNetCore.App", "Z" }, new[] { "Microsoft.AspNetCore.App" })] // Multiple references
+        [InlineData("Microsoft.NET.Sdk.Web", new[] { "Microsoft.AspNetCore.App", "Microsoft.AspNetCore.App" }, new[] { "Microsoft.AspNetCore.App" })] // Duplicate references
+        [InlineData("microsoft.NET.SDK.Web", new[] { "microsoft.ASPNetCore.App" }, new[] { "microsoft.ASPNetCore.App" })] // Ununusual case
+        [InlineData("Microsoft.NET.Sdk", new[] { "Microsoft.AspNetCore.App" }, new string[0])] // Wrong SDK
+        [InlineData("Microsoft.NET.Sdk.Web", new[] { "A", "B", "C" }, new string[0])] // Wrong framework reference
+        [InlineData(null, new[] { "Microsoft.AspNetCore.App" }, new string[0])] // No SDK
+        [InlineData("Microsoft.NET.Sdk.Web", new string[0], new string[0])] // No framework reference
+        [InlineData("Microsoft.NET.Sdk.Web", null, new string[0])] // Null framework references
+        public async Task AnalyzeAsyncTests(string? sdk, string[]? frameworkReferences, string[] expectedReferencesToRemove)
+        {
+            // Arrange
+            using var mock = AutoMock.GetLoose();
+            (var project, var state) = await GetMockProjectAndPackageState(mock, sdk, frameworkReferences?.Select(r => new Reference(r)));
+            var analyzer = mock.Create<WebSdkCleanupAnalyzer>();
+
+            // Act
+            var finalState = await analyzer.AnalyzeAsync(project, state, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(state, finalState);
+            Assert.Collection(
+                state.FrameworkReferencesToRemove,
+                expectedReferencesToRemove.Select<string, Action<Reference>>(e => r => Assert.Equal(e, r.Name)).ToArray());
+        }
+
+        [Fact]
+        public async Task NegativeAnalyzeAsyncTests()
+        {
+            // Arrange
+            using var mock = AutoMock.GetLoose();
+            (var project, var state) = await GetMockProjectAndPackageState(mock);
+            var analyzer = mock.Create<WebSdkCleanupAnalyzer>();
+
+            // Act / Assert
+            await Assert.ThrowsAsync<ArgumentNullException>("state", () => analyzer.AnalyzeAsync(project, null!, CancellationToken.None));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => analyzer.AnalyzeAsync(null!, state, CancellationToken.None));
+        }
+
+        private async Task<(IProject Project, PackageAnalysisState State)> GetMockProjectAndPackageState(AutoMock mock, string? sdk = null, IEnumerable<Reference>? frameworkReferences = null)
+        {
+            var projectRoot = mock.Mock<IProjectFile>();
+            projectRoot.Setup(r => r.IsSdk).Returns(sdk is not null);
+            if (sdk is not null)
+            {
+                projectRoot.Setup(r => r.Sdk).Returns(sdk);
+            }
+            else
+            {
+                projectRoot.Setup(r => r.Sdk).Throws<ArgumentOutOfRangeException>();
+            }
+
+            var project = mock.Mock<IProject>();
+            project.Setup(p => p.GetFile()).Returns(projectRoot.Object);
+            project.Setup(p => p.FrameworkReferences).Returns(frameworkReferences);
+
+            var context = mock.Mock<IUpgradeContext>();
+            context.Setup(c => c.CurrentProject).Returns(project.Object);
+
+            var restorer = mock.Mock<IPackageRestorer>();
+            restorer.Setup(r => r.RestorePackagesAsync(
+                It.IsAny<IUpgradeContext>(),
+                It.IsAny<IProject>(),
+                It.IsAny<CancellationToken>())).Returns(Task.FromResult(new RestoreOutput(string.Empty, string.Empty)));
+
+            return (project.Object, await PackageAnalysisState.CreateAsync(context.Object, restorer.Object, CancellationToken.None));
+        }
+    }
+}

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests.csproj
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Autofac.Extras.Moq" />
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Packages\Microsoft.DotNet.UpgradeAssistant.Steps.Packages.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/tool/Integration.Tests/E2ETest.cs
+++ b/tests/tool/Integration.Tests/E2ETest.cs
@@ -36,6 +36,7 @@ namespace Integration.Tests
         [InlineData("WpfSample/csharp", "BeanTrader.sln", "BeanTraderClient.csproj")]
         [InlineData("WpfSample/vb", "WpfApp1.sln", "")]
         [InlineData("PCL", "SamplePCL.csproj", "")]
+        [InlineData("WebLibrary/csharp", "WebLibrary.csproj", "")]
         [Theory]
         public async Task UpgradeTest(string scenarioPath, string inputFileName, string entrypoint)
         {

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Original/Properties/AssemblyInfo.cs
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Original/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Helper")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Helper")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9be957f4-d033-4dd4-83cc-77fb64ab3020")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Original/WebHelpers.cs
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Original/WebHelpers.cs
@@ -1,0 +1,11 @@
+﻿using System.Web;
+using System.Web.Mvc;
+
+namespace Helper
+{
+    public static class WebHelpers
+    {
+        public static string GetClientAddress() =>
+            Newtonsoft.Json.JsonConvert.SerializeObject(new { Verb = HttpVerbs.Get, Address = HttpContext.Current.Request.UserHostAddress });
+    }
+}

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Original/WebLibrary.csproj
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Original/WebLibrary.csproj
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9BE957F4-D033-4DD4-83CC-77FB64AB3020}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WebLibrary</RootNamespace>
+    <AssemblyName>WebLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.7\lib\net45\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="WebHelpers.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Original/packages.config
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Original/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net472" />
+</packages>

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Upgraded/Properties/AssemblyInfo.cs
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Upgraded/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Helper")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Helper")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9be957f4-d033-4dd4-83cc-77fb64ab3020")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Upgraded/WebHelpers.cs
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Upgraded/WebHelpers.cs
@@ -1,0 +1,9 @@
+﻿
+namespace Helper
+{
+    public static class WebHelpers
+    {
+        public static string GetClientAddress() =>
+            Newtonsoft.Json.JsonConvert.SerializeObject(new { Verb = HttpVerbs.Get, Address = HttpContext.Current.Request.UserHostAddress });
+    }
+}

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Upgraded/WebLibrary.csproj
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Upgraded/WebLibrary.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.2.212405">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+</Project>

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Upgraded/WebLibrary.csproj
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Upgraded/WebLibrary.csproj
@@ -14,7 +14,6 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Upgraded/WebLibrary.csproj
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WebLibrary/csharp/Upgraded/WebLibrary.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.2.212405">
+    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />


### PR DESCRIPTION
This updates Upgrade Assistant to use the latest version of try-convert (which won't remove classic ASP.NET dependencies from libraries that keep a NetFx TFM) and adds additional package update analyzers to replace ASP.NET dependencies with ASP.NET Core ones *after* the TFM has been updated.

Fixes #347 