### PR TITLE
Alert users of diagnostics that don't have a code fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Usage telemetry has been added to help guide product development. See [https://aka.ms/upgrade-assistant-telemetry](https://aka.ms/upgrade-assistant-telemetry) for details [#644](https://github.com/dotnet/upgrade-assistant/pull/644).
 - Command line option to pass options through in the form of `--option KEY=Value` [#651](https://github.com/dotnet/upgrade-assistant/pull/651)
 - Added an analyzer and code fix provider to remove unnecessary attributes and upgrade changed attributes (based on type mappings in registered typemap files) [#641](https://github.com/dotnet/upgrade-assistant/pull/641)
+- The `SourceUpdaterStep` and `RazorSourceUpdater` will now alert the user of any diagnostics from registered analyzers that require manual fixups (because no code fix was available). This allows Upgrade Assistant to notify users of code patterns that it can identify as needing updated but is unable to update automatically. [#662](https://github.com/dotnet/upgrade-assistant/pull/662)
 
 ### Fixed
 - Updated `HttpContext.Current` analyzer to more correctly identify uses of `HttpContext.Current` that need replaced [#628](https://github.com/dotnet/upgrade-assistant/pull/628).

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default/DefaultExtensionServiceProvider.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default/DefaultExtensionServiceProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default
             services.AddTransient<CodeFixProvider, HtmlHelperCodeFixer>();
             services.AddTransient<CodeFixProvider, HttpContextCurrentCodeFixer>();
             services.AddTransient<CodeFixProvider, HttpContextIsDebuggingEnabledCodeFixer>();
-            //services.AddTransient<CodeFixProvider, TypeUpgradeCodeFixer>();
+            services.AddTransient<CodeFixProvider, TypeUpgradeCodeFixer>();
             services.AddTransient<CodeFixProvider, UrlHelperCodeFixer>();
             services.AddTransient<CodeFixProvider, UsingSystemWebCodeFixer>();
         }

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default/DefaultExtensionServiceProvider.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Extensions.Default/DefaultExtensionServiceProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Default
             services.AddTransient<CodeFixProvider, HtmlHelperCodeFixer>();
             services.AddTransient<CodeFixProvider, HttpContextCurrentCodeFixer>();
             services.AddTransient<CodeFixProvider, HttpContextIsDebuggingEnabledCodeFixer>();
-            services.AddTransient<CodeFixProvider, TypeUpgradeCodeFixer>();
+            //services.AddTransient<CodeFixProvider, TypeUpgradeCodeFixer>();
             services.AddTransient<CodeFixProvider, UrlHelperCodeFixer>();
             services.AddTransient<CodeFixProvider, UsingSystemWebCodeFixer>();
         }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Source/SourceUpdaterStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Source/SourceUpdaterStep.cs
@@ -157,11 +157,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Source
                     var compilationWithAnalyzer = compilation
                         .WithAnalyzers(ImmutableArray.CreateRange(applicableAnalyzers), new CompilationWithAnalyzersOptions(new AnalyzerOptions(_additionalTexts), ProcessAnalyzerException, true, true));
 
-                    // Find all diagnostics that upgrade code fixers can address
+                    // Find all diagnostics that registered analyzers produce
+                    // Note that this intentionally identifies diagnostics that no code fix providers can
+                    // address so that users can be warned about diagnostics that they will need to address manually.
                     Diagnostics = (await compilationWithAnalyzer.GetAnalyzerDiagnosticsAsync(token).ConfigureAwait(false))
-                        .Where(d => d.Location.IsInSource &&
-                               _allCodeFixProviders.Any(f => f.FixableDiagnosticIds.Contains(d.Id)));
-                    Logger.LogDebug("Identified {DiagnosticCount} fixable diagnostics in project {ProjectName}", Diagnostics.Count(), project.Name);
+                        .Where(d => d.Location.IsInSource);
+                    Logger.LogDebug("Identified {DiagnosticCount} diagnostics in project {ProjectName}", Diagnostics.Count(), project.Name);
                 }
             }
         }


### PR DESCRIPTION
This updates the `RazorSourceUpdater` and `SourceUpdaterStep` to alert users via warnings of any diagnostics that were produced by registered analyzers but didn't have a code fix available. This allows UA analyzers to alert users of code patterns requiring manual updates.