### PR TITLE
Update pkg loader to not filter out packages with empty dependency sets

### DIFF
--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/PackageLoader.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/PackageLoader.cs
@@ -155,8 +155,15 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             return results
                 .Where(r =>
                 {
-                    var unsupported = tfmSet;
+                    // If the package has no dependency sets, then include it (as it may be build tools, analyzers, etc.).
+                    if (!r.DependencySets.Any())
+                    {
+                        return true;
+                    }
 
+                    // If the package has dependency sets, only include it if there are dependency sets for each
+                    // of the TFMs that need to be supported.
+                    var unsupported = tfmSet;
                     foreach (var dep in r.DependencySets)
                     {
                         foreach (var t in unsupported)


### PR DESCRIPTION
This was causing `PackageLoader.GetLatestVersionAsync` to not find *any* versions of analyzer packages (which don't typically have dependency sets).

Fixes #555 