### PR TITLE
Fix diagnostic IDs in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -258,11 +258,11 @@ dotnet_diagnostic.SA1502.severity = none
 # CA1303: Do not pass literals as localized parameters
 dotnet_diagnostic.CA1303.severity = none
 
-# CA1600: Elements should be documented
-dotnet_diagnostic.CA1600.severity = none
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = none
 
-# CA1601: Partial elements should be documented
-dotnet_diagnostic.CA1601.severity = none
+# SA1601: Partial elements should be documented
+dotnet_diagnostic.SA1601.severity = none
 
 # SA1633: The file header is missing or not located at the top of the file
 dotnet_diagnostic.SA1633.severity = none

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Razor/RazorSourceUpdater.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Razor/RazorSourceUpdater.cs
@@ -54,6 +54,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Razor
         /// <param name="analyzers">Analyzers to use when analyzing source code in the Razor documents.</param>
         /// <param name="codeFixProviders">Code fix providers to use when fixing diagnostics found in the Razor documents.</param>
         /// <param name="textMatcher">The text matching service to use for correlating old sections of text in Razor documents with updated texts.</param>
+        /// <param name="textReplacer">The text replacing service to use for updating replaced texts in the Razor documents.</param>
         /// <param name="logger">An ILogger to log diagnostics.</param>
         public RazorSourceUpdater(IEnumerable<DiagnosticAnalyzer> analyzers, IEnumerable<CodeFixProvider> codeFixProviders, ITextMatcher textMatcher, ITextReplacer textReplacer, ILogger<RazorSourceUpdater> logger)
         {


### PR DESCRIPTION
This fixes a couple diagnostic IDs in .editorconfig. We were accidentally disabling CA1600 and CA1601 instead of SA1600 and SA1601. Thanks @oteinone for spotting this!