### PR TITLE
ExtensionManager should be a singleton

### DIFF
--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionProviderExtensions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionProviderExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
                     o.Converters.Add(new JsonStringEnumConverter());
                 });
 
-            services.AddScoped<ExtensionManager>();
+            services.AddSingleton<ExtensionManager>();
             services.AddTransient<IEnumerable<ExtensionInstance>>(ctx => ctx.GetRequiredService<ExtensionManager>());
             services.AddExtensionLoaders();
 


### PR DESCRIPTION
This was making it so that extensions were loaded twice. Only one of them was used, but the ExtensionManager should be a singleton to only load extensions once.