### PR TITLE
Move TFM selector filters to proper extensions

### DIFF
--- a/Microsoft.DotNet.UpgradeAssistant.sln
+++ b/Microsoft.DotNet.UpgradeAssistant.sln
@@ -154,13 +154,21 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "maui", "maui", "{E3725E02-C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui", "src\extensions\maui\Microsoft.DotNet.UpgradeAssistant.Extensions.Maui\Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.csproj", "{A122DD5B-4B80-4558-8DB2-8E9EBFF12A1A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.UpgradeAssistant.Analysis", "src\components\Microsoft.DotNet.UpgradeAssistant.Analysis\Microsoft.DotNet.UpgradeAssistant.Analysis.csproj", "{B5B6D54F-7782-4CAC-AB13-48619B40465B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.UpgradeAssistant.Analysis", "src\components\Microsoft.DotNet.UpgradeAssistant.Analysis\Microsoft.DotNet.UpgradeAssistant.Analysis.csproj", "{B5B6D54F-7782-4CAC-AB13-48619B40465B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "eng", "eng", "{6D0B9445-40A2-48E6-9F04-A83EA207CC3C}"
 EndProject
 Project("{F088123C-0E9E-452A-89E6-6BA2F21D5CAC}") = "DependencyValidation", "eng\DependencyValidation\DependencyValidation.modelproj", "{7EE540F0-2904-4306-BF35-842F3D654F25}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal", "src\common\Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal\Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal.csproj", "{C1AA58AF-224E-428A-8A27-BC8BB18F2E2E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "windows", "windows", "{1D8A46E6-D0C5-429A-A7B6-8F1BE9551AD7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.UpgradeAssistant.Extensions.Windows", "src\extensions\windows\Microsoft.DotNet.UpgradeAssistant.Extensions.Windows\Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.csproj", "{69B55184-9DB6-4492-9501-E54207F4BED7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "windows", "windows", "{98B57945-2141-4880-B6C2-51B44C67E300}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.Tests", "tests\extensions\windows\Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.Tests.csproj", "{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -700,6 +708,30 @@ Global
 		{C1AA58AF-224E-428A-8A27-BC8BB18F2E2E}.Release|x64.Build.0 = Release|Any CPU
 		{C1AA58AF-224E-428A-8A27-BC8BB18F2E2E}.Release|x86.ActiveCfg = Release|Any CPU
 		{C1AA58AF-224E-428A-8A27-BC8BB18F2E2E}.Release|x86.Build.0 = Release|Any CPU
+		{69B55184-9DB6-4492-9501-E54207F4BED7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69B55184-9DB6-4492-9501-E54207F4BED7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69B55184-9DB6-4492-9501-E54207F4BED7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{69B55184-9DB6-4492-9501-E54207F4BED7}.Debug|x64.Build.0 = Debug|Any CPU
+		{69B55184-9DB6-4492-9501-E54207F4BED7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{69B55184-9DB6-4492-9501-E54207F4BED7}.Debug|x86.Build.0 = Debug|Any CPU
+		{69B55184-9DB6-4492-9501-E54207F4BED7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69B55184-9DB6-4492-9501-E54207F4BED7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69B55184-9DB6-4492-9501-E54207F4BED7}.Release|x64.ActiveCfg = Release|Any CPU
+		{69B55184-9DB6-4492-9501-E54207F4BED7}.Release|x64.Build.0 = Release|Any CPU
+		{69B55184-9DB6-4492-9501-E54207F4BED7}.Release|x86.ActiveCfg = Release|Any CPU
+		{69B55184-9DB6-4492-9501-E54207F4BED7}.Release|x86.Build.0 = Release|Any CPU
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}.Debug|x64.Build.0 = Debug|Any CPU
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}.Debug|x86.Build.0 = Debug|Any CPU
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}.Release|x64.ActiveCfg = Release|Any CPU
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}.Release|x64.Build.0 = Release|Any CPU
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}.Release|x86.ActiveCfg = Release|Any CPU
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -768,6 +800,10 @@ Global
 		{B5B6D54F-7782-4CAC-AB13-48619B40465B} = {28247E7B-243D-4901-B26A-7A7615EBADDC}
 		{7EE540F0-2904-4306-BF35-842F3D654F25} = {6D0B9445-40A2-48E6-9F04-A83EA207CC3C}
 		{C1AA58AF-224E-428A-8A27-BC8BB18F2E2E} = {DF2E1ED9-DC44-4DD4-B6A1-165304E88118}
