### PR TITLE
Move command options closer to object

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Analyze/ConsoleAnalyzeCommand.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Analyze/ConsoleAnalyzeCommand.cs
@@ -1,13 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
-using System.IO;
 using System.Threading;
-using Microsoft.DotNet.UpgradeAssistant.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Cli
@@ -18,29 +14,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             : base("analyze")
         {
             IsHidden = true;
-            Handler = CommandHandler.Create<ParseResult, AnalyzeOptions, CancellationToken>((result, options, token) =>
+            Handler = CommandHandler.Create<ParseResult, CommandOptions, CancellationToken>((result, options, token) =>
                 Host.CreateDefaultBuilder()
                     .UseConsoleUpgradeAssistant<ConsoleAnalyze>(options, result)
                     .RunUpgradeAssistantAsync(token));
-        }
-
-        private class AnalyzeOptions : IUpgradeAssistantOptions
-        {
-            public bool Verbose { get; set; }
-
-            public bool IsVerbose => Verbose;
-
-            public FileInfo Project { get; set; } = null!;
-
-            public bool IgnoreUnsupportedFeatures { get; set; }
-
-            public UpgradeTarget TargetTfmSupport { get; set; }
-
-            public IReadOnlyCollection<string> Extension { get; set; } = Array.Empty<string>();
-
-            public IReadOnlyCollection<string> Option { get; set; } = Array.Empty<string>();
-
-            public IEnumerable<AdditionalOption> AdditionalOptions => Option.ParseOptions();
         }
     }
 }

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Upgrade/ConsoleUpgradeCommand.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Upgrade/ConsoleUpgradeCommand.cs
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
-using System.IO;
 using System.Threading;
-using Microsoft.DotNet.UpgradeAssistant.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Cli
@@ -41,33 +38,13 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             AddOption(new Option<int>(new[] { "--non-interactive-wait" }, "Wait the supplied seconds before moving on to the next option in non-interactive mode."));
         }
 
-        private class UpgradeOptions : IUpgradeAssistantOptions
+        private class UpgradeOptions : CommandOptions, IUpgradeAssistantOptions
         {
-            public FileInfo Project { get; set; } = null!;
-
-            // Name must be Extension and not plural as the name of the argument that it binds to is `--extension`
-            public IReadOnlyCollection<string> Extension { get; set; } = Array.Empty<string>();
-
             public bool SkipBackup { get; set; }
-
-            // Name must be EntryPoint and not plural as the name of the argument that it binds to is `--entry-point`
-            public IReadOnlyCollection<string> EntryPoint { get; set; } = Array.Empty<string>();
-
-            public IReadOnlyCollection<string> Option { get; set; } = Array.Empty<string>();
-
-            public bool Verbose { get; set; }
-
-            public bool IsVerbose => Verbose;
-
-            public bool IgnoreUnsupportedFeatures { get; set; }
 
             public bool NonInteractive { get; set; }
 
             public int NonInteractiveWait { get; set; } = 2;
-
-            public UpgradeTarget TargetTfmSupport { get; set; } = UpgradeTarget.Current;
-
-            public IEnumerable<AdditionalOption> AdditionalOptions => Option.ParseOptions();
         }
     }
 }

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/UpgradeAssistantCommand.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/UpgradeAssistantCommand.cs
@@ -1,9 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.IO;
+using Microsoft.DotNet.UpgradeAssistant.Extensions;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Cli
 {
@@ -19,6 +21,29 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             AddOption(new Option<IReadOnlyCollection<string>>(new[] { "--entry-point", "-e" }, "Provides the entry-point project to start the upgrade process. This may include globbing patterns such as '*' for match."));
             AddOption(new Option<UpgradeTarget>(new[] { "--target-tfm-support" }, "Select if you would like the Long Term Support (LTS), Current, or Preview TFM. See https://dotnet.microsoft.com/platform/support/policy/dotnet-core for details for what these mean."));
             AddOption(new Option<bool>(new[] { "--ignore-unsupported-features" }, "Acknowledges that upgrade-assistant will not be able to completely upgrade a project. This indicates that the solution must be redesigned (e.g. consider Blazor to replace Web Forms)."));
+        }
+
+        protected class CommandOptions : IUpgradeAssistantOptions
+        {
+            public FileInfo Project { get; set; } = null!;
+
+            // Name must be Extension and not plural as the name of the argument that it binds to is `--extension`
+            public IReadOnlyCollection<string> Extension { get; set; } = Array.Empty<string>();
+
+            // Name must be EntryPoint and not plural as the name of the argument that it binds to is `--entry-point`
+            public IReadOnlyCollection<string> EntryPoint { get; set; } = Array.Empty<string>();
+
+            public IReadOnlyCollection<string> Option { get; set; } = Array.Empty<string>();
+
+            public bool Verbose { get; set; }
+
+            public bool IsVerbose => Verbose;
+
+            public bool IgnoreUnsupportedFeatures { get; set; }
+
+            public UpgradeTarget TargetTfmSupport { get; set; } = UpgradeTarget.Current;
+
+            public IEnumerable<AdditionalOption> AdditionalOptions => Option.ParseOptions();
         }
     }
 }


### PR DESCRIPTION
This moves the command options closer to where the options they bind to are defined. This should help with keeping things in sync.