### PR TITLE
Consolidate IProject.FilePath and .Directory

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/ConsoleUpgrade.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/ConsoleUpgrade.cs
@@ -115,13 +115,13 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
                 if (context.EntryPoint is not null)
                 {
-                    _io.Output.WriteLine($"Entrypoint: {context.EntryPoint.FilePath}");
+                    _io.Output.WriteLine($"Entrypoint: {context.EntryPoint.FileInfo}");
                     displayedProjectInfo = true;
                 }
 
                 if (context.CurrentProject is not null)
                 {
-                    _io.Output.WriteLine($"Current Project: {context.CurrentProject.FilePath}");
+                    _io.Output.WriteLine($"Current Project: {context.CurrentProject.FileInfo}");
                     displayedProjectInfo = true;
                 }
 

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/FileUpgradeStateFactory.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/FileUpgradeStateFactory.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             }
 
             IProject? FindProject(string? path)
-                => path is null ? null : context.Projects.FirstOrDefault(p => NormalizePath(p.FilePath) == path);
+                => path is null ? null : context.Projects.FirstOrDefault(p => NormalizePath(p.FileInfo.FullName) == path);
         }
 
         private async ValueTask<UpgradeState?> GetStateAsync(CancellationToken token)
@@ -88,12 +88,14 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
             var state = new UpgradeState
             {
-                EntryPoint = NormalizePath(context.EntryPoint?.FilePath),
-                CurrentProject = NormalizePath(context.CurrentProject?.FilePath),
+                EntryPoint = NormalizePath(context.EntryPoint?.FileInfo),
+                CurrentProject = NormalizePath(context.CurrentProject?.FileInfo),
             };
 
             await JsonSerializer.SerializeAsync(stream, state, cancellationToken: token).ConfigureAwait(false);
         }
