### PR TITLE
Remove Task<> from IAsyncEnumerable

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Analyze/ConsoleAnalyze.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Analyze/ConsoleAnalyze.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
                     Name = provider.Name,
                     InformationURI = provider.InformationURI,
                     Id = provider.Id,
-                    AnalysisResults = await provider.AnalyzeAsync(analzyerContext, token),
+                    AnalysisResults = provider.AnalyzeAsync(analzyerContext, token),
                 });
             }
 

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IAnalyzeResultProvider.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IAnalyzeResultProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Analysis
 {
@@ -16,6 +15,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Analysis
 
         Uri InformationURI { get; }
 
-        Task<IAsyncEnumerable<AnalyzeResult>> AnalyzeAsync(AnalyzeContext analysis, CancellationToken token);
+        IAsyncEnumerable<AnalyzeResult> AnalyzeAsync(AnalyzeContext analysis, CancellationToken token);
     }
 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/AnalyzePackageStatus.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/AnalyzePackageStatus.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.DotNet.UpgradeAssistant.Analysis;
 using Microsoft.DotNet.UpgradeAssistant.Dependencies;
 using Microsoft.Extensions.Logging;

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/AnalyzePackageStatus.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/AnalyzePackageStatus.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.UpgradeAssistant.Analysis;
@@ -33,7 +34,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
             _analysisState = null;
         }
 
-        public async Task<IAsyncEnumerable<AnalyzeResult>> AnalyzeAsync(AnalyzeContext analysis, CancellationToken token)
+        public async IAsyncEnumerable<AnalyzeResult> AnalyzeAsync(AnalyzeContext analysis, [EnumeratorCancellation] CancellationToken token)
         {
             if (analysis is null)
             {
@@ -42,8 +43,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
 
             var context = analysis.UpgradeContext;
             var projects = context.Projects.ToList();
-
-            var analyzeResults = new List<AnalyzeResult>();
 
             foreach (var project in projects)
             {
@@ -68,14 +67,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
                     Logger.LogCritical(exc, "Unexpected exception analyzing package references for: {ProjectPath}", context.CurrentProject.Required().FileInfo);
                 }
 
-                analyzeResults.Add(new()
+                yield return new()
                 {
                     FileLocation = project.FileInfo.Name,
                     Results = ExtractAnalysisResult(_analysisState)
-                });
+                };
             }
-
-            return analyzeResults.ToAsyncEnumerable();
         }
 
         private static IReadOnlyCollection<string> ExtractAnalysisResult(IDependencyAnalysisState? analysisState)


### PR DESCRIPTION
This removes `Task<IAsyncEnumerable<>>` from the signature since that is redundant for async operations.