+		{1D8A46E6-D0C5-429A-A7B6-8F1BE9551AD7} = {AA22EE67-3BBE-49A2-8868-531FE68FE162}
+		{69B55184-9DB6-4492-9501-E54207F4BED7} = {1D8A46E6-D0C5-429A-A7B6-8F1BE9551AD7}
+		{98B57945-2141-4880-B6C2-51B44C67E300} = {82BC0AAB-94CA-4D5B-BF95-F7329D1150CB}
+		{025C3A17-0FBB-4B5E-9386-6A5E979FAA56} = {98B57945-2141-4880-B6C2-51B44C67E300}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D02F665B-C14D-43C2-955C-9338A23836E0}

--- a/eng/DependencyValidation/DependencyValidation.modelproj
+++ b/eng/DependencyValidation/DependencyValidation.modelproj
@@ -118,6 +118,10 @@
       <Name>Microsoft.DotNet.UpgradeAssistant.Steps.Razor</Name>
       <Project>{117fff7e-019e-400e-9f51-a4f7f9f3195d}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\extensions\windows\Microsoft.DotNet.UpgradeAssistant.Extensions.Windows\Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.csproj">
+      <Name>Microsoft.DotNet.UpgradeAssistant.Extensions.Windows</Name>
+      <Project>{69b55184-9db6-4492-9501-e54207f4bed7}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Backup\Microsoft.DotNet.UpgradeAssistant.Steps.Backup.csproj">
       <Name>Microsoft.DotNet.UpgradeAssistant.Steps.Backup</Name>
       <Project>{7a96cca0-4d47-48c6-a889-b560048e0c16}</Project>

--- a/eng/DependencyValidation/UpgradeAssistant.layerdiagram
+++ b/eng/DependencyValidation/UpgradeAssistant.layerdiagram
@@ -215,6 +215,19 @@
             </reference>
           </references>
         </layer>
+        <layer Id="e7273546-c5b9-4a0d-adf4-7dd3c8f7bb1f" name="windows">
+          <references>
+            <reference Id="56ef7c3d-da87-420a-93f8-1ea2899143dd" name="windows">
+              <ArtifactNode Label="windows" Category="CodeSchema_Project" Id="(Assembly=../../src/extensions/windows)">
+                <Category Ref="CodeMap_SolutionFolder" />
+              </ArtifactNode>
+              <ExpandedNode Id="(Assembly=Microsoft.DotNet.UpgradeAssistant.Extensions.Windows)" Label="Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.dll" Category="CodeSchema_Assembly">
+                <Category Ref="FileSystem.Category.FileOfType.dll" />
+                <LinkCategory Ref="Represents" />
+              </ExpandedNode>
+            </reference>
+          </references>
+        </layer>
       </childLayers>
     </layer>
     <layer Id="421742ad-4313-43e3-bcee-4c01cd3c4c8c" name="Microsoft.DotNet.UpgradeAssistant.Abstractions">

--- a/eng/DependencyValidation/UpgradeAssistant.layerdiagram.layout
+++ b/eng/DependencyValidation/UpgradeAssistant.layerdiagram.layout
@@ -25,14 +25,14 @@
         </layerShape>
       </nestedChildShapes>
     </layerShape>
-    <dependencyConnector edgePoints="[(15.28125 : 5.75); (15.28125 : 7.375)]" fixedFrom="Algorithm" fixedTo="Algorithm" customColor="113, 111, 110">
+    <dependencyConnector edgePoints="[(15.28125 : 5.75); (15.28125 : 7.375)]" fixedFrom="NotFixed" fixedTo="NotFixed" customColor="113, 111, 110">
       <dependencyFromLayerToLayerMoniker Id="14d5a788-fc82-48e3-ada3-f48eae36550a" />
       <nodes>
         <layerShapeMoniker Id="8d717de7-8a7c-4613-99cc-dbb6565b9cee" />
         <layerShapeMoniker Id="b76fe73a-a7f7-42bf-aeca-470a23cddcee" />
       </nodes>
     </dependencyConnector>
