### PR TITLE
Use AppContext.BaseDirectory for extensions

### DIFF
--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionProviderExtensions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionProviderExtensions.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 
                 var fromConfig = originalConfiguration.GetSection("DefaultExtensions")
                     .Get<string[]>()
-                    .Select(n => Path.GetFullPath(Path.Combine(ExtensionDirectory, n)));
+                    .Select(n => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, ExtensionDirectory, n)));
 
                 var extensionPathString = originalConfiguration[UpgradeAssistantExtensionPathsSettingName];
                 var pathsFromString = extensionPathString?.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? Enumerable.Empty<string>();


### PR DESCRIPTION
Without this, the resolution is from the current working directory. For the built-in extensions, this should be from the installed location instead.
