### PR TITLE
Update authenticated NuGet source handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ If you're just starting to look at .NET 5.0 and would like to understand more ab
 2. [.NET Core porting documentation](https://docs.microsoft.com/dotnet/core/porting/)
 3. [Documentation of features not available on .NET Core](https://docs.microsoft.com/dotnet/core/porting/net-framework-tech-unavailable)
 
+### Authenticated NuGet sources
+
+As part of upgrading a project, Upgrade Assistant will need to both restore the project's NuGet packages and query configured NuGet sources for information on updated packages. If a project depends on authenticated NuGet sources, some extra steps may be necessary for Upgrade Assistant to work correctly:
+
+1. Upgrade Assistant requires that a v2 .NET Core-compatible NuGet credential provider be installed on the computer if authenticated NuGet sources are used. For example, if you are using authenticated Azure DevOps NuGet feeds, follow [these instructions](https://github.com/microsoft/artifacts-credprovider#setup) to setup a compatible credential provider.
+2. You may need to run Upgrade Assistant in interactive mode (which is the default execution mode) in order to authenticate the NuGet sources. After authenticating once, non-interactive mode can be used as the credentials are cached. 
+
 ### Extensibility
 The Upgrade Assistant has an extension system that make it easy for you to customize many of the upgrade steps without having to rebuild the tool. See how you can extend the tool [here](docs/extensibility.md).
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ If you're just starting to look at .NET 5.0 and would like to understand more ab
 
 As part of upgrading a project, Upgrade Assistant will need to both restore the project's NuGet packages and query configured NuGet sources for information on updated packages. If a project depends on authenticated NuGet sources, some extra steps may be necessary for Upgrade Assistant to work correctly:
 
-1. Upgrade Assistant requires that a v2 .NET Core-compatible NuGet credential provider be installed on the computer if authenticated NuGet sources are used. For example, if you are using authenticated Azure DevOps NuGet feeds, follow [these instructions](https://github.com/microsoft/artifacts-credprovider#setup) to setup a compatible credential provider.
-2. You may need to run Upgrade Assistant in interactive mode (which is the default execution mode) in order to authenticate the NuGet sources. After authenticating once, non-interactive mode can be used as the credentials are cached. 
+1. Upgrade Assistant requires that a v2 .NET Core-compatible NuGet credential provider be installed on the computer if authenticated NuGet sources are used. For example, if you are using authenticated Azure DevOps NuGet feeds, follow [these instructions](https://github.com/microsoft/artifacts-credprovider#setup) to setup a compatible credential provider. .NET Core NuGet credential providers are those installed under the netcore folder in .nuget/plugins, as explained [here](https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery).
+2. You may need to run Upgrade Assistant in interactive mode (which is the default execution mode) in order to authenticate the NuGet sources. After authenticating once, non-interactive mode can be used as the credentials are cached.
 
 ### Extensibility
 The Upgrade Assistant has an extension system that make it easy for you to customize many of the upgrade steps without having to rebuild the tool. See how you can extend the tool [here](docs/extensibility.md).

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/ProcessInfo.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/ProcessInfo.cs
@@ -19,7 +19,11 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
         public int SuccessCode { get; init; }
 
-        public Func<string, LogLevel> GetMessageLogLevel { get; init; } = msg => msg.Contains("Error") ? LogLevel.Error : LogLevel.Information;
+        /// <summary>
+        /// Gets a func that determines what log level should be used to log a message. The func takes a boolean indicating
+        /// whether the message is from stderr and a string containing the text of the message.
+        /// </summary>
+        public Func<bool, string, LogLevel> GetMessageLogLevel { get; init; } = (isStdErr, _) => isStdErr ? LogLevel.Error : LogLevel.Information;
 
         public IEnumerable<KeyValuePair<string, string>> EnvironmentVariables { get; init; } = Enumerable.Empty<KeyValuePair<string, string>>();
 

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/ProcessInfo.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/ProcessInfo.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.UpgradeAssistant
 {
@@ -18,7 +19,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
         public int SuccessCode { get; init; }
 
-        public bool Quiet { get; init; }
+        public Func<string, LogLevel> GetMessageLogLevel { get; init; } = msg => msg.Contains("Error") ? LogLevel.Error : LogLevel.Information;
 
         public IEnumerable<KeyValuePair<string, string>> EnvironmentVariables { get; init; } = Enumerable.Empty<KeyValuePair<string, string>>();
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/DotnetRestorePackageRestorer.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/DotnetRestorePackageRestorer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -12,13 +13,23 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 {
     public class DotnetRestorePackageRestorer : IPackageRestorer
     {
+        private static readonly string[] MessagesToDisplay = new[]
+        {
+            "Consider re-running the command with --interactive",
+            "ATTENTION: User interaction required",
+            "*****************************",
+            "To sign in, use a web browser"
+        };
+
+        private readonly IUserInput _userInput;
         private readonly ILogger<DotnetRestorePackageRestorer> _logger;
         private readonly IProcessRunner _runner;
 
-        public DotnetRestorePackageRestorer(ILogger<DotnetRestorePackageRestorer> logger, IProcessRunner runner)
+        public DotnetRestorePackageRestorer(IUserInput userInput, ILogger<DotnetRestorePackageRestorer> logger, IProcessRunner runner)
         {
-            _logger = logger;
-            _runner = runner;
+            _userInput = userInput ?? throw new ArgumentNullException(nameof(userInput));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _runner = runner ?? throw new ArgumentNullException(nameof(runner));
         }
 
         public async Task<bool> RestorePackagesAsync(IUpgradeContext context, IProject project, CancellationToken token)
@@ -51,10 +62,13 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             return _runner.RunProcessAsync(new ProcessInfo
             {
                 Command = "dotnet",
-                Arguments = Invariant($"restore \"{path}\""),
+                Arguments = _userInput.IsInteractive ? Invariant($"restore --interactive \"{path}\"") : Invariant($"restore \"{path}\""),
                 EnvironmentVariables = context.GlobalProperties,
                 Name = "dotnet-restore",
-                Quiet = true
+
+                // dotnet-restore does not need to receive user input to authenticate, so the only thing
+                // necessary to enable interactive auth is to make sure that necessary messages are displayed to users.
+                GetMessageLogLevel = message => MessagesToDisplay.Any(m => message.Contains(m, StringComparison.Ordinal)) ? LogLevel.Information : LogLevel.Debug,
             }, token);
         }
     }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildPackageRestorer.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildPackageRestorer.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             return result?.OverallResult == BuildResultCode.Success;
         }
 
-        private static ProjectInstance CreateProjectInstance(IUpgradeContext context, IProject project) => new ProjectInstance(project.FileInfo.FullName, context.GlobalProperties, toolsVersion: null);
+        private static ProjectInstance CreateProjectInstance(IUpgradeContext context, IProject project) => new(project.FileInfo.FullName, context.GlobalProperties, toolsVersion: null);
 
         public BuildResult? RestorePackages(ProjectInstance projectInstance)
         {

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/NuGetCredentialsStartup.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/NuGetCredentialsStartup.cs
@@ -2,16 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.Credentials;
-using NuGet.Protocol;
-using NuGet.Protocol.Plugins;
 
 namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 {
@@ -28,32 +22,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public Task<bool> StartupAsync(CancellationToken token)
         {
-            if (HttpHandlerResourceV3.CredentialService == null)
-            {
-                _logger.LogDebug("Registering NuGet credential providers");
-                HttpHandlerResourceV3.CredentialService = new Lazy<ICredentialService>(
-                    () => new CredentialService(
-                        providers: new AsyncLazy<IEnumerable<ICredentialProvider>>(async () => await GetCredentialProvidersAsync().ConfigureAwait(false)),
-                        nonInteractive: !_userInput.IsInteractive,
-                        handlesDefaultCredentials: PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders));
-            }
-
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(new NuGetLogger(_logger), !_userInput.IsInteractive);
             return Task.FromResult(true);
-        }
-
-        private async Task<IEnumerable<ICredentialProvider>> GetCredentialProvidersAsync()
-        {
-            var pluginProviderBuilder = new SecurePluginCredentialProviderBuilder(PluginManager.Instance, false, new NuGetLogger(_logger));
-            var pluginProviders = (await pluginProviderBuilder.BuildAllAsync().ConfigureAwait(false)).ToList();
-
-            if (PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders)
-            {
-                pluginProviders.Add(new DefaultNetworkCredentialsCredentialProvider());
-            }
-
-            _logger.LogDebug("Using NuGet credential providers: {Providers}", string.Join(", ", pluginProviders.Select(p => p.Id)));
-
-            return pluginProviders;
         }
     }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/PackageLoader.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/PackageLoader.cs
@@ -112,6 +112,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 catch (NuGetProtocolException)
                 {
                     _logger.LogWarning("Failed to get package versions from source {PackageSource} due to a NuGet protocol error", source.Source);
+                    _logger.LogInformation("If NuGet packages are coming from an authenticated source, Upgrade Assistant requires a .NET Core-compatible v2 credential provider be installed. To authenticate with an Azure DevOps NuGet source, for example, see https://github.com/microsoft/artifacts-credprovider#setup");
                 }
                 catch (HttpRequestException exc)
                 {
@@ -286,6 +287,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 catch (NuGetProtocolException)
                 {
                     _logger.LogWarning("Failed to get package finder from source {PackageSource} due to a NuGet protocol error, skipping this source", source.Source);
+                    _logger.LogInformation("If NuGet packages are coming from an authenticated source, Upgrade Assistant requires a .NET Core-compatible v2 credential provider be installed. To authenticate with an Azure DevOps NuGet source, for example, see https://github.com/microsoft/artifacts-credprovider#setup");
                 }
             }
 

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertTool.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertTool.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using static System.FormattableString;
@@ -75,6 +76,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
                 Arguments = GetArguments(project.Required()),
                 EnvironmentVariables = context.GlobalProperties,
                 IsErrorFilter = data => ErrorMessages.Any(data.Contains),
+                GetMessageLogLevel = (isStdErr, msg) => (isStdErr || ErrorMessages.Any(msg.Contains)) ? LogLevel.Error : LogLevel.Information
             }, token);
         }
 


### PR DESCRIPTION
This simplifies how Upgrade Assistant interacts with NuGet credential providers, allows `dotnet restore` to be run interactively, and improves documentation about authenticated NuGet scenarios.

Fixes #359 
Fixes #511 