-    <layerShape Id="4be49585-80f9-43a6-9897-b31e107d49a0" absoluteBounds="23.875, 3.625, 6.25, 2.125" customColor="161, 199, 231">
+    <layerShape Id="4be49585-80f9-43a6-9897-b31e107d49a0" absoluteBounds="23.875, 3.625, 6.375, 2.125" customColor="161, 199, 231">
       <layerMoniker Id="f3b3ff24-21fe-481d-811f-54467570aae6" />
       <nestedChildShapes>
         <layerShape Id="73fabb28-e4a1-4e58-bbe1-7f9a6688f74a" absoluteBounds="24.125, 4.75, 1.375, 0.5" customColor="161, 199, 231">
@@ -50,9 +50,12 @@
         <layerShape Id="bad421d0-f5e3-4965-9534-9047b5f2d562" absoluteBounds="27.875, 4, 1.875, 0.5" customColor="161, 199, 231">
           <layerMoniker Id="88cba715-32db-48a6-b460-ea07646bc60a" />
         </layerShape>
+        <layerShape Id="8a381e12-dfea-4faa-89f4-bf7f9e579667" absoluteBounds="27.875, 4.75, 1.875, 0.5" customColor="161, 199, 231">
+          <layerMoniker Id="e7273546-c5b9-4a0d-adf4-7dd3c8f7bb1f" />
+        </layerShape>
       </nestedChildShapes>
     </layerShape>
-    <dependencyConnector edgePoints="[(26.03125 : 5.75); (26.03125 : 7.375)]" fixedFrom="Algorithm" fixedTo="Algorithm" customColor="113, 111, 110">
+    <dependencyConnector edgePoints="[(27.09375 : 5.75); (27.09375 : 7.375)]" fixedFrom="Algorithm" fixedTo="Algorithm" customColor="113, 111, 110">
       <dependencyFromLayerToLayerMoniker Id="153f1107-fc9d-4101-843e-a911901b91e4" />
       <nodes>
         <layerShapeMoniker Id="4be49585-80f9-43a6-9897-b31e107d49a0" />
@@ -69,7 +72,7 @@
     <layerShape Id="291a0e27-c527-4a0a-89a7-4ac0551a6ec2" absoluteBounds="10.875, 2.25, 18.375, 0.75" customColor="161, 199, 231">
       <layerMoniker Id="39756952-3e40-4123-a0c0-bb48018fb60a" />
     </layerShape>
-    <dependencyConnector edgePoints="[(11.46875 : 3); (11.46875 : 7.375)]" fixedFrom="Algorithm" fixedTo="Algorithm" customColor="113, 111, 110">
+    <dependencyConnector edgePoints="[(11.46875 : 3); (11.46875 : 7.375)]" fixedFrom="NotFixed" fixedTo="NotFixed" customColor="113, 111, 110">
       <dependencyFromLayerToLayerMoniker Id="b22e3ba2-3b6f-41c0-b481-589da3a385e5" />
       <nodes>
         <layerShapeMoniker Id="291a0e27-c527-4a0a-89a7-4ac0551a6ec2" />
@@ -86,7 +89,7 @@
     <layerShape Id="936f240c-a956-4a13-a4c1-f7405040ccc5" absoluteBounds="29.5, 2.25, 2, 0.75" customColor="161, 199, 231">
       <layerMoniker Id="a9443ba7-6840-4dd8-82e8-ae589e769244" />
     </layerShape>
-    <dependencyConnector edgePoints="[(30.5 : 3); (30.5 : 7.375)]" fixedFrom="Algorithm" fixedTo="Algorithm" customColor="113, 111, 110">
+    <dependencyConnector edgePoints="[(30.90625 : 3); (30.90625 : 7.375)]" fixedFrom="Algorithm" fixedTo="Algorithm" customColor="113, 111, 110">
       <dependencyFromLayerToLayerMoniker Id="6ef70d28-03de-4271-98c8-5dcc00559617" />
       <nodes>
         <layerShapeMoniker Id="936f240c-a956-4a13-a4c1-f7405040ccc5" />
