### PR TITLE
Add better support for zip extensions

### DIFF
--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionMappedFileConfigureOptions{TOption,TTo}.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionMappedFileConfigureOptions{TOption,TTo}.cs
@@ -82,26 +82,5 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
                 return Array.Empty<TTo>();
             }
         }
-
-        private class SubFileProvider : IFileProvider
-        {
-            private readonly IFileProvider _other;
-            private readonly string _path;
-
-            public SubFileProvider(IFileProvider other, string path)
-            {
-                _other = other;
-                _path = path;
-            }
-
-            public IDirectoryContents GetDirectoryContents(string subpath)
-                => _other.GetDirectoryContents(Path.Combine(_path, subpath));
-
-            public IFileInfo GetFileInfo(string subpath)
-                => _other.GetFileInfo(Path.Combine(_path, subpath));
-
-            public IChangeToken Watch(string filter)
-                => _other.Watch(Path.Combine(_path, filter));
-        }
     }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/SubFileProvider.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/SubFileProvider.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions
+{
+    internal sealed class SubFileProvider : IFileProvider
+    {
+        private readonly IFileProvider _other;
+        private readonly string _path;
+
+        public SubFileProvider(IFileProvider other, string path)
+        {
+            _other = other;
+            _path = path;
+        }
+
+        public IDirectoryContents GetDirectoryContents(string subpath)
+            => _other.GetDirectoryContents(Path.Combine(_path, subpath));
+
+        public IFileInfo GetFileInfo(string subpath)
+            => _other.GetFileInfo(Path.Combine(_path, subpath));
+
+        public IChangeToken Watch(string filter)
+            => _other.Watch(Path.Combine(_path, filter));
+    }
+}

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ZipFileProvider.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ZipFileProvider.cs
@@ -36,6 +36,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 
         public IDirectoryContents GetDirectoryContents(string subpath)
         {
+            subpath = NormalizeZipPath(subpath);
             var list = new List<IFileInfo>();
 
             foreach (var entry in _archive.Entries)
@@ -56,9 +57,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
             return new ListDirectoryContents(list);
         }
 
+        private static string NormalizeZipPath(string path) => path.Replace('\\', '/');
+
         public IFileInfo GetFileInfo(string subpath)
         {
-            var entry = _archive.GetEntry(subpath);
+            var entry = _archive.GetEntry(NormalizeZipPath(subpath));
 
             if (entry is null)
             {


### PR DESCRIPTION
- AssemblyLoadContext requires assemblies to be seekable, so we now will copy assemblies to byte arrays if they are not seekable
- We check for pattern that occurs when a zip file is created from a folder where the top level directory is a simple folder

This change also consolidates loading logic all into the assembly load context where it will attempt to load the assemblies from the manifest.
