### PR TITLE
Include web typemap in analyzers test

### DIFF
--- a/tests/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers.Test/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers.Test.csproj
+++ b/tests/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers.Test/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers.Test.csproj
@@ -14,6 +14,9 @@
     <Content Include="assets\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="..\..\..\..\..\src\extensions\default\analyzers\Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers.Package\build\WebTypeReplacements.typemap" Link="WebTypeReplacements.typemap">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis">


### PR DESCRIPTION
Not sure how the CI build was passing without this, but tests seem to be broken. A previous PR moved the web typemap so it wouldn't show up in the default extension list, which meant at runtime it was not in the test folder. This links the files so it'll show up.