+
+        private static string NormalizePath(FileInfo? file) => file is null ? string.Empty : file.Name;
 
         private static string NormalizePath(string? path) => path is null ? string.Empty : Path.GetFileName(path);
 

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IProject.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IProject.cs
@@ -2,15 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.UpgradeAssistant
 {
     public interface IProject
     {
-        string Directory { get; }
-
-        string FilePath { get; }
+        FileInfo FileInfo { get; }
 
         Language Language { get; }
 

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Reporting/ReportGenerator.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Reporting/ReportGenerator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Reporting
                     .Select(generator => generator.GenerateContentAsync(project, token));
                 var sections = await Task.WhenAll(sectionTasks).ConfigureAwait(false);
 
-                yield return new Page(Path.GetFileName(project.FilePath))
+                yield return new Page(project.FileInfo.Name)
                 {
                     Content = sections
                 };

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/UpgradeStep.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/UpgradeStep.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
             try
             {
-                ProjectInitializedAgainst = context.CurrentProject?.FileInfo.FullName;
+                ProjectInitializedAgainst = context.CurrentProject?.FileInfo?.FullName;
                 (Status, StatusDetails, Risk) = await InitializeImplAsync(context, token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/UpgradeStep.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/UpgradeStep.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
             try
             {
-                ProjectInitializedAgainst = context.CurrentProject?.FilePath;
+                ProjectInitializedAgainst = context.CurrentProject?.FileInfo.FullName;
                 (Status, StatusDetails, Risk) = await InitializeImplAsync(context, token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
@@ -237,7 +237,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
                 return false;
             }
 
-            var currentProject = context.CurrentProject?.FilePath;
+            var currentProject = context.CurrentProject?.FileInfo.FullName;
 
             if (ProjectInitializedAgainst is null)
             {

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/DotnetRestorePackageRestorer.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/DotnetRestorePackageRestorer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 throw new ArgumentNullException(nameof(project));
             }
 
-            await RunRestoreAsync(context, project.FilePath, token).ConfigureAwait(false);
+            await RunRestoreAsync(context, project.FileInfo.FullName, token).ConfigureAwait(false);
 
             // Reload the project because, by design, NuGet properties (like NuGetPackageRoot)
             // aren't available in a project until after restore is run the first time.

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildPackageRestorer.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildPackageRestorer.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             return GetRestoreOutput(project);
         }
 
-        private static ProjectInstance CreateProjectInstance(IUpgradeContext context, IProject project) => new ProjectInstance(project.FilePath, context.GlobalProperties, toolsVersion: null);
+        private static ProjectInstance CreateProjectInstance(IUpgradeContext context, IProject project) => new ProjectInstance(project.FileInfo.FullName, context.GlobalProperties, toolsVersion: null);
 
         private static RestoreOutput GetRestoreOutput(IProject project)
         {

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
@@ -183,9 +183,9 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public bool ContainsItem(string itemName, ProjectItemType? itemType, CancellationToken token)
         {
-            var targetItemPath = GetPathRelativeToProject(itemName, Directory);
+            var targetItemPath = GetPathRelativeToProject(itemName, FileInfo.DirectoryName ?? string.Empty);
             var candidateItems = Project.Items
-                .Where(i => GetPathRelativeToProject(i.EvaluatedInclude, Directory).Equals(targetItemPath, StringComparison.OrdinalIgnoreCase));
+                .Where(i => GetPathRelativeToProject(i.EvaluatedInclude, FileInfo.DirectoryName ?? string.Empty).Equals(targetItemPath, StringComparison.OrdinalIgnoreCase));
 
             if (itemType is not null)
             {

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
@@ -17,6 +17,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
     {
         private ProjectRootElement? _projectRoot;
 
+        string IProjectFile.FilePath => FileInfo.FullName;
+
         // Don't get the project root from Project.Xml since some upgrade
         // steps may need to work with the project XML while it's not in
         // a completely loadable state (for example, prior to converting
@@ -27,7 +29,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             {
                 if (_projectRoot is null)
                 {
-                    _projectRoot = ProjectRootElement.Open(FilePath, Context.ProjectCollection);
+                    _projectRoot = ProjectRootElement.Open(FileInfo.FullName, Context.ProjectCollection);
                 }
 
                 return _projectRoot;

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
@@ -21,13 +21,13 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public MSBuildWorkspaceUpgradeContext Context { get; }
 
-        public string FilePath { get; }
+        public FileInfo FileInfo { get; }
 
-        public string Directory => Path.GetDirectoryName(FilePath)!;
+        public string Directory => FileInfo.Directory!.FullName;
 
-        public MSBuildProject(MSBuildWorkspaceUpgradeContext context, IComponentIdentifier componentIdentifier, string path, ILogger logger)
+        public MSBuildProject(MSBuildWorkspaceUpgradeContext context, IComponentIdentifier componentIdentifier, FileInfo file, ILogger logger)
         {
-            FilePath = path;
+            FileInfo = file;
             Context = context;
 
             _componentIdentifier = componentIdentifier;
@@ -43,23 +43,21 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 throw new InvalidOperationException("Could not find project path for reference");
             }
 
-            return Context.GetOrAddProject(project.FilePath);
+            return Context.GetOrAddProject(new FileInfo(project.FilePath));
         });
 
-        public Language Language => ParseLanguageByProjectFileExtension(FilePath);
+        public Language Language => ParseLanguageByProjectFileExtension(FileInfo.Extension);
 
-        private static Language ParseLanguageByProjectFileExtension(string filePath)
-        {
-            return Path.GetExtension(filePath).ToUpperInvariant() switch
+        private static Language ParseLanguageByProjectFileExtension(string extension)
+            => extension.ToUpperInvariant() switch
             {
                 ".CSPROJ" => Language.CSharp,
                 ".VBPROJ" => Language.VisualBasic,
                 ".FSPROJ" => Language.FSharp,
                 _ => Language.Unknown
             };
-        }
 
-        public MBuild.Project Project => Context.ProjectCollection.LoadProject(FilePath);
+        public MBuild.Project Project => Context.ProjectCollection.LoadProject(FileInfo.FullName);
 
         public ProjectOutputType OutputType =>
             ProjectRoot.Properties.FirstOrDefault(p => p.Name.Equals(MSBuildConstants.OutputTypePropertyName, StringComparison.OrdinalIgnoreCase))?.Value switch
@@ -92,7 +90,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             {
                 yield return Path.IsPathFullyQualified(item.EvaluatedInclude)
                     ? item.EvaluatedInclude
-                    : Path.Combine(Path.GetDirectoryName(FilePath) ?? string.Empty, item.EvaluatedInclude);
+                    : Path.Combine(FileInfo.DirectoryName ?? string.Empty, item.EvaluatedInclude);
             }
         }
 
@@ -154,7 +152,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
                     if (lockFile is null)
                     {
-                        throw new ProjectRestoreRequiredException($"Project is not restored: {FilePath}");
+                        throw new ProjectRestoreRequiredException($"Project is not restored: {FileInfo}");
                     }
 
                     var lockFileTarget = lockFile
@@ -163,7 +161,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
                     if (lockFileTarget is null)
                     {
-                        throw new ProjectRestoreRequiredException($"Could not find {tfm.DotNetFrameworkName} in {LockFilePath} for {FilePath}");
+                        throw new ProjectRestoreRequiredException($"Could not find {tfm.DotNetFrameworkName} in {LockFilePath} for {FileInfo}");
                     }
 
                     return lockFileTarget.Libraries.Select(l => new NuGetReference(l.Name, l.Version.ToNormalizedString()));
@@ -219,8 +217,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
                     if (propCount != 1)
                     {
-                        _logger.LogError("Expected project to have exactly one {PropertyName} property. Found {TargetFrameworkCount} TargetFramework properties for project {Project}.", propertyName, propCount, FilePath);
-                        throw new UpgradeException($"Expected project to have exactly one {propertyName} property. Found {propCount} TargetFramework properties for project {FilePath}.");
+                        _logger.LogError("Expected project to have exactly one {PropertyName} property. Found {TargetFrameworkCount} TargetFramework properties for project {Project}.", propertyName, propCount, FileInfo);
+                        throw new UpgradeException($"Expected project to have exactly one {propertyName} property. Found {propCount} TargetFramework properties for project {FileInfo}.");
                     }
 
                     return targetFrameworkProperties.Single().Value;
@@ -234,15 +232,15 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
         {
             if (obj is MSBuildProject other)
             {
-                return string.Equals(FilePath, other.FilePath, StringComparison.OrdinalIgnoreCase);
+                return string.Equals(FileInfo.FullName, other.FileInfo.FullName, StringComparison.OrdinalIgnoreCase);
             }
 
             return false;
         }
 
-        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(FilePath);
+        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(FileInfo);
 
         public Project GetRoslynProject()
-            => Context.Workspace.CurrentSolution.Projects.First(p => string.Equals(p.FilePath, FilePath, StringComparison.OrdinalIgnoreCase));
+            => Context.Workspace.CurrentSolution.Projects.First(p => string.Equals(p.FilePath, FileInfo.FullName, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
@@ -23,8 +23,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public FileInfo FileInfo { get; }
 
-        public string Directory => FileInfo.Directory!.FullName;
-
         public MSBuildProject(MSBuildWorkspaceUpgradeContext context, IComponentIdentifier componentIdentifier, FileInfo file, ILogger logger)
         {
             FileInfo = file;
@@ -182,7 +180,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
                 if (!Path.IsPathFullyQualified(lockFilePath))
                 {
-                    lockFilePath = Path.Combine(Directory, lockFilePath);
+                    lockFilePath = Path.Combine(FileInfo.DirectoryName ?? string.Empty, lockFilePath);
                 }
 
                 return lockFilePath;

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildTargetTFMSelector.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildTargetTFMSelector.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 }
             }
 
-            _logger.LogDebug("Considering TFM {TFM} for project {Project} based on its style and output type ({ProjectStyle}, {ProjectOutputType})", tfmName, project.FilePath, project.Components, project.OutputType);
+            _logger.LogDebug("Considering TFM {TFM} for project {Project} based on its style and output type ({ProjectStyle}, {ProjectOutputType})", tfmName, project.FileInfo, project.Components, project.OutputType);
 
             // If the project depends on another project with a higher version NetCore or NetStandard TFM,
             // use that TFM instead.
@@ -78,16 +78,16 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                     if (dep.TFM.IsNetCore || dep.TFM.IsNetStandard)
                     {
                         tfm = dep.TFM;
-                        _logger.LogDebug("Considering TFM {TFM} for project {Project} based on its dependency on {DepProject}", tfm, project.FilePath, dep.FilePath);
+                        _logger.LogDebug("Considering TFM {TFM} for project {Project} based on its dependency on {DepProject}", tfm, project.FileInfo, dep.FileInfo);
                     }
                 }
                 catch (UpgradeException)
                 {
-                    _logger.LogWarning($"Unable to determine TFM for dependency {dep.FilePath}; TFM for {project.FilePath} may not be correct.");
+                    _logger.LogWarning($"Unable to determine TFM for dependency {dep.FileInfo}; TFM for {project.FileInfo} may not be correct.");
                 }
             }
 
-            _logger.LogDebug("Recommending TFM {TFM} for project {Project}", tfm, project.FilePath);
+            _logger.LogDebug("Recommending TFM {TFM} for project {Project}", tfm, project.FileInfo);
 
             // Ensure we don't downgrade a project
             return _tfmComparer.Compare(project.TFM, tfm) > 0 ? project.TFM : tfm;

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
@@ -20,8 +20,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
         private readonly string? _vsPath;
         private readonly Dictionary<string, IProject> _projectCache;
 
-        private string? _entryPointPath;
-        private string? _projectPath;
+        private FileInfo? _entryPointPath;
+        private FileInfo? _projectPath;
 
         private MSBuildWorkspace? _workspace;
 
@@ -91,16 +91,16 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             ProjectCollection.Dispose();
         }
 
-        public IProject GetOrAddProject(string path)
+        public IProject GetOrAddProject(FileInfo path)
         {
-            if (_projectCache.TryGetValue(path, out var cached))
+            if (_projectCache.TryGetValue(path.FullName, out var cached))
             {
                 return cached;
             }
 
             var project = new MSBuildProject(this, _componentIdentifier, path, _logger);
 
-            _projectCache.Add(path, project);
+            _projectCache.Add(path.FullName, project);
 
             return project;
         }
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             }
         }
 
-        public void SetEntryPoint(IProject? entryPoint) => _entryPointPath = entryPoint?.FilePath;
+        public void SetEntryPoint(IProject? entryPoint) => _entryPointPath = entryPoint?.FileInfo;
 
         public IEnumerable<IProject> Projects
         {
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                     }
                     else
                     {
-                        yield return GetOrAddProject(project.FilePath);
+                        yield return GetOrAddProject(new FileInfo(project.FilePath));
                     }
                 }
             }
