### PR TITLE
Add initial implementation of IExtensionManager APIs

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/ExtensionManagement/ExtensionManagementCommand.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/ExtensionManagement/ExtensionManagementCommand.cs
@@ -25,7 +25,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli.Commands.ExtensionManagement
         public ExtensionManagementCommand()
             : base("extensions")
         {
-            IsHidden = !FeatureFlags.IsRequested("EXTENSION_MANAGEMENT");
             AddCommand(new AddExtensionCommand());
             AddCommand(new ListExtensionCommand());
             AddCommand(new RemoveExtensionCommand());
@@ -66,7 +65,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli.Commands.ExtensionManagement
                 AddHandler<AddExtensionAppCommand>();
                 AddArgument(new Argument<string>("name", LocalizedStrings.ExtensionManagementName));
                 AddOption(new Option<string>(new[] { "--source" }, () => DefaultSource, LocalizedStrings.ExtensionManagementSource));
-                AddOption(new Option<string>(new[] { "--version" }, () => DefaultSource, LocalizedStrings.ExtensionManagementVersion));
+                AddOption(new Option<string>(new[] { "--version" }, LocalizedStrings.ExtensionManagementVersion));
             }
 
             private class AddExtensionAppCommand : IAppCommand
@@ -158,19 +157,17 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli.Commands.ExtensionManagement
                     _logger = logger;
                 }
 
