### PR TITLE
Expand TargetFrameworkMoniker record to include parts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="coverlet.collector" Version="3.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Razor.Language" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Build" Version="16.8.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="16.8.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.4.1" />

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/DeconstructExtensions.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/DeconstructExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.DotNet.UpgradeAssistant
@@ -11,6 +12,14 @@ namespace Microsoft.DotNet.UpgradeAssistant
         {
             key = kvp.Key;
             value = kvp.Value;
+        }
+
+        public static void Deconstruct(this Version version, out int major, out int minor, out int build, out int revision)
+        {
+            major = version.Major;
+            minor = version.Minor;
+            build = version.Build;
+            revision = version.Revision;
         }
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/ITargetFrameworkMonikerComparer.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/ITargetFrameworkMonikerComparer.cs
@@ -25,5 +25,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
         /// <param name="result">A merged TFM. For example, passing <c>net5.0-windows</c> and <c>net6.0</c> will result in <c>net6.0-windows</c>.</param>
         /// <returns>Whether the merge was successful.</returns>
         bool TryMerge(TargetFrameworkMoniker tfm1, TargetFrameworkMoniker tfm2, [MaybeNullWhen(false)] out TargetFrameworkMoniker result);
+
+        bool TryParse(string input, [MaybeNullWhen(false)] out TargetFrameworkMoniker tfm);
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Microsoft.DotNet.UpgradeAssistant.Abstractions.csproj
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Microsoft.DotNet.UpgradeAssistant.Abstractions.csproj
@@ -17,6 +17,7 @@
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.HashCode" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TargetFrameworkMoniker.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TargetFrameworkMoniker.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Microsoft.DotNet.UpgradeAssistant
 {
-    public record TargetFrameworkMoniker(string Framework, Version FrameworkVersion) : IEquatable<TargetFrameworkMoniker>
+    public record TargetFrameworkMoniker
     {
         private const string NetStandard = "netstandard";
         private const string NetFramework = "netframework";
@@ -14,13 +14,13 @@ namespace Microsoft.DotNet.UpgradeAssistant
         private const string NetCoreApp = "netcoreapp";
 
 #pragma warning disable CA1707 // Identifiers should not contain underscores
-        public static readonly TargetFrameworkMoniker NetStandard10 = new TargetFrameworkMoniker(NetStandard, new Version(1, 0)).Normalize();
+        public static readonly TargetFrameworkMoniker NetStandard10 = new(NetStandard, new Version(1, 0));
         public static readonly TargetFrameworkMoniker NetStandard20 = NetStandard10 with { FrameworkVersion = new Version(2, 0) };
         public static readonly TargetFrameworkMoniker NetStandard21 = NetStandard20 with { FrameworkVersion = new Version(2, 1) };
         public static readonly TargetFrameworkMoniker NetCoreApp21 = new(NetCoreApp, new Version(2, 1));
         public static readonly TargetFrameworkMoniker NetCoreApp30 = NetCoreApp21 with { FrameworkVersion = new Version(3, 0) };
         public static readonly TargetFrameworkMoniker NetCoreApp31 = NetCoreApp30 with { FrameworkVersion = new Version(3, 1) };
-        public static readonly TargetFrameworkMoniker Net45 = new TargetFrameworkMoniker(Net, new Version(4, 5)).Normalize();
+        public static readonly TargetFrameworkMoniker Net45 = new(Net, new Version(4, 5));
         public static readonly TargetFrameworkMoniker Net46 = Net45 with { FrameworkVersion = new Version(4, 6) };
         public static readonly TargetFrameworkMoniker Net461 = Net45 with { FrameworkVersion = new Version(4, 6, 1) };
         public static readonly TargetFrameworkMoniker Net462 = Net45 with { FrameworkVersion = new Version(4, 6, 2) };
@@ -41,130 +41,20 @@ namespace Microsoft.DotNet.UpgradeAssistant
         }
 #pragma warning restore CA1034 // Nested types should not be visible
 
-        public string? Platform { get; init; }
+        private string? _platform;
+        private Version? _platformVersion;
+        private string _framework;
+        private Version _frameworkVersion;
 
-        public Version? PlatformVersion { get; init; }
-
-        public string Name => ToString();
-
-        public virtual bool Equals(TargetFrameworkMoniker? other)
+        public TargetFrameworkMoniker(string framework, Version frameworkVersion)
         {
-            if (other is null)
-            {
-                return false;
-            }
-
-            var @this = Normalize();
-            var tfm = other.Normalize();
-
-            return string.Equals(@this.Framework, tfm.Framework, StringComparison.OrdinalIgnoreCase)
-                && Equals(@this.FrameworkVersion, tfm.FrameworkVersion)
-                && string.Equals(@this.Platform, tfm.Platform, StringComparison.OrdinalIgnoreCase)
-                && Equals(@this.PlatformVersion, tfm.PlatformVersion);
+            _framework = framework;
+            _frameworkVersion = frameworkVersion;
         }
 
-        public override int GetHashCode()
-        {
-            var normalized = Normalize();
-            var hashcode = default(HashCode);
-
-            hashcode.Add(normalized.Framework, StringComparer.OrdinalIgnoreCase);
-            hashcode.Add(normalized.FrameworkVersion);
-            hashcode.Add(normalized.Platform, StringComparer.OrdinalIgnoreCase);
-            hashcode.Add(normalized.PlatformVersion);
-
-            return hashcode.ToHashCode();
-        }
-
-        public override string ToString()
-        {
-            var normalized = Normalize();
-            var sb = new StringBuilder();
-
-            sb.Append(normalized.Framework);
-            sb.Append(normalized.FrameworkVersion);
-
-            if (IsFramework)
-            {
-                sb.Replace(".", string.Empty);
-            }
-            else if (IsNet50OrAbove && normalized.Platform is not null)
-            {
-                sb.Append('-');
-                sb.Append(normalized.Platform);
-
-                if (PlatformVersion is not null)
-                {
-                    sb.Append(normalized.PlatformVersion);
-                }
-            }
-
-            return sb.ToString();
-        }
-
-        public bool IsFramework
+        public string Framework
         {
             get
-            {
-                if (Framework.Equals(Net, StringComparison.OrdinalIgnoreCase) && !Is50OrAbove)
-                {
-                    return true;
-                }
-
-                return Framework.ToUpperInvariant().Contains(NetFramework.ToUpperInvariant());
-            }
-        }
-
-        public bool IsNetStandard => Framework.ToUpperInvariant().Contains(NetStandard.ToUpperInvariant());
-
-        private bool IsNet50OrAbove => (IsNetCoreApp || Framework.Equals(Net, StringComparison.OrdinalIgnoreCase)) && Is50OrAbove;
-
-        private bool Is50OrAbove => FrameworkVersion.Major >= 5;
-
-        private bool IsNetCoreApp => Framework.ToUpperInvariant().Contains(NetCoreApp.ToUpperInvariant());
-
-        public bool IsNetCore => IsNetCoreApp || IsNet50OrAbove;
-
-        public bool IsWindows => Platform?.Equals(Platforms.Windows, StringComparison.OrdinalIgnoreCase) ?? false;
-
-        private bool IsNormalized { get; init; }
-
-        /// <summary>
-        /// Normalizes the names and versions used to ensure that comparisons will be accurate.
-        /// </summary>
-        /// <returns>A normalized instance. If the current instance is already normalized, it will be returned without any changes.</returns>
-        public TargetFrameworkMoniker Normalize()
-        {
-            if (IsNormalized)
-            {
-                return this;
-            }
-
-            return this with
-            {
-                Framework = GetNormalizedFramework(),
-                FrameworkVersion = NormalizeVersion(FrameworkVersion) ?? FrameworkVersion,
-                Platform = GetNormalizedPlatform(),
-                PlatformVersion = NormalizeVersion(PlatformVersion),
-                IsNormalized = true,
-            };
-
-            string? GetNormalizedPlatform()
-            {
-                if (IsWindows)
-                {
-                    return Platforms.Windows;
-                }
-
-                if (string.IsNullOrEmpty(Platform))
-                {
-                    return null;
-                }
-
-                return Platform;
-            }
-
-            string GetNormalizedFramework()
             {
                 if (IsFramework || IsNet50OrAbove)
                 {
@@ -184,14 +74,125 @@ namespace Microsoft.DotNet.UpgradeAssistant
                 }
             }
 
-            static Version? NormalizeVersion(Version? v) => v switch
-            {
-                null => null,
-                (0, 0, 0, 0) => null,
-                _ when v.Build > 0 && v.Revision > 0 => v,
-                _ when v.Build > 0 => new Version(v.Major, v.Minor, v.Build),
-                _ => new Version(v.Major, v.Minor),
-            };
+            init => _framework = value;
         }
+
+        public Version FrameworkVersion
+        {
+            get => NormalizeVersion(_frameworkVersion) ?? _frameworkVersion;
+            init => _frameworkVersion = value;
+        }
+
+        public string? Platform
+        {
+            get
+            {
+                if (IsWindows)
+                {
+                    return Platforms.Windows;
+                }
+
+                if (string.IsNullOrEmpty(_platform))
+                {
+                    return null;
+                }
+
+                return _platform;
+            }
+
+            init => _platform = value;
+        }
+
+        public Version? PlatformVersion
+        {
+            get => NormalizeVersion(_platformVersion);
+            init => _platformVersion = value;
+        }
+
+        public string Name => ToString();
+
+        public virtual bool Equals(TargetFrameworkMoniker? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return string.Equals(Framework, other.Framework, StringComparison.OrdinalIgnoreCase)
+                && Equals(FrameworkVersion, other.FrameworkVersion)
+                && string.Equals(Platform, other.Platform, StringComparison.OrdinalIgnoreCase)
+                && Equals(PlatformVersion, other.PlatformVersion);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashcode = default(HashCode);
+
+            hashcode.Add(Framework, StringComparer.OrdinalIgnoreCase);
+            hashcode.Add(FrameworkVersion);
+            hashcode.Add(Platform, StringComparer.OrdinalIgnoreCase);
+            hashcode.Add(PlatformVersion);
+
+            return hashcode.ToHashCode();
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            sb.Append(Framework);
+            sb.Append(FrameworkVersion);
+
+            if (IsFramework)
+            {
+                sb.Replace(".", string.Empty);
+            }
+            else if (IsNet50OrAbove && Platform is string platform)
+            {
+                sb.Append('-');
+                sb.Append(platform);
+
+                if (PlatformVersion is Version platformVersion)
+                {
+                    sb.Append(platformVersion);
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        public bool IsFramework
+        {
+            get
+            {
+                if (_framework.Equals(Net, StringComparison.OrdinalIgnoreCase) && !Is50OrAbove)
+                {
+                    return true;
+                }
+
+                return _framework.ToUpperInvariant().Contains(NetFramework.ToUpperInvariant());
+            }
+        }
+
+        public bool IsNetStandard => _framework.ToUpperInvariant().Contains(NetStandard.ToUpperInvariant());
+
+        private bool IsNet50OrAbove => (IsNetCoreApp || _framework.Equals(Net, StringComparison.OrdinalIgnoreCase)) && Is50OrAbove;
+
+        private bool Is50OrAbove => _frameworkVersion.Major >= 5;
+
+        private bool IsNetCoreApp => _framework.ToUpperInvariant().Contains(NetCoreApp.ToUpperInvariant());
+
+        public bool IsNetCore => IsNetCoreApp || IsNet50OrAbove;
+
+        public bool IsWindows => _platform?.Equals(Platforms.Windows, StringComparison.OrdinalIgnoreCase) ?? false;
+
+        private static Version? NormalizeVersion(Version? v) => v switch
+        {
+            null => null,
+            (0, 0, 0, 0) => null,
+            _ when v.Build > 0 && v.Revision > 0 => v,
+            _ when v.Build > 0 => new Version(v.Major, v.Minor, v.Build),
+            _ => new Version(v.Major, v.Minor),
+        };
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TargetFrameworkMoniker.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TargetFrameworkMoniker.cs
@@ -30,7 +30,9 @@ namespace Microsoft.DotNet.UpgradeAssistant
         public static readonly TargetFrameworkMoniker Net48 = Net45 with { FrameworkVersion = new Version(4, 8) };
         public static readonly TargetFrameworkMoniker Net50 = NetCoreApp30 with { Framework = Net, FrameworkVersion = new Version(5, 0) };
         public static readonly TargetFrameworkMoniker Net50_Windows = Net50 with { Platform = Platforms.Windows };
+        public static readonly TargetFrameworkMoniker Net50_Linux = Net50 with { Platform = Platforms.Linux };
         public static readonly TargetFrameworkMoniker Net60 = Net50 with { FrameworkVersion = new Version(6, 0) };
+        public static readonly TargetFrameworkMoniker Net60_Linux = Net60 with { Platform = Platforms.Linux };
         public static readonly TargetFrameworkMoniker Net60_Windows = Net60 with { Platform = Platforms.Windows };
 #pragma warning restore CA1707 // Identifiers should not contain underscores
 
@@ -38,6 +40,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
         public static class Platforms
         {
             public const string Windows = "windows";
+            public const string Linux = "linux";
         }
 #pragma warning restore CA1034 // Nested types should not be visible
 

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TargetFrameworkMoniker.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TargetFrameworkMoniker.cs
@@ -44,10 +44,10 @@ namespace Microsoft.DotNet.UpgradeAssistant
         }
 #pragma warning restore CA1034 // Nested types should not be visible
 
-        private string? _platform;
-        private Version? _platformVersion;
-        private string _framework;
-        private Version _frameworkVersion;
+        private readonly string? _platform;
+        private readonly Version? _platformVersion;
+        private readonly string _framework;
+        private readonly Version _frameworkVersion;
 
         public TargetFrameworkMoniker(string framework, Version frameworkVersion)
         {

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TargetFrameworkMoniker.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TargetFrameworkMoniker.cs
@@ -2,25 +2,196 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Text;
 
 namespace Microsoft.DotNet.UpgradeAssistant
 {
-    public record TargetFrameworkMoniker(string Name)
+    public record TargetFrameworkMoniker(string Framework, Version FrameworkVersion) : IEquatable<TargetFrameworkMoniker>
     {
-        public static TargetFrameworkMoniker NetStandard20 { get; } = new TargetFrameworkMoniker("netstandard2.0");
+        private const string NetStandard = "netstandard";
+        private const string NetFramework = "netframework";
+        private const string Net = "net";
+        private const string NetCoreApp = "netcoreapp";
 
-        private const string NetStandardNamePrefix = "netstandard";
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+        public static readonly TargetFrameworkMoniker NetStandard10 = new TargetFrameworkMoniker(NetStandard, new Version(1, 0)).Normalize();
+        public static readonly TargetFrameworkMoniker NetStandard20 = NetStandard10 with { FrameworkVersion = new Version(2, 0) };
+        public static readonly TargetFrameworkMoniker NetStandard21 = NetStandard20 with { FrameworkVersion = new Version(2, 1) };
+        public static readonly TargetFrameworkMoniker NetCoreApp21 = new(NetCoreApp, new Version(2, 1));
+        public static readonly TargetFrameworkMoniker NetCoreApp30 = NetCoreApp21 with { FrameworkVersion = new Version(3, 0) };
+        public static readonly TargetFrameworkMoniker NetCoreApp31 = NetCoreApp30 with { FrameworkVersion = new Version(3, 1) };
+        public static readonly TargetFrameworkMoniker Net45 = new TargetFrameworkMoniker(Net, new Version(4, 5)).Normalize();
+        public static readonly TargetFrameworkMoniker Net46 = Net45 with { FrameworkVersion = new Version(4, 6) };
+        public static readonly TargetFrameworkMoniker Net461 = Net45 with { FrameworkVersion = new Version(4, 6, 1) };
+        public static readonly TargetFrameworkMoniker Net462 = Net45 with { FrameworkVersion = new Version(4, 6, 2) };
+        public static readonly TargetFrameworkMoniker Net47 = Net45 with { FrameworkVersion = new Version(4, 7) };
+        public static readonly TargetFrameworkMoniker Net471 = Net45 with { FrameworkVersion = new Version(4, 7, 1) };
+        public static readonly TargetFrameworkMoniker Net472 = Net45 with { FrameworkVersion = new Version(4, 7, 2) };
+        public static readonly TargetFrameworkMoniker Net48 = Net45 with { FrameworkVersion = new Version(4, 8) };
+        public static readonly TargetFrameworkMoniker Net50 = NetCoreApp30 with { Framework = Net, FrameworkVersion = new Version(5, 0) };
+        public static readonly TargetFrameworkMoniker Net50_Windows = Net50 with { Platform = Platforms.Windows };
+        public static readonly TargetFrameworkMoniker Net60 = Net50 with { FrameworkVersion = new Version(6, 0) };
+        public static readonly TargetFrameworkMoniker Net60_Windows = Net60 with { Platform = Platforms.Windows };
+#pragma warning restore CA1707 // Identifiers should not contain underscores
 
-        private const string NetPrefix = "net";
+#pragma warning disable CA1034 // Nested types should not be visible
+        public static class Platforms
+        {
+            public const string Windows = "windows";
+        }
+#pragma warning restore CA1034 // Nested types should not be visible
 
-        public override string ToString() => Name;
+        public string? Platform { get; init; }
 
-        public bool IsFramework => !IsNetStandard && !IsNetCore;
+        public Version? PlatformVersion { get; init; }
 
-        public bool IsNetStandard => Name.StartsWith(NetStandardNamePrefix, StringComparison.OrdinalIgnoreCase);
+        public string Name => ToString();
 
-        public bool IsNetCore => Name.StartsWith(NetPrefix, StringComparison.OrdinalIgnoreCase) && Name.Contains(".");
+        public virtual bool Equals(TargetFrameworkMoniker? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
 
-        public bool IsWindows => Name.Contains("windows");
+            var @this = Normalize();
+            var tfm = other.Normalize();
+
+            return string.Equals(@this.Framework, tfm.Framework, StringComparison.OrdinalIgnoreCase)
+                && Equals(@this.FrameworkVersion, tfm.FrameworkVersion)
+                && string.Equals(@this.Platform, tfm.Platform, StringComparison.OrdinalIgnoreCase)
+                && Equals(@this.PlatformVersion, tfm.PlatformVersion);
+        }
+
+        public override int GetHashCode()
+        {
+            var normalized = Normalize();
+            var hashcode = default(HashCode);
+
+            hashcode.Add(normalized.Framework, StringComparer.OrdinalIgnoreCase);
+            hashcode.Add(normalized.FrameworkVersion);
+            hashcode.Add(normalized.Platform, StringComparer.OrdinalIgnoreCase);
+            hashcode.Add(normalized.PlatformVersion);
+
+            return hashcode.ToHashCode();
+        }
+
+        public override string ToString()
+        {
+            var normalized = Normalize();
+            var sb = new StringBuilder();
+
+            sb.Append(normalized.Framework);
+            sb.Append(normalized.FrameworkVersion);
+
+            if (IsFramework)
+            {
+                sb.Replace(".", string.Empty);
+            }
+            else if (IsNet50OrAbove && normalized.Platform is not null)
+            {
+                sb.Append('-');
+                sb.Append(normalized.Platform);
+
+                if (PlatformVersion is not null)
+                {
+                    sb.Append(normalized.PlatformVersion);
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        public bool IsFramework
+        {
+            get
+            {
+                if (Framework.Equals(Net, StringComparison.OrdinalIgnoreCase) && !Is50OrAbove)
+                {
+                    return true;
+                }
+
+                return Framework.ToUpperInvariant().Contains(NetFramework.ToUpperInvariant());
+            }
+        }
+
+        public bool IsNetStandard => Framework.ToUpperInvariant().Contains(NetStandard.ToUpperInvariant());
+
+        private bool IsNet50OrAbove => (IsNetCoreApp || Framework.Equals(Net, StringComparison.OrdinalIgnoreCase)) && Is50OrAbove;
+
+        private bool Is50OrAbove => FrameworkVersion.Major >= 5;
+
+        private bool IsNetCoreApp => Framework.ToUpperInvariant().Contains(NetCoreApp.ToUpperInvariant());
+
+        public bool IsNetCore => IsNetCoreApp || IsNet50OrAbove;
+
+        public bool IsWindows => Platform?.Equals(Platforms.Windows, StringComparison.OrdinalIgnoreCase) ?? false;
+
+        private bool IsNormalized { get; init; }
+
+        /// <summary>
+        /// Normalizes the names and versions used to ensure that comparisons will be accurate.
+        /// </summary>
+        /// <returns>A normalized instance. If the current instance is already normalized, it will be returned without any changes.</returns>
+        public TargetFrameworkMoniker Normalize()
+        {
+            if (IsNormalized)
+            {
+                return this;
+            }
+
+            return this with
+            {
+                Framework = GetNormalizedFramework(),
+                FrameworkVersion = NormalizeVersion(FrameworkVersion) ?? FrameworkVersion,
+                Platform = GetNormalizedPlatform(),
+                PlatformVersion = NormalizeVersion(PlatformVersion),
+                IsNormalized = true,
+            };
+
+            string? GetNormalizedPlatform()
+            {
+                if (IsWindows)
+                {
+                    return Platforms.Windows;
+                }
+
+                if (string.IsNullOrEmpty(Platform))
+                {
+                    return null;
+                }
+
+                return Platform;
+            }
+
+            string GetNormalizedFramework()
+            {
+                if (IsFramework || IsNet50OrAbove)
+                {
+                    return Net;
+                }
+                else if (IsNetCoreApp)
+                {
+                    return NetCoreApp;
+                }
+                else if (IsNetStandard)
+                {
+                    return NetStandard;
+                }
+                else
+                {
+                    return Framework;
+                }
+            }
+
+            static Version? NormalizeVersion(Version? v) => v switch
+            {
+                null => null,
+                (0, 0, 0, 0) => null,
+                _ when v.Build > 0 && v.Revision > 0 => v,
+                _ when v.Build > 0 => new Version(v.Major, v.Minor, v.Build),
+                _ => new Version(v.Major, v.Minor),
+            };
+        }
     }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public IEnumerable<string> Imports => ProjectRoot.Imports.Select(p => Path.GetFileName(p.Project));
 
-        public void SetTFM(TargetFrameworkMoniker tfm) => new TargetFrameworkMonikerCollection(this).SetTargetFramework(tfm);
+        public void SetTFM(TargetFrameworkMoniker tfm) => new TargetFrameworkMonikerCollection(this, _comparer).SetTargetFramework(tfm);
 
         public void AddPackages(IEnumerable<NuGetReference> references)
         {

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
         private readonly ILogger _logger;
         private readonly IComponentIdentifier _componentIdentifier;
         private readonly IPackageRestorer _restorer;
+        private readonly ITargetFrameworkMonikerComparer _comparer;
 
         public MSBuildWorkspaceUpgradeContext Context { get; }
 
@@ -28,6 +29,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             MSBuildWorkspaceUpgradeContext context,
             IComponentIdentifier componentIdentifier,
             IPackageRestorer restorer,
+            ITargetFrameworkMonikerComparer comparer,
             FileInfo file,
             ILogger logger)
         {
@@ -36,6 +38,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
             _componentIdentifier = componentIdentifier;
             _restorer = restorer;
+            _comparer = comparer;
             _logger = logger;
         }
 
@@ -106,7 +109,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
         public IEnumerable<Reference> References =>
             ProjectRoot.GetAllReferences().Select(r => r.AsReference()).ToList();
 
-        public IReadOnlyCollection<TargetFrameworkMoniker> TargetFrameworks => new TargetFrameworkMonikerCollection(this);
+        public IReadOnlyCollection<TargetFrameworkMoniker> TargetFrameworks => new TargetFrameworkMonikerCollection(this, _comparer);
 
         public override bool Equals(object? obj)
         {

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildRegistrationStartup.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildRegistrationStartup.cs
@@ -65,6 +65,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
                             _instance = msBuildInstances
                                 .OrderByDescending(m => m.Version)
+                                .Where(m => m.Version.Major != 6)
+                                .Where(m => m.Version.Build != 300)
                                 .First();
                             _logger.LogInformation("MSBuild registered from {MSBuildPath}", _instance.MSBuildPath);
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildRegistrationStartup.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildRegistrationStartup.cs
@@ -65,8 +65,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
                             _instance = msBuildInstances
                                 .OrderByDescending(m => m.Version)
-                                .Where(m => m.Version.Major != 6)
-                                .Where(m => m.Version.Build != 300)
                                 .First();
                             _logger.LogInformation("MSBuild registered from {MSBuildPath}", _instance.MSBuildPath);
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
     internal sealed class MSBuildWorkspaceUpgradeContext : IUpgradeContext, IDisposable
     {
         private readonly IPackageRestorer _restorer;
+        private readonly ITargetFrameworkMonikerComparer _comparer;
         private readonly IComponentIdentifier _componentIdentifier;
         private readonly ILogger<MSBuildWorkspaceUpgradeContext> _logger;
         private readonly string? _vsPath;
@@ -50,6 +51,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             UpgradeOptions options,
             IVisualStudioFinder vsFinder,
             IPackageRestorer restorer,
+            ITargetFrameworkMonikerComparer comparer,
             IComponentIdentifier componentIdentifier,
             ILogger<MSBuildWorkspaceUpgradeContext> logger)
         {
@@ -66,6 +68,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             _projectCache = new Dictionary<string, IProject>(StringComparer.OrdinalIgnoreCase);
             InputPath = options.ProjectPath;
             _restorer = restorer;
+            _comparer = comparer;
             _componentIdentifier = componentIdentifier ?? throw new ArgumentNullException(nameof(componentIdentifier));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _vsPath = vsFinder.GetLatestVisualStudioPath();
@@ -90,7 +93,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 return cached;
             }
 
-            var project = new MSBuildProject(this, _componentIdentifier, _restorer, path, _logger);
+            var project = new MSBuildProject(this, _componentIdentifier, _restorer, _comparer, path, _logger);
 
             _projectCache.Add(path.FullName, project);
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/NuGetTargetFrameworkMonikerComparer.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/NuGetTargetFrameworkMonikerComparer.cs
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             {
                 Platform = platform,
                 PlatformVersion = version,
-            }.Normalize();
+            };
             return true;
 
             static string? GetPlatform(NuGetFramework f1, NuGetFramework f2)
@@ -186,7 +186,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             {
                 Platform = parsed.Platform,
                 PlatformVersion = parsed.PlatformVersion,
-            }.Normalize();
+            };
             return true;
         }
     }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/NuGetTargetFrameworkMonikerComparer.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/NuGetTargetFrameworkMonikerComparer.cs
@@ -112,13 +112,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 _ => null,
             };
 
-            var frameworkName = (maxFramework.Framework, maxFramework.Version) switch
-            {
-                (".NETCoreApp", Version v) when v >= TargetFrameworkMoniker.Net50.FrameworkVersion => "net",
-                (string f, _) => f
-            };
-
-            result = new TargetFrameworkMoniker(frameworkName, maxFramework.Version)
+            result = new TargetFrameworkMoniker(maxFramework.Framework, maxFramework.Version)
             {
                 Platform = platform,
                 PlatformVersion = version,

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/TargetFrameworkMonikerCollection.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/TargetFrameworkMonikerCollection.cs
@@ -12,17 +12,19 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
         private const string SdkSingleTargetFramework = "TargetFramework";
         private const string SdkMultipleTargetFrameworks = "TargetFrameworks";
 
+        private readonly ITargetFrameworkMonikerComparer _comparer;
         private readonly IProjectFile _projectFile;
 
         private string[]? _tfms;
 
-        public TargetFrameworkMonikerCollection(IProjectFile projectFile)
+        public TargetFrameworkMonikerCollection(IProjectFile projectFile, ITargetFrameworkMonikerComparer comparer)
         {
             if (projectFile is null)
             {
                 throw new ArgumentNullException(nameof(projectFile));
             }
 
+            _comparer = comparer;
             _projectFile = projectFile;
         }
 
@@ -73,7 +75,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
         {
             foreach (var tfm in RawValues)
             {
-                yield return new TargetFrameworkMoniker(tfm);
+                if (_comparer.TryParse(tfm, out var parsed))
+                {
+                    yield return parsed;
+                }
             }
         }
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/TargetFramework/TargetFrameworkSelector.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/TargetFramework/TargetFrameworkSelector.cs
@@ -49,7 +49,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.TargetFramework
 
             var appBase = _upgradeTarget == UpgradeTarget.Current ? _currentTFMBase : _ltsTFMBase;
             var current = GetDefaultTargetFrameworkMoniker(project);
-            var appBaseTfm = new TargetFrameworkMoniker(appBase);
+
+            if (!_comparer.TryParse(appBase, out var appBaseTfm))
+            {
+                throw new InvalidOperationException("Invalid app base TFM");
+            }
 
             var updater = new FilterState(_comparer, project, current, appBaseTfm, _logger)
             {

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/TargetFramework/WindowsSdkTargetFrameworkSelectorFilter.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/TargetFramework/WindowsSdkTargetFrameworkSelectorFilter.cs
@@ -1,14 +1,13 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.DotNet.UpgradeAssistant.TargetFramework
 {
     public class WindowsSdkTargetFrameworkSelectorFilter : ITargetFrameworkSelectorFilter
     {
-        private const string WindowsSuffix = "-windows";
-
         public void Process(ITargetFrameworkSelectorFilterState tfm)
         {
             if (tfm is null)
@@ -18,13 +17,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.TargetFramework
 
             if (TryGetMoniker(tfm, out var result))
             {
-                tfm.TryUpdate(new TargetFrameworkMoniker(result));
+                tfm.TryUpdate(result);
             }
         }
 
-        private static bool TryGetMoniker(ITargetFrameworkSelectorFilterState updater, [MaybeNullWhen(false)] out string tfm)
+        private static bool TryGetMoniker(ITargetFrameworkSelectorFilterState updater, [MaybeNullWhen(false)] out TargetFrameworkMoniker tfm)
         {
-            // ToDo: We should be able to manipulate specific parts of the TFM
             var current = updater.Current;
 
             if (current.IsNetStandard)
@@ -35,12 +33,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.TargetFramework
             // Projects with Windows Desktop components or a WinExe output type should use a -windows suffix
             if (updater.Components.HasFlag(ProjectComponents.WindowsDesktop) || updater.Project.OutputType == ProjectOutputType.WinExe)
             {
-                tfm = $"{current}{WindowsSuffix}";
+                tfm = current with { Platform = TargetFrameworkMoniker.Platforms.Windows };
 
                 if (updater.Components.HasFlag(ProjectComponents.WinRT))
                 {
                     // TODO: Default to this version to ensure everything is supported.
-                    tfm += "10.0.19041.0";
+                    tfm = tfm with { PlatformVersion = new Version(10, 0, 19041, 0) };
                 }
 
                 return true;

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/TargetFramework/WindowsSdkTargetFrameworkSelectorFilter.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/TargetFramework/WindowsSdkTargetFrameworkSelectorFilter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.TargetFramework
                 if (updater.Components.HasFlag(ProjectComponents.WinRT))
                 {
                     // TODO: Default to this version to ensure everything is supported.
-                    tfm = tfm with { PlatformVersion = new Version(10, 0, 19041, 0) };
+                    tfm = tfm with { PlatformVersion = TargetFrameworkMoniker.Net50_Windows_10_0_19041_0.PlatformVersion };
                 }
 
                 return true;

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/UpgraderManager.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/UpgraderManager.cs
@@ -12,16 +12,13 @@ namespace Microsoft.DotNet.UpgradeAssistant
 {
     public class UpgraderManager
     {
-        private readonly IPackageRestorer _restorer;
         private readonly IUpgradeStepOrderer _orderer;
         private readonly ILogger _logger;
 
         public UpgraderManager(
-            IPackageRestorer restorer,
             IUpgradeStepOrderer orderer,
             ILogger<UpgraderManager> logger)
         {
-            _restorer = restorer ?? throw new ArgumentNullException(nameof(restorer));
             _orderer = orderer ?? throw new ArgumentNullException(nameof(orderer));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/NewtonsoftReferenceAnalyzer.cs
@@ -16,7 +16,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
     {
         private const string NewtonsoftPackageName = "Microsoft.AspNetCore.Mvc.NewtonsoftJson";
 
-        private readonly TargetFrameworkMoniker _netCore3Moniker = new TargetFrameworkMoniker("netcoreapp3.0");
         private readonly IPackageLoader _packageLoader;
         private readonly ILogger<NewtonsoftReferenceAnalyzer> _logger;
         private readonly ITargetFrameworkMonikerComparer _tfmComparer;
@@ -47,7 +46,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
             // This reference only needs added to ASP.NET Core exes
             if (!(components.HasFlag(ProjectComponents.AspNetCore)
                 && project.OutputType == ProjectOutputType.Exe
-                && !project.TargetFrameworks.Any(tfm => _tfmComparer.Compare(tfm, _netCore3Moniker) < 0)))
+                && !project.TargetFrameworks.Any(tfm => _tfmComparer.Compare(tfm, TargetFrameworkMoniker.NetCoreApp30) < 0)))
             {
                 return state;
             }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TargetCompatibilityReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TargetCompatibilityReferenceAnalyzer.cs
@@ -13,7 +13,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
     public class TargetCompatibilityReferenceAnalyzer : IPackageReferencesAnalyzer
     {
         private readonly IPackageLoader _packageLoader;
-        private readonly ITargetFrameworkSelector _tfmSelector;
         private readonly IVersionComparer _comparer;
         private readonly ILogger<TargetCompatibilityReferenceAnalyzer> _logger;
 
@@ -21,12 +20,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
 
         public TargetCompatibilityReferenceAnalyzer(
             IPackageLoader packageLoader,
-            ITargetFrameworkSelector tfmSelector,
             IVersionComparer comparer,
             ILogger<TargetCompatibilityReferenceAnalyzer> logger)
         {
             _packageLoader = packageLoader ?? throw new ArgumentNullException(nameof(packageLoader));
-            _tfmSelector = tfmSelector ?? throw new ArgumentNullException(nameof(tfmSelector));
             _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }

--- a/tests/Microsoft.DotNet.UpgradeAssistant.TestHelpers/TargetFrameworkMonikerParser.cs
+++ b/tests/Microsoft.DotNet.UpgradeAssistant.TestHelpers/TargetFrameworkMonikerParser.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Moq;
+
+namespace Microsoft.DotNet.UpgradeAssistant
+{
+    public static class TargetFrameworkMonikerParser
+    {
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+        public const string NetCoreApp21 = "netcoreapp2.1";
+        public const string NetCoreApp30 = "netcoreapp3.0";
+        public const string NetCoreApp31 = "netcoreapp3.1";
+        public const string NetStandard10 = "netstandard1.0";
+        public const string NetStandard20 = "netstandard2.0";
+        public const string NetStandard21 = "netstandard2.1";
+        public const string Net45 = "net45";
+        public const string Net46 = "net46";
+        public const string Net461 = "net461";
+        public const string Net462 = "net462";
+        public const string Net47 = "net47";
+        public const string Net471 = "net471";
+        public const string Net48 = "net48";
+        public const string Net50 = "net5.0";
+        public const string Net50_Windows = "net5.0-windows";
+        public const string Net50_Windows_10_0_5 = "net5.0-windows10.0.5";
+        public const string Net50_Windows_10_1_5 = "net5.0-windows10.1.5";
+        public const string Net50_Windows_10_0_19041_0 = "net5.0-windows10.0.19041.0";
+        public const string Net60 = "net6.0";
+        public const string Net60_Windows = "net6.0-windows";
+        public const string Net60_Windows_10_0_5 = "net6.0-windows10.0.5";
+        public const string Net60_Windows_10_1_5 = "net6.0-windows10.1.5";
+        public const string Net60_Windows_10_0_19041_0 = "net6.0-windows10.0.19041.0";
+
+        public const string Current = Net50;
+        public const string Preview = Net60;
+        public const string LTS = NetCoreApp31;
+
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+
+        private static readonly Dictionary<string, TargetFrameworkMoniker> _map = new Dictionary<string, TargetFrameworkMoniker>(StringComparer.OrdinalIgnoreCase)
+        {
+            { NetCoreApp21, TargetFrameworkMoniker.NetCoreApp21 },
+            { NetCoreApp30, TargetFrameworkMoniker.NetCoreApp30 },
+            { NetCoreApp31, TargetFrameworkMoniker.NetCoreApp31 },
+            { NetStandard10, TargetFrameworkMoniker.NetStandard10 },
+            { NetStandard20, TargetFrameworkMoniker.NetStandard20 },
+            { NetStandard21, TargetFrameworkMoniker.NetStandard21 },
+            { Net45, TargetFrameworkMoniker.Net45 },
+            { Net46, TargetFrameworkMoniker.Net46 },
+            { Net461, TargetFrameworkMoniker.Net461 },
+            { Net462, TargetFrameworkMoniker.Net462 },
+            { Net47, TargetFrameworkMoniker.Net47 },
+            { Net471, TargetFrameworkMoniker.Net471 },
+            { Net48, TargetFrameworkMoniker.Net48 },
+            { Net50, TargetFrameworkMoniker.Net50 },
+            { Net50_Windows, TargetFrameworkMoniker.Net50_Windows },
+            { Net50_Windows_10_0_5, TargetFrameworkMoniker.Net50_Windows with { PlatformVersion = new Version(10, 0, 5) } },
+            { Net50_Windows_10_1_5, TargetFrameworkMoniker.Net50_Windows with { PlatformVersion = new Version(10, 1, 5) } },
+            { Net50_Windows_10_0_19041_0, TargetFrameworkMoniker.Net50_Windows with { PlatformVersion = new Version(10, 0, 19041, 0) } },
+            { Net60, TargetFrameworkMoniker.Net60 },
+            { Net60_Windows, TargetFrameworkMoniker.Net60_Windows },
+            { Net60_Windows_10_0_5, TargetFrameworkMoniker.Net60_Windows with { PlatformVersion = new Version(10, 0, 5) } },
+            { Net60_Windows_10_1_5, TargetFrameworkMoniker.Net60_Windows with { PlatformVersion = new Version(10, 1, 5) } },
+            { Net60_Windows_10_0_19041_0, TargetFrameworkMoniker.Net60_Windows with { PlatformVersion = new Version(10, 0, 19041, 0) } },
+        };
+
+        public static TargetFrameworkMoniker ParseTfm(string input) => _map[input];
+
+        public static void SetupTryParse(this Mock<ITargetFrameworkMonikerComparer> mock)
+        {
+            foreach (var (tfmString, tfm) in _map)
+            {
+                var result = tfm;
+                mock.Setup(m => m.TryParse(tfmString, out result)).Returns(true);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.UpgradeAssistant.TestHelpers/TargetFrameworkMonikerParser.cs
+++ b/tests/Microsoft.DotNet.UpgradeAssistant.TestHelpers/TargetFrameworkMonikerParser.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Moq;
 
 namespace Microsoft.DotNet.UpgradeAssistant
@@ -63,12 +64,14 @@ namespace Microsoft.DotNet.UpgradeAssistant
             { Net50_Windows_10_0_19041_0, TargetFrameworkMoniker.Net50_Windows with { PlatformVersion = new Version(10, 0, 19041, 0) } },
             { Net60, TargetFrameworkMoniker.Net60 },
             { Net60_Windows, TargetFrameworkMoniker.Net60_Windows },
+            { Net60_Linux, TargetFrameworkMoniker.Net60_Linux },
             { Net60_Windows_10_0_5, TargetFrameworkMoniker.Net60_Windows with { PlatformVersion = new Version(10, 0, 5) } },
             { Net60_Windows_10_1_5, TargetFrameworkMoniker.Net60_Windows with { PlatformVersion = new Version(10, 1, 5) } },
             { Net60_Windows_10_0_19041_0, TargetFrameworkMoniker.Net60_Windows with { PlatformVersion = new Version(10, 0, 19041, 0) } },
         };
 
-        public static TargetFrameworkMoniker ParseTfm(string input) => _map[input];
+        [return: NotNullIfNotNull("input")]
+        public static TargetFrameworkMoniker? ParseTfm(string? input) => input is null ? null : _map[input];
 
         public static void SetupTryParse(this Mock<ITargetFrameworkMonikerComparer> mock)
         {

--- a/tests/Microsoft.DotNet.UpgradeAssistant.TestHelpers/TargetFrameworkMonikerParser.cs
+++ b/tests/Microsoft.DotNet.UpgradeAssistant.TestHelpers/TargetFrameworkMonikerParser.cs
@@ -30,6 +30,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
         public const string Net50_Windows_10_0_19041_0 = "net5.0-windows10.0.19041.0";
         public const string Net60 = "net6.0";
         public const string Net60_Windows = "net6.0-windows";
+        public const string Net60_Linux = "net6.0-linux";
         public const string Net60_Windows_10_0_5 = "net6.0-windows10.0.5";
         public const string Net60_Windows_10_1_5 = "net6.0-windows10.1.5";
         public const string Net60_Windows_10_0_19041_0 = "net6.0-windows10.0.19041.0";

--- a/tests/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Tests/TargetFrameworkMonikerTests.cs
+++ b/tests/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Tests/TargetFrameworkMonikerTests.cs
@@ -61,7 +61,9 @@ namespace Microsoft.DotNet.UpgradeAssistant.Abstractions.Tests
         {
             get
             {
+                // These are variations that may occur from various NuGet parsing APIs for the framework. We expect TargetFrameworkMoniker to normalize these.
                 yield return new object[] { new TargetFrameworkMoniker(".NETFramework", new Version(4, 5, 0)), Net45 };
+                yield return new object[] { new TargetFrameworkMoniker(".NETFramework", new Version(4, 5, 0)) { Platform = TargetFrameworkMoniker.Platforms.Windows, PlatformVersion = new Version(1, 0) }, Net45 };
                 yield return new object[] { new TargetFrameworkMoniker(".NETCoreApp", new Version(5, 0)), Net50 };
                 yield return new object[] { new TargetFrameworkMoniker("net", new Version(5, 0, 0)), Net50 };
                 yield return new object[] { TargetFrameworkMoniker.Net50 with { Platform = string.Empty }, Net50 };
@@ -75,6 +77,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Abstractions.Tests
         [Theory]
         public void AlternateNamesTests(TargetFrameworkMoniker tfm, string expected)
         {
+            Assert.Equal(ParseTfm(expected), tfm);
             Assert.Equal(expected, tfm.ToString());
         }
 

--- a/tests/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Tests/TargetFrameworkMonikerTests.cs
+++ b/tests/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Tests/TargetFrameworkMonikerTests.cs
@@ -1,0 +1,156 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+using static Microsoft.DotNet.UpgradeAssistant.TargetFrameworkMonikerParser;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Abstractions.Tests
+{
+    public class TargetFrameworkMonikerTests
+    {
+        public static IEnumerable<object[]> EqualityData()
+        {
+            yield return new object[] { TargetFrameworkMoniker.Net45, TargetFrameworkMoniker.Net45 };
+            yield return new object[] { TargetFrameworkMoniker.Net45, TargetFrameworkMoniker.Net45 with { Framework = "NET" } };
+            yield return new object[] { TargetFrameworkMoniker.Net45, TargetFrameworkMoniker.Net45 with { FrameworkVersion = new Version(4, 5, 0) } };
+        }
+
+        [MemberData(nameof(EqualityData))]
+        [Theory]
+        public void EqualsTests(TargetFrameworkMoniker tfm1, TargetFrameworkMoniker tfm2)
+        {
+            Assert.Equal(tfm1, tfm2);
+        }
+
+        [InlineData(NetStandard10)]
+        [InlineData(NetStandard20)]
+        [InlineData(NetStandard21)]
+        [InlineData(NetCoreApp21)]
+        [InlineData(NetCoreApp30)]
+        [InlineData(NetCoreApp31)]
+        [InlineData(Net45)]
+        [InlineData(Net46)]
+        [InlineData(Net461)]
+        [InlineData(Net462)]
+        [InlineData(Net47)]
+        [InlineData(Net471)]
+        [InlineData(Net48)]
+        [InlineData(Net50)]
+        [InlineData(Net50_Windows)]
+        [InlineData(Net50_Windows_10_0_5)]
+        [InlineData(Net60)]
+        [InlineData(Net60_Windows)]
+        [InlineData(Net60_Windows_10_0_5)]
+        [Theory]
+        public void ToStringTests(string input)
+        {
+            // Arrange
+            var tfm = ParseTfm(input);
+
+            // Act
+            var result = tfm.ToString();
+
+            // Assert
+            Assert.Equal(input, result);
+        }
+
+        public static IEnumerable<object[]> AlternateNames
+        {
+            get
+            {
+                yield return new object[] { new TargetFrameworkMoniker(".NETFramework", new Version(4, 5, 0)), Net45 };
+                yield return new object[] { new TargetFrameworkMoniker(".NETCoreApp", new Version(5, 0)), Net50 };
+                yield return new object[] { new TargetFrameworkMoniker("net", new Version(5, 0, 0)), Net50 };
+                yield return new object[] { TargetFrameworkMoniker.Net50 with { Platform = string.Empty }, Net50 };
+                yield return new object[] { TargetFrameworkMoniker.Net50_Windows with { PlatformVersion = new Version(0, 0, 0, 0) }, Net50_Windows };
+                yield return new object[] { new TargetFrameworkMoniker(".NETCoreApp", new Version(5, 0, 0)), Net50 };
+                yield return new object[] { new TargetFrameworkMoniker(".NETStandard", new Version(2, 1, 0)), NetStandard21 };
+            }
+        }
+
+        [MemberData(nameof(AlternateNames))]
+        [Theory]
+        public void AlternateNamesTests(TargetFrameworkMoniker tfm, string expected)
+        {
+            Assert.Equal(expected, tfm.ToString());
+        }
+
+        [InlineData(NetStandard10, true)]
+        [InlineData(NetStandard20, true)]
+        [InlineData(NetStandard21, true)]
+        [InlineData(NetCoreApp30, false)]
+        [InlineData(NetCoreApp31, false)]
+        [InlineData(Net45, false)]
+        [InlineData(Net46, false)]
+        [InlineData(Net461, false)]
+        [InlineData(Net462, false)]
+        [InlineData(Net47, false)]
+        [InlineData(Net471, false)]
+        [InlineData(Net48, false)]
+        [InlineData(Net50, false)]
+        [InlineData(Net50_Windows, false)]
+        [InlineData(Net50_Windows_10_0_5, false)]
+        [InlineData(Net60, false)]
+        [InlineData(Net60_Windows, false)]
+        [InlineData(Net60_Windows_10_0_5, false)]
+        [Theory]
+        public void IsStandardTests(string input, bool isStandard)
+        {
+            var tfm = ParseTfm(input);
+            Assert.Equal(isStandard, tfm.IsNetStandard);
+        }
+
+        [InlineData(NetStandard10, false)]
+        [InlineData(NetStandard20, false)]
+        [InlineData(NetStandard21, false)]
+        [InlineData(NetCoreApp30, false)]
+        [InlineData(NetCoreApp31, false)]
+        [InlineData(Net45, true)]
+        [InlineData(Net46, true)]
+        [InlineData(Net461, true)]
+        [InlineData(Net462, true)]
+        [InlineData(Net47, true)]
+        [InlineData(Net471, true)]
+        [InlineData(Net48, true)]
+        [InlineData(Net50, false)]
+        [InlineData(Net50_Windows, false)]
+        [InlineData(Net50_Windows_10_0_5, false)]
+        [InlineData(Net60, false)]
+        [InlineData(Net60_Windows, false)]
+        [InlineData(Net60_Windows_10_0_5, false)]
+        [Theory]
+        public void IsFrameworkTests(string input, bool isFramework)
+        {
+            var tfm = ParseTfm(input);
+            Assert.Equal(isFramework, tfm.IsFramework);
+        }
+
+        [InlineData(NetStandard10, false)]
+        [InlineData(NetStandard20, false)]
+        [InlineData(NetStandard21, false)]
+        [InlineData(NetCoreApp30, true)]
+        [InlineData(NetCoreApp31, true)]
+        [InlineData(Net45, false)]
+        [InlineData(Net46, false)]
+        [InlineData(Net461, false)]
+        [InlineData(Net462, false)]
+        [InlineData(Net47, false)]
+        [InlineData(Net471, false)]
+        [InlineData(Net48, false)]
+        [InlineData(Net50, true)]
+        [InlineData(Net50_Windows, true)]
+        [InlineData(Net50_Windows_10_0_5, true)]
+        [InlineData(Net60, true)]
+        [InlineData(Net60_Windows, true)]
+        [InlineData(Net60_Windows_10_0_5, true)]
+        [Theory]
+        public void IsNetCoreTests(string input, bool isNetCore)
+        {
+            var tfm = ParseTfm(input);
+            Assert.Equal(isNetCore, tfm.IsNetCore);
+        }
+    }
+}

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/NuGetTargetFrameworkMonikerComparerTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/NuGetTargetFrameworkMonikerComparerTests.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Autofac.Extras.Moq;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -13,7 +10,7 @@ using static Microsoft.DotNet.UpgradeAssistant.TargetFrameworkMonikerParser;
 namespace Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests
 {
     [Collection(MSBuildStepTestCollection.Name)]
-    public class TargetFrameworkIdentifierTests
+    public class NuGetTargetFrameworkMonikerComparerTests
     {
         [InlineData(Net50, NetCoreApp31, true)]
         [InlineData(Net50, Net50, true)]
@@ -93,6 +90,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests
         [InlineData(Net60_Windows_10_0_5, Net50_Windows_10_0_5, Net60)]
         [InlineData(Net60_Windows_10_1_5, Net50_Windows_10_1_5, Net60_Windows_10_0_5)]
         [InlineData(Net60_Windows_10_1_5, Net50_Windows_10_1_5, Net60_Windows_10_1_5)]
+        [InlineData(Net60_Windows_10_1_5, Net60_Windows_10_0_5, Net50_Windows_10_1_5)]
         [InlineData(Net60_Windows, Net60_Windows, Net50_Windows)]
         [InlineData(null, Net60_Linux, Net50_Windows)]
         [InlineData(Net60, Net50, Net60)]

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/TargetFrameworkIdentifierTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/TargetFrameworkIdentifierTests.cs
@@ -1,76 +1,79 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Autofac.Extras.Moq;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
+
+using static Microsoft.DotNet.UpgradeAssistant.TargetFrameworkMonikerParser;
 
 namespace Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests
 {
     [Collection(MSBuildStepTestCollection.Name)]
     public class TargetFrameworkIdentifierTests
     {
-        [InlineData("net5.0", "netcoreapp3.1", true)]
-        [InlineData("net5.0", "net5.0", true)]
-        [InlineData("net5.0", "netstandard2.0", true)]
-        [InlineData("net5.0", "netstandard1.0", true)]
-        [InlineData("net5.0", "netstandard2.1", true)]
-        [InlineData("net5.0", "net48", false)]
-        [InlineData("net5.0", "net471", false)]
-        [InlineData("net5.0", "net47", false)]
-        [InlineData("net5.0", "net45", false)]
-        [InlineData("netcoreapp3.1", "netcoreapp3.1", true)]
-        [InlineData("netcoreapp3.1", "net5.0", false)]
-        [InlineData("netcoreapp3.1", "netstandard2.0", true)]
-        [InlineData("netcoreapp3.1", "netstandard1.0", true)]
-        [InlineData("netcoreapp3.1", "netstandard2.1", true)]
-        [InlineData("netcoreapp3.1", "net48", false)]
-        [InlineData("netcoreapp3.1", "net471", false)]
-        [InlineData("netcoreapp3.1", "net47", false)]
-        [InlineData("netcoreapp3.1", "net45", false)]
-        [InlineData("net48", "netcoreapp3.1", false)]
-        [InlineData("net471", "netcoreapp3.1", false)]
-        [InlineData("net471", "net5.0", false)]
-        [InlineData("net471", "netstandard2.0", false)]
-        [InlineData("net461", "netstandard2.0", false)]
-        [InlineData("net46", "netstandard2.0", false)]
+        [InlineData(Net50, NetCoreApp31, true)]
+        [InlineData(Net50, Net50, true)]
+        [InlineData(Net50, NetStandard20, true)]
+        [InlineData(Net50, NetStandard10, true)]
+        [InlineData(Net50, NetStandard21, true)]
+        [InlineData(Net50, Net48, false)]
+        [InlineData(Net50, Net471, false)]
+        [InlineData(Net50, Net47, false)]
+        [InlineData(Net50, Net45, false)]
+        [InlineData(NetCoreApp31, NetCoreApp31, true)]
+        [InlineData(NetCoreApp31, Net50, false)]
+        [InlineData(NetCoreApp31, NetStandard20, true)]
+        [InlineData(NetCoreApp31, NetStandard10, true)]
+        [InlineData(NetCoreApp31, NetStandard21, true)]
+        [InlineData(NetCoreApp31, Net48, false)]
+        [InlineData(NetCoreApp31, Net471, false)]
+        [InlineData(NetCoreApp31, Net47, false)]
+        [InlineData(NetCoreApp31, Net45, false)]
+        [InlineData(Net48, NetCoreApp31, false)]
+        [InlineData(Net471, NetCoreApp31, false)]
+        [InlineData(Net471, Net50, false)]
+        [InlineData(Net471, NetStandard20, false)]
+        [InlineData(Net461, NetStandard20, false)]
         [Theory]
         public void IsCoreCompatibleSDKTargetFramework(string target, string tfm, bool isCompatible)
         {
             var tfmComparer = new NuGetTargetFrameworkMonikerComparer(new NullLogger<NuGetTargetFrameworkMonikerComparer>());
-            var result = tfmComparer.IsCompatible(new TargetFrameworkMoniker(target), new TargetFrameworkMoniker(tfm));
+            var result = tfmComparer.IsCompatible(ParseTfm(target), ParseTfm(tfm));
 
             Assert.Equal(isCompatible, result);
         }
 
         [InlineData(null, null, 0)]
-        [InlineData(null, "netcoreapp3.1", -1)]
-        [InlineData("netcoreapp3.1", null, 1)]
-        [InlineData("net5.0", "netcoreapp3.1", 1)]
-        [InlineData("net5.0", "net5.0", 0)]
-        [InlineData("net5.0", "netstandard2.0", 1)]
-        [InlineData("net5.0", "netstandard1.0", 1)]
-        [InlineData("net5.0", "netstandard2.1", 1)]
-        [InlineData("net5.0", "net48", -1)]
-        [InlineData("net5.0", "net471", -1)]
-        [InlineData("net5.0", "net47", -1)]
-        [InlineData("net5.0", "net45", -1)]
-        [InlineData("netcoreapp3.1", "netcoreapp3.1", 0)]
-        [InlineData("netcoreapp3.1", "net5.0", -1)]
-        [InlineData("netcoreapp3.1", "netstandard2.0", 1)]
-        [InlineData("netcoreapp3.1", "netstandard1.0", 1)]
-        [InlineData("netcoreapp3.1", "netstandard2.1", 1)]
-        [InlineData("netcoreapp3.1", "net48", -1)]
-        [InlineData("netcoreapp3.1", "net471", -1)]
-        [InlineData("netcoreapp3.1", "net47", -1)]
-        [InlineData("netcoreapp3.1", "net45", -1)]
-        [InlineData("net48", "netcoreapp3.1", -1)]
-        [InlineData("net471", "netcoreapp3.1", -1)]
-        [InlineData("net471", "net5.0", -1)]
-        [InlineData("net471", "netstandard2.0", -1)]
-        [InlineData("net461", "netstandard2.0", -1)]
-        [InlineData("net46", "netstandard2.0", -1)]
+        [InlineData(null, NetCoreApp31, -1)]
+        [InlineData(NetCoreApp31, null, 1)]
+        [InlineData(Net50, NetCoreApp31, 1)]
+        [InlineData(Net50, Net50, 0)]
+        [InlineData(Net50, NetStandard20, 1)]
+        [InlineData(Net50, NetStandard10, 1)]
+        [InlineData(Net50, NetStandard21, 1)]
+        [InlineData(Net50, Net48, -1)]
+        [InlineData(Net50, Net471, -1)]
+        [InlineData(Net50, Net47, -1)]
+        [InlineData(Net50, Net45, -1)]
+        [InlineData(NetCoreApp31, NetCoreApp31, 0)]
+        [InlineData(NetCoreApp31, Net50, -1)]
+        [InlineData(NetCoreApp31, NetStandard20, 1)]
+        [InlineData(NetCoreApp31, NetStandard10, 1)]
+        [InlineData(NetCoreApp31, NetStandard21, 1)]
+        [InlineData(NetCoreApp31, Net48, -1)]
+        [InlineData(NetCoreApp31, Net471, -1)]
+        [InlineData(NetCoreApp31, Net47, -1)]
+        [InlineData(NetCoreApp31, Net45, -1)]
+        [InlineData(Net48, NetCoreApp31, -1)]
+        [InlineData(Net471, NetCoreApp31, -1)]
+        [InlineData(Net471, Net50, -1)]
+        [InlineData(Net471, NetStandard20, -1)]
+        [InlineData(Net461, NetStandard20, -1)]
+        [InlineData(Net46, NetStandard20, -1)]
         [Theory]
         public void TfmCompare(string target, string tfm, int expected)
         {
@@ -80,23 +83,23 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests
             Assert.Equal(expected, result);
 
             static TargetFrameworkMoniker? Create(string? input)
-                => input is null ? null : new TargetFrameworkMoniker(input);
+                => input is null ? null : ParseTfm(input);
         }
 
-        [InlineData("net6.0-windows", "net5.0-windows", "net6.0")]
-        [InlineData("net6.0-windows", "net6.0", "net5.0-windows")]
-        [InlineData("net6.0-windows", "net5.0", "net6.0-windows")]
-        [InlineData("net6.0-windows10.0.5", "net5.0", "net6.0-windows10.0.5")]
-        [InlineData("net6.0-windows10.0.5", "net5.0-windows10.0.5", "net6.0")]
-        [InlineData("net6.0-windows10.1.5", "net5.0-windows10.1.5", "net6.0-windows10.0.5")]
-        [InlineData("net6.0-windows10.1.5", "net5.0-windows10.1.5", "net6.0-windows10.1.5")]
-        [InlineData("net6.0-windows", "net6.0-windows", "net5.0-windows")]
+        [InlineData(Net60_Windows, Net50_Windows, Net60)]
+        [InlineData(Net60_Windows, Net60, Net50_Windows)]
+        [InlineData(Net60_Windows, Net50, Net60_Windows)]
+        [InlineData(Net60_Windows_10_0_5, Net50, Net60_Windows_10_0_5)]
+        [InlineData(Net60_Windows_10_0_5, Net50_Windows_10_0_5, Net60)]
+        [InlineData(Net60_Windows_10_1_5, Net50_Windows_10_1_5, Net60_Windows_10_0_5)]
+        [InlineData(Net60_Windows_10_1_5, Net50_Windows_10_1_5, Net60_Windows_10_1_5)]
+        [InlineData(Net60_Windows, Net60_Windows, Net50_Windows)]
         [InlineData(null, "net6.0-linux", "net5.0-windows")]
-        [InlineData("net6.0", "net5.0", "net6.0")]
-        [InlineData("net5.0", "net462", "net5.0")]
-        [InlineData("net5.0", "net5.0", "netstandard2.0")]
-        [InlineData("netstandard2.0", "netstandard2.0", "netstandard2.0")]
-        [InlineData("netstandard2.1", "netstandard2.0", "netstandard2.1")]
+        [InlineData(Net60, Net50, Net60)]
+        [InlineData(Net50, Net462, Net50)]
+        [InlineData(Net50, Net50, NetStandard20)]
+        [InlineData(NetStandard20, NetStandard20, NetStandard20)]
+        [InlineData(NetStandard21, NetStandard20, NetStandard21)]
         [Theory]
         public void MergeTests(string expected, string tfm1, string tfm2)
         {

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/TargetFrameworkIdentifierTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/TargetFrameworkIdentifierTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests
         [InlineData(Net60_Windows_10_1_5, Net50_Windows_10_1_5, Net60_Windows_10_0_5)]
         [InlineData(Net60_Windows_10_1_5, Net50_Windows_10_1_5, Net60_Windows_10_1_5)]
         [InlineData(Net60_Windows, Net60_Windows, Net50_Windows)]
-        [InlineData(null, "net6.0-linux", "net5.0-windows")]
+        [InlineData(null, Net60_Linux, Net50_Windows)]
         [InlineData(Net60, Net50, Net60)]
         [InlineData(Net50, Net462, Net50)]
         [InlineData(Net50, Net50, NetStandard20)]
@@ -108,13 +108,13 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests
             var comparer = mock.Create<NuGetTargetFrameworkMonikerComparer>();
 
             // Act
-            var didMerge = comparer.TryMerge(new TargetFrameworkMoniker(tfm1), new TargetFrameworkMoniker(tfm2), out var result);
+            var didMerge = comparer.TryMerge(ParseTfm(tfm1), ParseTfm(tfm2), out var result);
 
             // Assert
             if (expected is not null)
             {
                 Assert.True(didMerge);
-                Assert.Equal(new TargetFrameworkMoniker(expected), result);
+                Assert.Equal(ParseTfm(expected), result);
             }
             else
             {

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/TargetFramework/DependencyMinimumTargetFrameworkSelectorFilterTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/TargetFramework/DependencyMinimumTargetFrameworkSelectorFilterTests.cs
@@ -9,17 +9,12 @@ using Microsoft.DotNet.UpgradeAssistant.TargetFramework;
 using Moq;
 using Xunit;
 
+using static Microsoft.DotNet.UpgradeAssistant.TargetFrameworkMonikerParser;
+
 namespace Microsoft.DotNet.UpgradeAssistant.Tests
 {
     public class DependencyMinimumTargetFrameworkSelectorFilterTests
     {
-        private const string Current = "net0.0current";
-        private const string Preview = "net0.0laterpreview";
-        private const string LTS = "net0.0lts";
-        private const string NetStandard20 = "netstandard2.0";
-        private const string NetStandard21 = "netstandard2.1";
-        private const string Net45 = "net45";
-
         [InlineData(new string[] { }, new string[] { }, null)]
         [InlineData(new[] { NetStandard20 }, new[] { NetStandard20 }, NetStandard20)]
         [InlineData(new[] { NetStandard21 }, new[] { NetStandard20 }, NetStandard21)]
@@ -40,10 +35,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.Tests
             using var mock = AutoMock.GetLoose(b => b.RegisterType<TestTfmComparer>().As<ITargetFrameworkMonikerComparer>());
 
             var depProject1 = new Mock<IProject>();
-            depProject1.Setup(p => p.TargetFrameworks).Returns(dep1Tfms.Select(t => new TargetFrameworkMoniker(t)).ToArray());
+            depProject1.Setup(p => p.TargetFrameworks).Returns(dep1Tfms.Select(t => ParseTfm(t)).ToArray());
 
             var depProject2 = new Mock<IProject>();
-            depProject2.Setup(p => p.TargetFrameworks).Returns(dep2tfms.Select(t => new TargetFrameworkMoniker(t)).ToArray());
+            depProject2.Setup(p => p.TargetFrameworks).Returns(dep2tfms.Select(t => ParseTfm(t)).ToArray());
 
             var project = mock.Mock<IProject>();
             project.Setup(p => p.ProjectReferences).Returns(new[] { depProject1.Object, depProject2.Object });
@@ -58,7 +53,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Tests
 
             // Assert
             var count = expected is null ? Times.Never() : Times.AtLeastOnce();
-            var tfm = expected is null ? null : new TargetFrameworkMoniker(expected);
+            var tfm = expected is null ? null : ParseTfm(expected);
             state.Verify(s => s.TryUpdate(tfm!), count);
         }
 
@@ -89,6 +84,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Tests
             }
 
             public bool TryMerge(TargetFrameworkMoniker tfm1, TargetFrameworkMoniker tfm2, out TargetFrameworkMoniker result)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool TryParse(string input, out TargetFrameworkMoniker tfm)
             {
                 throw new NotImplementedException();
             }

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/TargetFramework/TargetFrameworkSelectorTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/TargetFramework/TargetFrameworkSelectorTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Tests
             mock.Mock<IOptions<TFMSelectorOptions>>().Setup(o => o.Value).Returns(_options);
 
             var moniker = mock.Mock<ITargetFrameworkMonikerComparer>();
-            moniker.Setup(c => c.TryMerge(new TargetFrameworkMoniker(current), tfm, out finalTfm)).Returns(true);
+            moniker.Setup(c => c.TryMerge(ParseTfm(current), tfm, out finalTfm)).Returns(true);
             moniker.SetupTryParse();
 
             var appBase = target == UpgradeTarget.Current ? _options.CurrentTFMBase : _options.LTSTFMBase;

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/TargetFramework/WindowsSdkTargetFrameworkSelectorFilterTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/TargetFramework/WindowsSdkTargetFrameworkSelectorFilterTests.cs
@@ -7,27 +7,29 @@ using Microsoft.DotNet.UpgradeAssistant.TargetFramework;
 using Moq;
 using Xunit;
 
+using static Microsoft.DotNet.UpgradeAssistant.TargetFrameworkMonikerParser;
+
 namespace Microsoft.DotNet.UpgradeAssistant.Tests
 {
     public class WindowsSdkTargetFrameworkSelectorFilterTests
     {
-        [InlineData(ProjectComponents.None, ProjectOutputType.Exe, "", false)]
-        [InlineData(ProjectComponents.AspNet, ProjectOutputType.Exe, "", false)]
-        [InlineData(ProjectComponents.AspNetCore, ProjectOutputType.Exe, "", false)]
-        [InlineData(ProjectComponents.WindowsDesktop, ProjectOutputType.Exe, "-windows", true)]
-        [InlineData(ProjectComponents.None, ProjectOutputType.WinExe, "-windows", true)]
-        [InlineData(ProjectComponents.AspNet | ProjectComponents.WindowsDesktop, ProjectOutputType.Exe, "-windows", true)]
-        [InlineData(ProjectComponents.WinForms | ProjectComponents.WindowsDesktop, ProjectOutputType.Exe, "-windows", true)]
-        [InlineData(ProjectComponents.WinRT | ProjectComponents.WindowsDesktop, ProjectOutputType.Exe, "-windows10.0.19041.0", true)]
+        [InlineData(ProjectComponents.None, ProjectOutputType.Exe, Net50, Net50, false)]
+        [InlineData(ProjectComponents.AspNet, ProjectOutputType.Exe, Net50, Net50, false)]
+        [InlineData(ProjectComponents.AspNetCore, ProjectOutputType.Exe, Net50, Net50, false)]
+        [InlineData(ProjectComponents.WindowsDesktop, ProjectOutputType.Exe, Net50, Net50_Windows, true)]
+        [InlineData(ProjectComponents.None, ProjectOutputType.WinExe, Net50, Net50_Windows, true)]
+        [InlineData(ProjectComponents.AspNet | ProjectComponents.WindowsDesktop, ProjectOutputType.Exe, Net50, Net50_Windows, true)]
+        [InlineData(ProjectComponents.WinForms | ProjectComponents.WindowsDesktop, ProjectOutputType.Exe, Net50, Net50_Windows, true)]
+        [InlineData(ProjectComponents.WinRT | ProjectComponents.WindowsDesktop, ProjectOutputType.Exe, Net50, Net50_Windows_10_0_19041_0, true)]
         [Theory]
-        public void ProcessTests(ProjectComponents components, ProjectOutputType outputType, string expectedSuffix, bool tryUpdate)
+        public void ProcessTests(ProjectComponents components, ProjectOutputType outputType, string startingTfmString, string expectedTfmString, bool tryUpdate)
         {
             // Arrange
             var fixture = new Fixture();
             using var mock = AutoMock.GetLoose();
 
-            var tfm = fixture.Create<TargetFrameworkMoniker>();
-            var expectedTfm = new TargetFrameworkMoniker(tfm.Name + expectedSuffix);
+            var tfm = ParseTfm(startingTfmString);
+            var expectedTfm = ParseTfm(expectedTfmString);
 
             var project = new Mock<IProject>();
             project.Setup(p => p.OutputType).Returns(outputType);

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/Analyzers/NewtonsoftReferenceAnalyzerTests.cs
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/Analyzers/NewtonsoftReferenceAnalyzerTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests.Analyzers
             var packageLoader = CreatePackageLoader(mock);
 
             // shift project attributes so that it is not applicable
-            project.Setup(p => p.TargetFrameworks).Returns(new[] { new TargetFrameworkMoniker("net472") });
+            project.Setup(p => p.TargetFrameworks).Returns(new[] { TargetFrameworkMoniker.Net472 });
             var comparer = mock.Mock<ITargetFrameworkMonikerComparer>();
             comparer.Setup(comparer => comparer.Compare(It.IsAny<TargetFrameworkMoniker>(), It.IsAny<TargetFrameworkMoniker>()))
                 .Returns(-1);
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests.Analyzers
             nugetReferences.Setup(n => n.IsTransitivelyAvailable(It.IsAny<string>()))
                 .Returns(false);
 
-            project.Setup(p => p.TargetFrameworks).Returns(new[] { new TargetFrameworkMoniker("net5.0") });
+            project.Setup(p => p.TargetFrameworks).Returns(new[] { TargetFrameworkMoniker.Net50 });
             project.Setup(p => p.GetComponentsAsync(default)).Returns(new ValueTask<ProjectComponents>(ProjectComponents.AspNetCore));
             project.Setup(p => p.OutputType).Returns(ProjectOutputType.Exe);
             project.Setup(p => p.GetNuGetReferencesAsync(default)).Returns(new ValueTask<INuGetReferences>(nugetReferences.Object));


### PR DESCRIPTION
This change replaces a simple record with `Name` to be one that includes
the parts that matter: FrameworkName, Version, Platform, PlatformVersion

This will then be formatted as needed in the property `Name`.