@@ -223,7 +223,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public void SetCurrentProject(IProject? project)
         {
-            _projectPath = project?.FilePath;
+            _projectPath = project?.FileInfo;
         }
 
         public bool UpdateSolution(Solution updatedSolution)

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/CanLoadProjectFile.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/CanLoadProjectFile.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Checks
             catch (Exception e)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                _logger.LogError("Project {Name} can not be loaded: {Message}", project.FilePath, e.Message);
+                _logger.LogError("Project {Name} can not be loaded: {Message}", project.FileInfo, e.Message);
                 return Task.FromResult(false);
             }
         }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/CentralPackageManagementCheck.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/CentralPackageManagementCheck.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Checks
 
             if (bool.TryParse(projectRoot.GetPropertyValue("EnableCentralPackageVersions"), out var result) && result)
             {
-                _logger.LogError("Project {Name} uses EnableCentralPackageVersions which is not currently supported. Please see https://github.com/dotnet/upgrade-assistant/issues/252 to request this feature.", project.FilePath);
+                _logger.LogError("Project {Name} uses EnableCentralPackageVersions which is not currently supported. Please see https://github.com/dotnet/upgrade-assistant/issues/252 to request this feature.", project.FileInfo);
                 return Task.FromResult(false);
             }
             else

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/MultiTargetingCheck.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/MultiTargetingCheck.cs
@@ -29,12 +29,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Checks
             try
             {
                 var tfm = project.TFM;
-                _logger.LogTrace("Confirmed project {Project} has a valid TFM ({TFM})", project.FilePath, tfm);
+                _logger.LogTrace("Confirmed project {Project} has a valid TFM ({TFM})", project.FileInfo, tfm);
                 return Task.FromResult(true);
             }
             catch (UpgradeException)
             {
-                _logger.LogError("Project {Project} cannot be upgraded. Input projects must have exactly one <TargetFramework> or <TargetFrameworkVersion> property. Multi-targeted projects are not yet supported.", project.FilePath);
+                _logger.LogError("Project {Project} cannot be upgraded. Input projects must have exactly one <TargetFramework> or <TargetFrameworkVersion> property. Multi-targeted projects are not yet supported.", project.FileInfo);
                 return Task.FromResult(false);
             }
         }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/VisualBasicWpfCheck.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/Checks/VisualBasicWpfCheck.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Checks
 
             if (project.Language == Language.VisualBasic && project.Components.HasFlag(ProjectComponents.Wpf))
             {
-                _logger.LogError("Project {Project} cannot be upgraded. try-convert version 0.7.212201 does not support the migration of Visual Basic WPF applications", project.FilePath);
+                _logger.LogError("Project {Project} cannot be upgraded. try-convert version 0.7.212201 does not support the migration of Visual Basic WPF applications", project.FileInfo);
                 return Task.FromResult(false);
             }
 

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/AppSettingsConfigUpdater.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/AppSettingsConfigUpdater.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters
             var project = context.CurrentProject.Required();
 
             // Determine where appsettings.json should live
