### PR TITLE
Updates to some telemetry points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,6 @@ PublishScripts/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
-launchSettings.json
 
 .packages/
 /.dotnet

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Microsoft.DotNet.UpgradeAssistant.Cli.csproj
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Microsoft.DotNet.UpgradeAssistant.Cli.csproj
@@ -12,6 +12,9 @@
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="appsettings.Development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Properties/launchSettings.json
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Microsoft.DotNet.UpgradeAssistant.Cli": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/UsedCommandTelemetry.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/UsedCommandTelemetry.cs
@@ -22,6 +22,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
         public Task<bool> StartupAsync(CancellationToken token)
         {
+            _telemetry.TrackEvent("cli/command", new Dictionary<string, string>
+            {
+                { "Name", _result.CommandResult.Command.Name },
+                { "Type", "command" },
+            });
+
             foreach (var child in _result.CommandResult.Children)
             {
                 var type = child switch

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/appsettings.Development.json
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/appsettings.Development.json
@@ -1,0 +1,5 @@
+﻿{
+  "Telemetry": {
+    "IsEnabled": "false"
+  }
+}

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/appsettings.json
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/appsettings.json
@@ -1,5 +1,6 @@
 ﻿{
   "Telemetry": {
+    "IsEnabled": "true",
     "InstrumentationKey": "66aba558-ae18-4ec4-a738-517213cfcdfb",
     "DisplayName": "Upgrade Assistant",
     "DetailsLink": "https://aka.ms/upgrade-assistant-telemetry"

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Telemetry/Telemetry.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Telemetry/Telemetry.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Telemetry
 
             _options = options.Value;
 
-            Enabled = !EnvironmentHelper.GetEnvironmentVariableAsBool(_options.TelemetryOptout) && PermissionExists(sentinel);
+            Enabled = _options.IsEnabled && !EnvironmentHelper.GetEnvironmentVariableAsBool(_options.TelemetryOptout) && PermissionExists(sentinel);
 
             if (!Enabled)
             {

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Telemetry/TelemetryOptions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Telemetry/TelemetryOptions.cs
@@ -5,6 +5,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Telemetry
 {
     public class TelemetryOptions
     {
+        public bool IsEnabled { get; set; }
+
         public string ProductVersion { get; set; } = string.Empty;
 
         public string DisplayName { get; set; } = string.Empty;

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/TelemetryExtensions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/TelemetryExtensions.cs
@@ -12,8 +12,12 @@ namespace Microsoft.DotNet.UpgradeAssistant
 {
     public static class TelemetryExtensions
     {
-        public static IDisposable TimeStep(this ITelemetry telemetry, string eventName, UpgradeStep step)
-            => telemetry.TimeEvent($"step/{eventName}", onComplete: (p, _) => p.Add("Step Status", step.Status.ToString()));
+        public static IDisposable TimeStep(this ITelemetry telemetry, string commandName, UpgradeStep step)
+            => telemetry.TimeEvent($"step", onComplete: (p, _) =>
+            {
+                p.Add("CommandName", commandName);
+                p.Add("Step Status", step.Status.ToString());
+            });
 
         public static async Task TrackProjectPropertiesAsync(this ITelemetry telemetry, IUpgradeContext context, CancellationToken token)
         {

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/UpgradeContextTelemetry.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/UpgradeContextTelemetry.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -40,7 +39,6 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
             // Solution and project ids are already hashed and so don't need to deal with that
             TryAdd(t.Properties, "Solution Id", context.SolutionId);
-            TryAdd(t.Properties, "Entrypoint Id", string.Join(";", context.EntryPoints.Select(e => e.Id)));
             TryAdd(t.Properties, "Project Id", context.CurrentProject?.Id);
 
             // StepIds should be hashed as they can potentially be extended by external users

--- a/tests/tool/Integration.Tests/UpgradeRunner.cs
+++ b/tests/tool/Integration.Tests/UpgradeRunner.cs
@@ -39,6 +39,7 @@ namespace Integration.Tests
 
             var options = new TestOptions(project);
             var status = await Host.CreateDefaultBuilder()
+                .UseEnvironment(Environments.Development)
                 .UseUpgradeAssistant<ConsoleUpgrade>(options)
                 .ConfigureServices(services =>
                 {


### PR DESCRIPTION
This change does the following:

- Removes EndpointId as it doesn't add value
- Adds a development appsettings that turns off telemetry while developing and testing