### PR TITLE
Bug fix: When upgrading VB Web App the config step does not complete

### DIFF
--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/AppSettingsConfigUpdater.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/AppSettingsConfigUpdater.cs
@@ -154,7 +154,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters
             // Check for existing appSettings.json files for app settings
             foreach (var setting in appSettings)
             {
-                if (!jsonConfigFiles.Any(s => !string.IsNullOrEmpty(s.Configuration[setting.Key])))
+                if (!jsonConfigFiles.Any(s => !string.IsNullOrEmpty(s.Configuration[setting.Key]))
+                    && !_appSettings.ContainsKey(setting.Key))
                 {
                     _appSettings.Add(setting.Key, setting.Value);
                 }

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/AppSettingsConfigUpdater.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/AppSettingsConfigUpdater.cs
@@ -154,10 +154,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters
             // Check for existing appSettings.json files for app settings
             foreach (var setting in appSettings)
             {
-                if (!jsonConfigFiles.Any(s => !string.IsNullOrEmpty(s.Configuration[setting.Key]))
-                    && !_appSettings.ContainsKey(setting.Key))
+                if (!jsonConfigFiles.Any(s => !string.IsNullOrEmpty(s.Configuration[setting.Key])))
                 {
-                    _appSettings.Add(setting.Key, setting.Value);
+                    if (!_appSettings.ContainsKey(setting.Key))
+                    {
+                        _appSettings.Add(setting.Key, setting.Value);
+                    }
                 }
                 else
                 {

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/AppSettingsConfigUpdater.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters/AppSettingsConfigUpdater.cs
@@ -156,10 +156,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default.ConfigUpdaters
             {
                 if (!jsonConfigFiles.Any(s => !string.IsNullOrEmpty(s.Configuration[setting.Key])))
                 {
-                    if (!_appSettings.ContainsKey(setting.Key))
-                    {
-                        _appSettings.Add(setting.Key, setting.Value);
-                    }
+                    _appSettings[setting.Key] = setting.Value;
                 }
                 else
                 {

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration/ConfigUpdaterStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration/ConfigUpdaterStep.cs
@@ -14,6 +14,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration
 {
     public class ConfigUpdaterStep : UpgradeStep
     {
+        private readonly IEnumerable<ConfigUpdaterSubStep> _allSteps;
+
         private readonly string[] _configFilePaths;
 
         public ImmutableArray<ConfigFile> ConfigFiles { get; private set; }
@@ -52,7 +54,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration
             }
 
             _configFilePaths = (configUpdaterOptions.ConfigFilePaths ?? Enumerable.Empty<string>()).ToArray();
-            SubSteps = configUpdaters.Select(u => new ConfigUpdaterSubStep(this, u, logger)).ToList();
+            SubSteps = _allSteps = configUpdaters.Select(u => new ConfigUpdaterSubStep(this, u, logger)).ToList();
         }
 
         protected override Task<bool> IsApplicableImplAsync(IUpgradeContext context, CancellationToken token)
@@ -78,6 +80,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration
             ConfigFiles = ImmutableArray.CreateRange(configPaths.Select(p => new ConfigFile(p)));
             Logger.LogDebug("Loaded {ConfigCount} config files", ConfigFiles.Length);
 
+            await FilterSubStepsByIsApplicableAsync(context, token).ConfigureAwait(false);
+
             foreach (var step in SubSteps)
             {
                 await step.InitializeAsync(context, token).ConfigureAwait(false);
@@ -88,6 +92,26 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration
             return incompleteSubSteps == 0
                 ? new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "No config updaters need applied", BuildBreakRisk.None)
                 : new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"{incompleteSubSteps} config updaters need applied", SubSteps.Where(s => !s.IsDone).Max(s => s.Risk));
+        }
+
+        private async Task FilterSubStepsByIsApplicableAsync(IUpgradeContext context, CancellationToken token)
+        {
+            var applicableSubSteps = new List<ConfigUpdaterSubStep>();
+            foreach (var substep in _allSteps)
+            {
+                if (await substep.IsApplicableAsync(context, token).ConfigureAwait(false))
+                {
+                    applicableSubSteps.Add(substep);
+                }
+            }
+
+            SubSteps = applicableSubSteps;
+        }
+
+        public override UpgradeStepInitializeResult Reset()
+        {
+            SubSteps = _allSteps;
+            return base.Reset();
         }
 
         protected override Task<UpgradeStepApplyResult> ApplyImplAsync(IUpgradeContext context, CancellationToken token)

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration/ConfigUpdaterSubStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration/ConfigUpdaterSubStep.cs
@@ -90,8 +90,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration
 
             try
             {
-                return await IsApplicableAsync(context, token).ConfigureAwait(false)
-                    && await _configUpdater.IsApplicableAsync(context, _parentStep.ConfigFiles, token).ConfigureAwait(false)
+                return await _configUpdater.IsApplicableAsync(context, _parentStep.ConfigFiles, token).ConfigureAwait(false)
                     ? new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"Config updater \"{_configUpdater.Title}\" needs applied", _configUpdater.Risk)
                     : new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, string.Empty, BuildBreakRisk.None);
             }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration/ConfigUpdaterSubStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration/ConfigUpdaterSubStep.cs
@@ -90,7 +90,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Configuration
 
             try
             {
-                return await _configUpdater.IsApplicableAsync(context, _parentStep.ConfigFiles, token).ConfigureAwait(false)
+                return await IsApplicableAsync(context, token).ConfigureAwait(false)
+                    && await _configUpdater.IsApplicableAsync(context, _parentStep.ConfigFiles, token).ConfigureAwait(false)
                     ? new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"Config updater \"{_configUpdater.Title}\" needs applied", _configUpdater.Risk)
                     : new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, string.Empty, BuildBreakRisk.None);
             }


### PR DESCRIPTION
* The *ConfigUpdaterSubstep* should check IsApplicable (which calls `AppliesToProjectAsync`)
* The *AppSettingsConfigUpdater* should check to see if adding a key to the dictionary will cause an exception. This could happen if `IsApplicableAsync` us called more than once.