### PR TITLE
Make the VS interop lib private

### DIFF
--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/Microsoft.DotNet.UpgradeAssistant.MSBuild.csproj
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/Microsoft.DotNet.UpgradeAssistant.MSBuild.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis">
       <Version>3.9.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop">
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" PrivateAssets="runtime">
       <!-- This package is mostly COM definitions which can be loaded in .NET 5 runtime just fine -->
       <NoWarn>NU1701</NoWarn>
       <Version>2.3.2262-g94fae01e</Version>


### PR DESCRIPTION
This package is a build time component only and provides COM types that
are used to identify where VS is.