@@ -110,14 +113,14 @@
     <layerShape Id="e78c1014-0b86-46de-873d-5d087cf4a0e6" absoluteBounds="18.5, 6.5, 5.375, 0.375" customColor="161, 199, 231">
       <layerMoniker Id="87aac048-b443-4d5c-bd87-162b1ff74794" />
     </layerShape>
-    <dependencyConnector edgePoints="[(20.8125 : 5.75); (20.8125 : 6.5)]" fixedFrom="Algorithm" fixedTo="Algorithm" customColor="113, 111, 110">
+    <dependencyConnector edgePoints="[(20.8125 : 5.75); (20.8125 : 6.5)]" fixedFrom="NotFixed" fixedTo="NotFixed" customColor="113, 111, 110">
       <dependencyFromLayerToLayerMoniker Id="ca5beb93-d957-49cb-908d-e10527cbe7e4" />
       <nodes>
         <layerShapeMoniker Id="8d717de7-8a7c-4613-99cc-dbb6565b9cee" />
         <layerShapeMoniker Id="e78c1014-0b86-46de-873d-5d087cf4a0e6" />
       </nodes>
     </dependencyConnector>
-    <dependencyConnector edgePoints="[(18.625 : 4.1875); (19.125 : 4.1875)]" fixedFrom="Algorithm" fixedTo="Algorithm" customColor="113, 111, 110">
+    <dependencyConnector edgePoints="[(18.625 : 4.1875); (19.125 : 4.1875)]" fixedFrom="NotFixed" fixedTo="NotFixed" customColor="113, 111, 110">
       <dependencyFromLayerToLayerMoniker Id="14b2369b-4543-47d6-a84f-d3bf816a66d4" />
       <nodes>
         <layerShapeMoniker Id="7a1994a4-773e-44a3-b34f-d4a357dac6e7" />

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Microsoft.DotNet.UpgradeAssistant.Cli.csproj
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Microsoft.DotNet.UpgradeAssistant.Cli.csproj
@@ -105,6 +105,9 @@
     <Extension Include="..\..\extensions\maui\Microsoft.DotNet.UpgradeAssistant.Extensions.Maui\Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.csproj">
       <Name>maui</Name>
     </Extension>
+    <Extension Include="..\..\extensions\windows\Microsoft.DotNet.UpgradeAssistant.Extensions.Windows\Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.csproj">
+      <Name>windows</Name>
+    </Extension>
   </ItemGroup>
   <ItemGroup>
     <Compile Update="LocalizedStrings.Designer.cs">

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/appsettings.json
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/appsettings.json
@@ -16,6 +16,7 @@
     "default",
     "vb",
     "web",
-    "maui"
+    "maui",
+    "windows"
   ]
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/UpgraderExtensions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/UpgraderExtensions.cs
@@ -48,8 +48,6 @@ namespace Microsoft.DotNet.UpgradeAssistant
             services.AddTransient<ITargetFrameworkSelector, TargetFrameworkSelector>();
 
             services.AddTransient<ITargetFrameworkSelectorFilter, DependencyMinimumTargetFrameworkSelectorFilter>();
-            services.AddTransient<ITargetFrameworkSelectorFilter, WebProjectTargetFrameworkSelectorFilter>();
-            services.AddTransient<ITargetFrameworkSelectorFilter, WindowsSdkTargetFrameworkSelectorFilter>();
             services.AddTransient<ITargetFrameworkSelectorFilter, ExecutableTargetFrameworkSelectorFilter>();
         }
     }

--- a/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/WebExtension.cs
+++ b/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/WebExtension.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web
 
             services.Services.AddTransient<IDependencyAnalyzer, NewtonsoftReferenceAnalyzer>();
             services.Services.AddScoped<IUpdater<ConfigFile>, WebNamespaceConfigUpdater>();
+            services.Services.AddTransient<ITargetFrameworkSelectorFilter, WebProjectTargetFrameworkSelectorFilter>();
             services.Services.AddRazorUpdaterStep();
         }
     }