-            var appSettingsPath = Path.Combine(project.Directory ?? string.Empty, AppSettingsJsonFileName);
+            var appSettingsPath = Path.Combine(project.FileInfo.DirectoryName, AppSettingsJsonFileName);
 
             // Parse existing appsettings.json properties, if any
             var existingJson = "{}";

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/AppSettingsConfigUpdater.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/AppSettingsConfigUpdater.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters
             var project = context.CurrentProject.Required();
 
             // Determine where appsettings.json should live
-            var appSettingsPath = Path.Combine(project.FileInfo.DirectoryName, AppSettingsJsonFileName);
+            var appSettingsPath = Path.Combine(project.FileInfo.DirectoryName ?? string.Empty, AppSettingsJsonFileName);
 
             // Parse existing appsettings.json properties, if any
             var existingJson = "{}";

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/WebNamespaceConfigUpdater.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/WebNamespaceConfigUpdater.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters
                     viewImportsContents.Insert(0, $"{RazorUsingPrefix}{ns}");
                 }
 
-                var path = _viewImportsPath ?? Path.Combine(project.FileInfo.DirectoryName, ViewImportsRelativePath);
+                var path = _viewImportsPath ?? Path.Combine(project.FileInfo.DirectoryName ?? string.Empty, ViewImportsRelativePath);
                 File.WriteAllLines(path, viewImportsContents);
                 _logger.LogInformation("View imports written to {ViewImportsPath}", path);
 

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/WebNamespaceConfigUpdater.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/WebNamespaceConfigUpdater.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters
                     viewImportsContents.Insert(0, $"{RazorUsingPrefix}{ns}");
                 }
 
