### PR TITLE
Change queue to unblock PR and CI builds

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -38,7 +38,7 @@ stages:
         pool:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCorePublic-Pool
-            queue: buildpool.windows.10.amd64.vs2019.open
+            queue: buildpool.windows.10.amd64.vs2019.pre.open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCoreInternal-Pool
             queue: buildpool.windows.10.amd64.vs2019


### PR DESCRIPTION
As per suggestion from the eng services team, moving to a preview queue if possible could relieve the original vs2019 queue. This should also help us unblock our PR and CI builds.