--- a/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/WebProjectTargetFrameworkSelectorFilter.cs
+++ b/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/WebProjectTargetFrameworkSelectorFilter.cs
@@ -4,7 +4,7 @@
 using System;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.DotNet.UpgradeAssistant.TargetFramework
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web
 {
     public class WebProjectTargetFrameworkSelectorFilter : ITargetFrameworkSelectorFilter
     {
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.TargetFramework
         {
             if (tfm is null)
             {
-                throw new System.ArgumentNullException(nameof(tfm));
+                throw new ArgumentNullException(nameof(tfm));
             }
 
             if (tfm.Components.HasFlag(ProjectComponents.AspNet) || tfm.Components.HasFlag(ProjectComponents.AspNetCore))

--- a/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/ExtensionManifest.json
+++ b/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/ExtensionManifest.json
@@ -1,0 +1,7 @@
+﻿{
+  "ExtensionName": "windows",
+
+  "ExtensionServiceProviders": [
+    "Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.dll"
+  ]
+}

--- a/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.csproj
+++ b/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\common\Microsoft.DotNet.UpgradeAssistant.Abstractions\Microsoft.DotNet.UpgradeAssistant.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="ExtensionManifest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/WindowsSdkTargetFrameworkSelectorFilter.cs
+++ b/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/WindowsSdkTargetFrameworkSelectorFilter.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.DotNet.UpgradeAssistant.TargetFramework
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Windows
 {
     public class WindowsSdkTargetFrameworkSelectorFilter : ITargetFrameworkSelectorFilter
     {
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.TargetFramework
         {
             if (tfm is null)
             {
-                throw new System.ArgumentNullException(nameof(tfm));
+                throw new ArgumentNullException(nameof(tfm));
             }
 
             if (TryGetMoniker(tfm, out var result))

--- a/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/WindowsServiceProvider.cs
+++ b/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/WindowsServiceProvider.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Windows
+{
+    public class WindowsServiceProvider : IExtensionServiceProvider
+    {
+        public void AddServices(IExtensionServiceCollection services)
+        {
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.Services.AddTransient<ITargetFrameworkSelectorFilter, WindowsSdkTargetFrameworkSelectorFilter>();
+        }
+    }
+}

--- a/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests/WebProjectTargetFrameworkSelectorFilterTests.cs
+++ b/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests/WebProjectTargetFrameworkSelectorFilterTests.cs
@@ -3,11 +3,10 @@
 
 using Autofac.Extras.Moq;
 using AutoFixture;
-using Microsoft.DotNet.UpgradeAssistant.TargetFramework;
 using Moq;
 using Xunit;
 
-namespace Microsoft.DotNet.UpgradeAssistant.Tests
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests
 {
     public class WebProjectTargetFrameworkSelectorFilterTests
     {

--- a/tests/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.Tests.csproj
+++ b/tests/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsUnitTestProject>true</IsUnitTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Autofac.Extras.Moq">
+      <Version>6.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+      <Version>3.0.2</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\common\Microsoft.DotNet.UpgradeAssistant.Abstractions\Microsoft.DotNet.UpgradeAssistant.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\extensions\windows\Microsoft.DotNet.UpgradeAssistant.Extensions.Windows\Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.csproj" />
+    <ProjectReference Include="..\..\Microsoft.DotNet.UpgradeAssistant.TestHelpers\Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/extensions/windows/WindowsSdkTargetFrameworkSelectorFilterTests.cs
+++ b/tests/extensions/windows/WindowsSdkTargetFrameworkSelectorFilterTests.cs
@@ -3,13 +3,14 @@
 
 using Autofac.Extras.Moq;
 using AutoFixture;
+using Microsoft.DotNet.UpgradeAssistant.Extensions.Windows;
 using Microsoft.DotNet.UpgradeAssistant.TargetFramework;
 using Moq;
 using Xunit;
 
 using static Microsoft.DotNet.UpgradeAssistant.TargetFrameworkMonikerParser;
 
-namespace Microsoft.DotNet.UpgradeAssistant.Tests
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.Tests
 {
     public class WindowsSdkTargetFrameworkSelectorFilterTests
     {


### PR DESCRIPTION
This change does a couple of things:

- Creates an extension for `windows` specific actions (ie uwp/winforms/wpf)
- Moves the TFM selector filters to extensions when that makes sense