-                public Task RunAsync(CancellationToken token)
+                public async Task RunAsync(CancellationToken token)
                 {
                     foreach (var n in _options.Value.Extensions)
                     {
                         _logger.LogInformation(LocalizedStrings.RemovingExtension, n.Name);
 
-                        if (!_extensionManager.Remove(n.Name))
+                        if (!await _extensionManager.RemoveAsync(n.Name, token))
                         {
                             _logger.LogWarning(LocalizedStrings.RemovingExtensionFailed, n.Name);
                         }
                     }
-
-                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Program.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Program.cs
@@ -33,7 +33,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             // Top-level commands (upgrade, analyze, etc.) are registered as commands and parse with System.CommandLine
             root.AddCommand(new ConsoleAnalyzeCommand());
             root.AddCommand(new ConsoleUpgradeCommand());
-            root.AddCommand(new ExtensionManagementCommand());
+
+            if (FeatureFlags.IsRequested("EXTENSION_MANAGEMENT"))
+            {
+                root.AddCommand(new ExtensionManagementCommand());
+            }
 
             return new CommandLineBuilder(root)
                 .UseDefaults()

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/Extensions/IExtensionManager.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/Extensions/IExtensionManager.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 
         IEnumerable<ExtensionSource> Registered { get; }
 
-        bool Remove(string name);
+        Task<bool> RemoveAsync(string name, CancellationToken token);
 
         Task<ExtensionSource?> UpdateAsync(string name, CancellationToken token);
 

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/IUpgradeAssistantConfigurationLoader.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/IUpgradeAssistantConfigurationLoader.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.UpgradeAssistant
+{
+    public interface IUpgradeAssistantConfigurationLoader
+    {
+        Task SaveAsync(UpgradeAssistantConfiguration configuration, CancellationToken token);
+
+        Task<UpgradeAssistantConfiguration> LoadAsync(CancellationToken token);
+    }
+}

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/UpgradeAssistantConfiguration.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/UpgradeAssistantConfiguration.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.DotNet.UpgradeAssistant.Extensions;
+
+namespace Microsoft.DotNet.UpgradeAssistant
+{
+    public record UpgradeAssistantConfiguration
+    {
+        public ImmutableArray<ExtensionSource> Extensions { get; init; } = ImmutableArray<ExtensionSource>.Empty;
+    }
+}

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/DefaultUpgradeAssistantConfigurationLoader.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/DefaultUpgradeAssistantConfigurationLoader.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions
+{
+    public class DefaultUpgradeAssistantConfigurationLoader : IUpgradeAssistantConfigurationLoader
+    {
+        private readonly JsonSerializerOptions _options = new()
+        {
+            WriteIndented = true,
+        };
+
+        private readonly string _path;
+        private readonly ILogger<DefaultUpgradeAssistantConfigurationLoader> _logger;
+
+        public DefaultUpgradeAssistantConfigurationLoader(
+            IOptions<ExtensionOptions> options,
+            ILogger<DefaultUpgradeAssistantConfigurationLoader> logger)
+        {
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _path = options.Value.ConfigurationFilePath;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<UpgradeAssistantConfiguration> LoadAsync(CancellationToken token)
+        {
+            if (File.Exists(_path))
+            {
+                using var stream = File.OpenRead(_path);
+
+                try
+                {
+                    var data = await JsonSerializer.DeserializeAsync<UpgradeAssistantConfiguration>(stream, _options, token).ConfigureAwait(false);
+
+                    if (data is not null)
+                    {
+                        return data;
+                    }
+                }
+                catch (JsonException e)
+                {
+                    _logger.LogError(e, "Unexpected error reading configuration file at {Path}", _path);
+                }
+            }
+
+            return new();
+        }
+
+        public async Task SaveAsync(UpgradeAssistantConfiguration configuration, CancellationToken token)
+        {
+            using var stream = File.OpenWrite(_path);
+
+            await JsonSerializer.SerializeAsync(stream, configuration, _options, token).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionLoaders/IExtensionLoader.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionLoaders/IExtensionLoader.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 {
-    internal interface IExtensionLoader
+    public interface IExtensionLoader
     {
         ExtensionInstance? LoadExtension(string path);
     }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionOptions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions
@@ -18,5 +19,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
         public ICollection<ExtensionInstance> Extensions { get; } = new List<ExtensionInstance>();
 
         public Version CurrentVersion { get; set; } = null!;
+
+        public string ConfigurationFilePath { get; } = Path.Combine(Environment.CurrentDirectory, "upgrade-assistant.json");
     }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionProviderExtensions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionProviderExtensions.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 
@@ -23,7 +24,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
         /// extensions found in specified paths.
         /// </summary>
         /// <param name="services">The service collection to register services into.</param>
-        /// <returns>A builder for options</returns>
+        /// <returns>A builder for options.</returns>
         public static OptionsBuilder<ExtensionOptions> AddExtensions(this IServiceCollection services)
         {
             if (services is null)
@@ -41,6 +42,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 
             services.AddSingleton<IExtensionManager, ExtensionManager>();
             services.AddExtensionLoaders();
+            services.TryAddSingleton<IUpgradeAssistantConfigurationLoader, DefaultUpgradeAssistantConfigurationLoader>();
 
             return services.AddOptions<ExtensionOptions>();
         }

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Extensions.Tests/ExtensionManagerTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Extensions.Tests/ExtensionManagerTests.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Autofac.Extras.Moq;
+using AutoFixture;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Tests
+{
+    public class ExtensionManagerTests
+    {
+        private readonly Fixture _fixture;
+
+        public ExtensionManagerTests()
+        {
+            _fixture = new Fixture();
+        }
+
+        [Fact]
+        public async Task AddExtensionTestIsAdded()
+        {
+            // Arrange
+            using var mock = AutoMock.GetLoose();
+
+            var extension = _fixture.Create<ExtensionSource>();
+            var config = new UpgradeAssistantConfiguration();
+            var expected = config with { Extensions = ImmutableArray.Create(extension) };
+
+            mock.Mock<IUpgradeAssistantConfigurationLoader>().Setup(l => l.LoadAsync(default)).ReturnsAsync(config);
+
+            // Act
+            await mock.Create<ExtensionManager>().AddAsync(extension, default).ConfigureAwait(false);
+
+            // Assert
+            mock.Mock<IUpgradeAssistantConfigurationLoader>().Setup(l => l.SaveAsync(expected, default));
+        }
+
+        [Fact]
+        public async Task RemoveExtensionIsRemoved()
+        {
+            // Arrange
+            using var mock = AutoMock.GetLoose();
+
+            var extension = _fixture.Create<ExtensionSource>();
+            var config = new UpgradeAssistantConfiguration { Extensions = ImmutableArray.Create(extension) };
+            var expected = config with { Extensions = config.Extensions.Remove(extension) };
+
+            mock.Mock<IUpgradeAssistantConfigurationLoader>().Setup(l => l.LoadAsync(default)).ReturnsAsync(config);
+
+            // Act
+            var result = await mock.Create<ExtensionManager>().RemoveAsync(extension.Name, default).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(result);
+            mock.Mock<IUpgradeAssistantConfigurationLoader>().Setup(l => l.SaveAsync(expected, default));
+        }
+
+        [Fact]
+        public async Task UpdateIsNotUpdated()
+        {
+            // Arrange
+            using var mock = AutoMock.GetLoose();
+
+            var extension = _fixture.Create<ExtensionSource>();
+            var config = new UpgradeAssistantConfiguration { Extensions = ImmutableArray.Create(extension) };
+            var expected = config with { Extensions = config.Extensions.Remove(extension) };
+
+            mock.Mock<IUpgradeAssistantConfigurationLoader>().Setup(l => l.LoadAsync(default)).ReturnsAsync(config);
+
+            // Act
+            var result = await mock.Create<ExtensionManager>().UpdateAsync(extension.Name, default).ConfigureAwait(false);
+
+            // Assert
+            Assert.Null(result);
+            mock.Mock<IUpgradeAssistantConfigurationLoader>().Setup(l => l.SaveAsync(expected, default));
+        }
+    }
+}


### PR DESCRIPTION
This change adds a config file for Upgrade Assistant that can hold items
that are expected to be persisted, starting with extensions. The file created will look like this:

```
upgrade-assistant.json:

{
  "Extensions": [
    {
      "Name": "test",
      "Source": "https://api.nuget.org/v3/index.json",
      "Version": null
    }
  ]
}
```

The values of `source`/`version`  will be validated/etc in a subsequent PR

Fixes #710 