-                var path = _viewImportsPath ?? Path.Combine(project.Directory ?? string.Empty, ViewImportsRelativePath);
+                var path = _viewImportsPath ?? Path.Combine(project.FileInfo.DirectoryName, ViewImportsRelativePath);
                 File.WriteAllLines(path, viewImportsContents);
                 _logger.LogInformation("View imports written to {ViewImportsPath}", path);
 

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Backup/BackupStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Backup/BackupStep.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Backup
                 throw new ArgumentNullException(nameof(context));
             }
 
-            _projectDir = context.CurrentProject.Required().Directory;
+            _projectDir = context.CurrentProject.Required().FileInfo.DirectoryName;
             _backupPath ??= GetDefaultBackupPath(_projectDir);
 
             if (_skipBackup)

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration/ConfigUpdaterStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration/ConfigUpdaterStep.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration
         protected override bool IsApplicableImpl(IUpgradeContext context) =>
             context?.CurrentProject is not null &&
             SubSteps.Any() &&
-            _configFilePaths.Select(p => Path.Combine(context.CurrentProject.Directory, p)).Any(f => File.Exists(f));
+            _configFilePaths.Select(p => Path.Combine(context.CurrentProject.FileInfo.DirectoryName, p)).Any(f => File.Exists(f));
 
         protected override async Task<UpgradeStepInitializeResult> InitializeImplAsync(IUpgradeContext context, CancellationToken token)
         {
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration
 
             var project = context.CurrentProject.Required();
 
-            var configPaths = _configFilePaths.Select(p => Path.Combine(project.Directory ?? string.Empty, p)).Where(p => File.Exists(p));
+            var configPaths = _configFilePaths.Select(p => Path.Combine(project.FileInfo.DirectoryName, p)).Where(p => File.Exists(p));
             Logger.LogDebug("Loading config files: {ConfigFiles}", string.Join(", ", configPaths));
             ConfigFiles = ImmutableArray.CreateRange(configPaths.Select(p => new ConfigFile(p)));
             Logger.LogDebug("Loaded {ConfigCount} config files", ConfigFiles.Length);

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageUpdaterStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageUpdaterStep.cs
@@ -95,8 +95,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
             catch (Exception exc)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                Logger.LogCritical(exc, "Unexpected exception analyzing package references for: {ProjectPath}", context.CurrentProject.Required().FilePath);
-                return new UpgradeStepInitializeResult(UpgradeStepStatus.Failed, $"Unexpected exception analyzing package references for: {context.CurrentProject.Required().FilePath}", BuildBreakRisk.Unknown);
+                Logger.LogCritical(exc, "Unexpected exception analyzing package references for: {ProjectPath}", context.CurrentProject.Required().FileInfo);
+                return new UpgradeStepInitializeResult(UpgradeStepStatus.Failed, $"Unexpected exception analyzing package references for: {context.CurrentProject.Required().FileInfo}", BuildBreakRisk.Unknown);
             }
 
             if (_analysisState is null || !_analysisState.ChangesRecommended)
