### PR TITLE
using float range and tryParse

### DIFF
--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/NuGetReference.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/NuGetReference.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
 {
     public record NuGetReference(string Name, string Version)
     {
-        public bool HasWildcardVersion => Version.Contains("*");
+        public bool HasWildcardVersion => Version.EndsWith("*", StringComparison.OrdinalIgnoreCase);
 
         public override string ToString()
         {

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/NuGetReference.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/NuGetReference.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
 {
     public record NuGetReference(string Name, string Version)
     {
-        public bool HasWildcardVersion => Version.Equals("*", StringComparison.OrdinalIgnoreCase);
+        public bool HasWildcardVersion => Version.Contains("*");
 
         public override string ToString()
         {

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/NuGetExtensions.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/NuGetExtensions.cs
@@ -11,8 +11,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
         {
             if (nugetRef.HasWildcardVersion)
             {
+                // https://docs.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions
+                // reference versions can be any of the following (*, 4.*, 6.0.*)
                 if (FloatRange.TryParse(nugetRef.Version, out var range))
                 {
+                    // when a range is used
                     if (range.HasMinVersion)
                     {
                         return range.MinVersion;

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/NuGetExtensions.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/NuGetExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using NuGet.Versioning;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
@@ -9,6 +10,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
     {
         public static NuGetVersion? GetNuGetVersion(this NuGetReference nugetRef)
         {
+            if (nugetRef == null)
+            {
+                throw new ArgumentNullException(nameof(nugetRef));
+            }
+
             if (nugetRef.HasWildcardVersion)
             {
                 // https://docs.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/NuGetExtensions.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/NuGetExtensions.cs
@@ -11,10 +11,23 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
         {
             if (nugetRef.HasWildcardVersion)
             {
+                if (FloatRange.TryParse(nugetRef.Version, out var range))
+                {
+                    if (range.HasMinVersion)
+                    {
+                        return range.MinVersion;
+                    }
+                }
+
                 return null;
             }
 
-            return NuGetVersion.Parse(nugetRef.Version);
+            if (NuGetVersion.TryParse(nugetRef.Version, out var version))
+            {
+                return version;
+            }
+
+            return null;
         }
     }
 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/NuGetExtensions.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/NuGetExtensions.cs
@@ -5,7 +5,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
 {
-    internal static class NuGetExtensions
+    public static class NuGetExtensions
     {
         public static NuGetVersion? GetNuGetVersion(this NuGetReference nugetRef)
         {

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests.csproj
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
@@ -16,6 +16,7 @@
     <PackageReference Include="AutoFixture" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="NuGet.Versioning" />
     <ProjectReference Include="..\..\..\src\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Packages\Microsoft.DotNet.UpgradeAssistant.Steps.Packages.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/NuGetExtensionsTests.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/NuGetExtensionsTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Xunit;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests
+{
+    public class NuGetExtensionsTests
+    {
+        [InlineData("6.0.*")]
+        [InlineData("4.*")]
+        [InlineData("*")]
+        [Theory]
+        public void GetNuGetVersionCanHandleFloatingVersions(string version)
+        {
+            if (version == null)
+            {
+                throw new ArgumentNullException(nameof(version));
+            }
+
+            var indexOfWildCard = version.IndexOf("*", StringComparison.Ordinal);
+            var expectedVersion = version.Substring(0, indexOfWildCard) + "0";
+            if (version.Equals("*", StringComparison.Ordinal))
+            {
+                expectedVersion = "0.0";
+            }
+
+            var reference = new NuGetReference("Example", version);
+
+            var actualVersion = reference.GetNuGetVersion();
+
+            Assert.Equal(expectedVersion, actualVersion?.ToString());
+        }
+    }
+}

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/NuGetExtensionsTests.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/NuGetExtensionsTests.cs
@@ -13,25 +13,23 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests
             Assert.Throws<ArgumentNullException>(() => reference!.GetNuGetVersion());
         }
 
-        [InlineData("6.0.*")]
-        [InlineData("4.*")]
-        [InlineData("*")]
+        [InlineData("6.0.*", "6.0.0")]
+        [InlineData("4.*", "4.0")]
+        [InlineData("*", "0.0")]
         [Theory]
-        public void GetNuGetVersionCanHandleFloatingVersions(string version)
+        public void GetNuGetVersionCanHandleFloatingVersions(string versionToTest, string expectedVersion)
         {
-            if (version == null)
+            if (versionToTest == null)
             {
-                throw new ArgumentNullException(nameof(version));
+                throw new ArgumentNullException(nameof(versionToTest));
             }
 
-            var indexOfWildCard = version.IndexOf("*", StringComparison.Ordinal);
-            var expectedVersion = version.Substring(0, indexOfWildCard) + "0";
-            if (version.Equals("*", StringComparison.Ordinal))
+            if (expectedVersion == null)
             {
-                expectedVersion = "0.0";
+                throw new ArgumentNullException(nameof(expectedVersion));
             }
 
-            var reference = new NuGetReference("Example", version);
+            var reference = new NuGetReference("Example", versionToTest);
 
             var actualVersion = reference.GetNuGetVersion();
 

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/NuGetExtensionsTests.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/NuGetExtensionsTests.cs
@@ -5,6 +5,15 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests
 {
     public class NuGetExtensionsTests
     {
+
+        [Fact]
+        public void GetNuGetVersionThrowsWhenNull()
+        {
+            NuGetReference reference = default;
+
+            Assert.Throws<ArgumentNullException>(() => reference!.GetNuGetVersion());
+        }
+
         [InlineData("6.0.*")]
         [InlineData("4.*")]
         [InlineData("*")]

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/NuGetExtensionsTests.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/NuGetExtensionsTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests
         [Fact]
         public void GetNuGetVersionThrowsWhenNull()
         {
-            NuGetReference reference = default;
+            NuGetReference? reference = default;
 
             Assert.Throws<ArgumentNullException>(() => reference!.GetNuGetVersion());
         }

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/NuGetExtensionsTests.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/NuGetExtensionsTests.cs
@@ -5,7 +5,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests
 {
     public class NuGetExtensionsTests
     {
-
         [Fact]
         public void GetNuGetVersionThrowsWhenNull()
         {


### PR DESCRIPTION
Addresses a bug with upgrade assistant being unable to operate on a C# Unit Test project. The version string, by default, is 16.* for the "Microsoft.NET.Test.Sdk" package.