### PR TITLE
Fix Add SDK method to handle empty string

### DIFF
--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/SdkCollection.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/SdkCollection.cs
@@ -27,9 +27,16 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public void Add(string item)
         {
-            if (!Contains(item))
+            if (!string.IsNullOrEmpty(_projectRoot.Sdk))
             {
-                _projectRoot.Sdk = string.Concat(_projectRoot.Sdk, ";", item);
+                if (!Contains(item))
+                {
+                    _projectRoot.Sdk = string.Concat(_projectRoot.Sdk, ";", item);
+                }
+            }
+            else
+            {
+                _projectRoot.Sdk = item;
             }
         }
 


### PR DESCRIPTION
Add SDK method in SDKCollection need to add an SDK element when empty without the preceding `;`
