### PR TITLE
Showing try-convert error for vbproj unit test projects

### DIFF
--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertTool.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertTool.cs
@@ -21,7 +21,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
         private static readonly string[] ErrorMessages = new[]
         {
             "This project has custom imports that are not accepted by try-convert",
-            "is an unsupported project type. Not all project type guids are supported."
+            "is an unsupported project type. Not all project type guids are supported.",
+            "has invalid Project Type Guids for test projects and is not supported."
         };
 
         private readonly IProcessRunner _runner;

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertTool.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertTool.cs
@@ -22,7 +22,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
         {
             "This project has custom imports that are not accepted by try-convert",
             "is an unsupported project type. Not all project type guids are supported.",
-            "has invalid Project Type Guids for test projects and is not supported."
+            "has invalid Project Type Guids for test projects and is not supported.",
+            "is a coded UI test. Coded UI tests are deprecated and not convertable to .NET Core.",
+            "is an unsupported MSTest test type. Only Unit Tests are supported.",
+            "does not have a supported OutputType."
         };
 
         private readonly IProcessRunner _runner;


### PR DESCRIPTION
Because the error was previously hidden the upgrade-assistant was treating this step as success.

The displayed error message will be similar to:
`[try-convert] '..\VbUnitTest1Converted.vbproj' has invalid Project Type Guids for test projects and is not supported.`