@@ -183,8 +183,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
             catch (Exception exc)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                Logger.LogCritical(exc, "Unexpected exception analyzing package references for: {ProjectPath}", context.CurrentProject.Required().FilePath);
-                return new UpgradeStepApplyResult(UpgradeStepStatus.Failed, $"Unexpected exception analyzing package references for: {context.CurrentProject.Required().FilePath}");
+                Logger.LogCritical(exc, "Unexpected exception analyzing package references for: {ProjectPath}", context.CurrentProject.Required().FileInfo);
+                return new UpgradeStepApplyResult(UpgradeStepStatus.Failed, $"Unexpected exception analyzing package references for: {context.CurrentProject.Required().FileInfo}");
             }
         }
 

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertTool.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertTool.cs
@@ -96,6 +96,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
             return null;
         }
 
-        private static string GetArguments(IProject project) => string.Format(CultureInfo.InvariantCulture, TryConvertArgumentsFormat, project.Required().FilePath);
+        private static string GetArguments(IProject project) => string.Format(CultureInfo.InvariantCulture, TryConvertArgumentsFormat, project.Required().FileInfo);
     }
 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             var completeChecks = _orderedProjects.Select(async p => IsCompleted(context, p) || !await RunChecksAsync(p, token).ConfigureAwait(false));
             if ((await Task.WhenAll(completeChecks).ConfigureAwait(false)).All(b => b))
             {
-                Logger.LogInformation("No projects need upgraded for entry point {EntryPoint}", context.EntryPoint.FilePath);
+                Logger.LogInformation("No projects need upgraded for entry point {EntryPoint}", context.EntryPoint.FileInfo);
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "No projects need upgraded", BuildBreakRisk.None);
             }
 
