### PR TITLE
Add support for a minimum required version in extension

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Constants.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Constants.cs
@@ -1,18 +1,35 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Reflection;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Cli
 {
     public static class Constants
     {
-        public static string Version
+        public static string FullVersion
         {
             get
             {
                 var attribute = typeof(Constants).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
                 return attribute?.InformationalVersion ?? "0.0.0-unspecified";
+            }
+        }
+
+        public static Version Version
+        {
+            get
+            {
+                var version = FullVersion;
+                var idx = version.IndexOf('-', StringComparison.Ordinal);
+
+                if (idx > 0)
+                {
+                    version = version.Substring(0, idx);
+                }
+
+                return Version.Parse(version);
             }
         }
     }

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/FileUpgradeStateFactory.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/FileUpgradeStateFactory.cs
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
         private class UpgradeState
         {
-            public string Build { get; init; } = Constants.Version;
+            public string Build { get; init; } = Constants.FullVersion;
 
             public string? CurrentProject { get; init; }
 

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Program.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Program.cs
@@ -114,7 +114,19 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
                     services.AddSingleton<IUpgradeStateManager, FileUpgradeStateFactory>();
 
-                    services.AddExtensions(context.Configuration, options.Extension);
+                    services.AddExtensions()
+                        .AddDefaultExtensions(context.Configuration)
+                        .AddFromEnvironmentVariables(context.Configuration)
+                        .Configure(opts =>
+                        {
+                            opts.CurrentVersion = Constants.Version;
+
+                            foreach (var path in options.Extension)
+                            {
+                                opts.ExtensionPaths.Add(path);
+                            }
+                        });
+
                     services.AddMsBuild();
                     services.AddSingleton(options);
 
@@ -173,7 +185,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
         private static void ShowHeader()
         {
-            var title = $"- Microsoft .NET Upgrade Assistant v{Constants.Version} -";
+            var title = $"- Microsoft .NET Upgrade Assistant v{Constants.FullVersion} -";
             Console.WriteLine(new string('-', title.Length));
             Console.WriteLine(title);
             Console.WriteLine(new string('-', title.Length));

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionInstance.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionInstance.cs
@@ -67,6 +67,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 
         public Version? Version => GetOptions<Version>("Version");
 
+        public Version? MinUpgradeAssistantVersion => GetOptions<Version>("MinRequiredVersion");
+
         public T? GetOptions<T>(string sectionName) => Configuration.GetSection(sectionName).Get<T>();
 
         public void Dispose()

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionManager.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionManager.cs
@@ -26,7 +26,14 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
                 {
                     if (LoadExtension(path) is ExtensionInstance extension)
                     {
-                        list.Add(extension);
+                        if (extension.MinUpgradeAssistantVersion is Version minVersion && minVersion < options.Value.CurrentVersion)
+                        {
+                            logger.LogWarning("Could not load extension from {Path}", path);
+                        }
+                        else
+                        {
+                            list.Add(extension);
+                        }
                     }
                     else
                     {

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionManager.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionManager.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
                     {
                         if (extension.MinUpgradeAssistantVersion is Version minVersion && minVersion < options.Value.CurrentVersion)
                         {
-                            logger.LogWarning("Could not load extension from {Path}", path);
+                            logger.LogWarning("Could not load extension from {Path}. Requires at least v{Version} of Upgrade Assistant.", path, minVersion);
                         }
                         else
                         {
@@ -56,11 +56,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
                         {
                             if (instance.Version is Version version)
                             {
-                                logger.LogDebug("Loaded extension: {Name} v{Version} [{Location}]", instance.Name, version, instance.Location);
+                                logger.LogDebug("Found extension '{Name}' v{Version} [{Location}]", instance.Name, version, instance.Location);
                             }
                             else
                             {
-                                logger.LogDebug("Loaded extension: {Name} [{Location}]", instance.Name, instance.Location);
+                                logger.LogDebug("Found extension '{Name}' [{Location}]", instance.Name, instance.Location);
                             }
 
                             return instance;

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionOptions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions
@@ -8,5 +9,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
     public class ExtensionOptions
     {
         public ICollection<string> ExtensionPaths { get; } = new List<string>();
+
+        public Version CurrentVersion { get; set; } = null!;
     }
 }


### PR DESCRIPTION
This change allows an extension to say what it's minimum required version for Upgrade Assistant is.