@@ -90,13 +90,13 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             {
                 // If there is only one project, it is the current project
                 newCurrentProject = _orderedProjects[0];
-                Logger.LogDebug("Setting only project in solution as the current project: {Project}", newCurrentProject.FilePath);
+                Logger.LogDebug("Setting only project in solution as the current project: {Project}", newCurrentProject.FileInfo);
             }
             else if (!context.InputIsSolution)
             {
                 // If the user has specified a particular project, only that should be the current project
-                newCurrentProject = _orderedProjects.Where(i => Path.GetFileName(i.FilePath).Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase)).First();
-                Logger.LogDebug("Setting user-selected project as the current project: {Project}", newCurrentProject.FilePath);
+                newCurrentProject = _orderedProjects.Where(i => i.FileInfo.Name.Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase)).First();
+                Logger.LogDebug("Setting user-selected project as the current project: {Project}", newCurrentProject.FileInfo);
             }
 
             // If no current project has been found, then this step is incomplete
@@ -108,11 +108,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             {
                 if (IsCompleted(context, newCurrentProject))
                 {
-                    Logger.LogDebug("Project {Project} does not need upgraded", newCurrentProject.FilePath);
+                    Logger.LogDebug("Project {Project} does not need upgraded", newCurrentProject.FileInfo);
                 }
                 else if (!(await RunChecksAsync(newCurrentProject, token).ConfigureAwait(false)))
                 {
-                    Logger.LogError("Unable to upgrade project {Project}", newCurrentProject.FilePath);
+                    Logger.LogError("Unable to upgrade project {Project}", newCurrentProject.FileInfo);
                 }
                 else
                 {

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/EntrypointSelectionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/EntrypointSelectionStep.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
                 var project = projects[0];
                 context.SetEntryPoint(project);
 
-                Logger.LogInformation("Setting entrypoint to only project in solution: {Project}", project.FilePath);
+                Logger.LogInformation("Setting entrypoint to only project in solution: {Project}", project.FileInfo);
 
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "Selected only project.", BuildBreakRisk.None);
             }
@@ -89,17 +89,17 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             // other dependencies were loaded along with it.
             if (!context.InputIsSolution)
             {
-                var project = projects.First(i => Path.GetFileName(i.FilePath).Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase));
+                var project = projects.First(i => i.FileInfo.Name.Equals(Path.GetFileName(context.InputPath), StringComparison.OrdinalIgnoreCase));
                 context.SetEntryPoint(project);
 
-                Logger.LogInformation("Setting entrypoint to user selected project: {Project}", project.FilePath);
+                Logger.LogInformation("Setting entrypoint to user selected project: {Project}", project.FileInfo);
 
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "Selected user's choice of entry point project.", BuildBreakRisk.None);
             }
 
             if (!string.IsNullOrEmpty(_entryPoint))
             {
-                var entryPointProject = projects.FirstOrDefault(i => Path.GetFileName(i.FilePath).Equals(_entryPoint, StringComparison.OrdinalIgnoreCase));
+                var entryPointProject = projects.FirstOrDefault(i => i.FileInfo.Name.Equals(_entryPoint, StringComparison.OrdinalIgnoreCase));
                 if (entryPointProject is not null)
                 {
                     context.SetEntryPoint(entryPointProject);

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/FinalizeSolutionStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/FinalizeSolutionStep.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             }
             else
             {
-                return Task.FromResult(new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"Finalize upgrade of entry point {context.EntryPoint.FilePath}", BuildBreakRisk.None));
+                return Task.FromResult(new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"Finalize upgrade of entry point {context.EntryPoint.FileInfo}", BuildBreakRisk.None));
             }
         }
 

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Source/SourceUpdaterStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Source/SourceUpdaterStep.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Source
 
             Project = context.CurrentProject.Required();
 
-            var projectPath = Project.FilePath;
+            var projectPath = Project.FileInfo;
 
             Logger.LogDebug("Opening project {ProjectPath}", projectPath);
 

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/TemplateInserterStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Templates/TemplateInserterStep.cs
@@ -106,8 +106,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Templates
             catch (Exception exc)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                Logger.LogCritical(exc, "Unexpected exception initializing template inserter step for: {ProjectPath}", project.FilePath);
-                return new UpgradeStepInitializeResult(UpgradeStepStatus.Failed, $"Unexpected exception initializing template inserter step for: {project.FilePath}", BuildBreakRisk.Unknown);
+                Logger.LogCritical(exc, "Unexpected exception initializing template inserter step for: {ProjectPath}", project.FileInfo);
+                return new UpgradeStepInitializeResult(UpgradeStepStatus.Failed, $"Unexpected exception initializing template inserter step for: {project.FileInfo}", BuildBreakRisk.Unknown);
             }
         }
 
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Templates
             // For each item to be added, make necessary replacements and then add the item to the project
             foreach (var item in _itemsToAdd.Values)
             {
-                var filePath = Path.Combine(project.Directory, item.Path);
+                var filePath = Path.Combine(project.FileInfo.DirectoryName, item.Path);
 
                 // If the file already exists, move it
                 if (File.Exists(filePath))

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests/ConfigUpdaterStepTests.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests/ConfigUpdaterStepTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests
 
             // Assert
             Assert.Equal(expectedConfigPaths.Select(f => XDocument.Load(f, LoadOptions.SetLineInfo).ToString()).ToArray(), step.ConfigFiles.Select(c => c.Contents.ToString()).ToArray());
-            Assert.Equal(expectedConfigPaths.Select(f => Path.Combine(".", f)).ToArray(), step.ConfigFiles.Select(c => c.Path).ToArray());
+            Assert.Equal(expectedConfigPaths.Select(f => new FileInfo(f).FullName).ToArray(), step.ConfigFiles.Select(c => c.Path).ToArray());
             if (incompleteConfigUpdaterCount > 0)
             {
                 Assert.Equal(UpgradeStepStatus.Incomplete, step.Status);

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests/ConfigUpdaterStepTests.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests/ConfigUpdaterStepTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests
                 RegisterConfigUpdaters(cfg, completeConfigUpdaterCount, incompleteConfigUpdaterCount);
             });
             var project = mock.Mock<IProject>();
-            project.Setup(p => p.Directory).Returns(".");
+            project.Setup(p => p.FileInfo).Returns(new FileInfo("./test"));
             var context = mock.Mock<IUpgradeContext>();
             context.Setup(c => c.CurrentProject).Returns(projectLoaded ? project.Object : null);
             var step = mock.Create<ConfigUpdaterStep>();

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests/ConfigUpdaterSubStepTests.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests/ConfigUpdaterSubStepTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -219,7 +220,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests
             });
 
             var project = mock.Mock<IProject>();
-            project.Setup(p => p.Directory).Returns(".");
+            project.Setup(p => p.FileInfo).Returns(new FileInfo("./test"));
             if (projectComponents.HasValue)
             {
                 project.Setup(p => p.Components).Returns(projectComponents.Value);


### PR DESCRIPTION
We don't need separate properties for these. This change replaces these two properties with a single `IProject.FileInfo` property.