### PR TITLE
Reference test packages in Directory.Build.targets

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <ValidateLayerDiagram>false</ValidateLayerDiagram>
     <NoWarn>$(NoWarn);CA1062</NoWarn>
+    <IsPackable>false</IsPackable>
+    <IsUnitTestProject>true</IsUnitTestProject>
   </PropertyGroup>
 
 </Project>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -2,6 +2,14 @@
 
   <ItemGroup>
     <PackageReference Include="Autofixture" Version="4.15.0" />
+    <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="Autofac.Extras.Moq" Version="6.0.0" />
+
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+      <Version>3.0.2</Version>
+    </PackageReference>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />

--- a/tests/Microsoft.DotNet.UpgradeAssistant.TestHelpers/Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj
+++ b/tests/Microsoft.DotNet.UpgradeAssistant.TestHelpers/Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.UpgradeAssistant</RootNamespace>
+    <IsUnitTestProject>false</IsUnitTestProject>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\common\Microsoft.DotNet.UpgradeAssistant.Abstractions\Microsoft.DotNet.UpgradeAssistant.Abstractions.csproj" />

--- a/tests/Microsoft.DotNet.UpgradeAssistant.TestHelpers/Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj
+++ b/tests/Microsoft.DotNet.UpgradeAssistant.TestHelpers/Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj
@@ -4,11 +4,6 @@
     <RootNamespace>Microsoft.DotNet.UpgradeAssistant</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq">
-      <Version>6.0.0</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\common\Microsoft.DotNet.UpgradeAssistant.Abstractions\Microsoft.DotNet.UpgradeAssistant.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\components\Microsoft.DotNet.UpgradeAssistant.MSBuild\Microsoft.DotNet.UpgradeAssistant.MSBuild.csproj" />
   </ItemGroup>

--- a/tests/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Tests/Microsoft.DotNet.UpgradeAssistant.Abstractions.Tests.csproj
+++ b/tests/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Tests/Microsoft.DotNet.UpgradeAssistant.Abstractions.Tests.csproj
@@ -1,22 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Moq">
-      <Version>4.16.0</Version>
-    </PackageReference>
-    <PackageReference Include="AutoFixture">
-      <Version>4.15.0</Version>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\extensions\default\analyzers\Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CodeFixes\Microsoft.DotNet.UpgradeAssistant.Extensions.Default.CodeFixes.csproj" />
     <ProjectReference Include="..\..\Microsoft.DotNet.UpgradeAssistant.TestHelpers\Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj" />

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Extensions.Tests/Microsoft.DotNet.UpgradeAssistant.Extensions.Tests.csproj
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Extensions.Tests/Microsoft.DotNet.UpgradeAssistant.Extensions.Tests.csproj
@@ -1,18 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <IsUnitTestProject>true</IsUnitTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\..\src\components\Microsoft.DotNet.UpgradeAssistant.Extensions\Microsoft.DotNet.UpgradeAssistant.Extensions.csproj" />
-    <ProjectReference Include="..\..\Microsoft.DotNet.UpgradeAssistant.TestHelpers\Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests.csproj
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests/Microsoft.DotNet.UpgradeAssistant.MSBuild.Tests.csproj
@@ -1,22 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Moq">
-      <Version>4.16.0</Version>
-    </PackageReference>
-    <PackageReference Include="AutoFixture">
-      <Version>4.15.0</Version>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\components\Microsoft.DotNet.UpgradeAssistant\Microsoft.DotNet.UpgradeAssistant.csproj" />
     <ProjectReference Include="..\..\..\src\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Packages\Microsoft.DotNet.UpgradeAssistant.Steps.Packages.csproj" />

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/Microsoft.DotNet.UpgradeAssistant.Tests.csproj
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/Microsoft.DotNet.UpgradeAssistant.Tests.csproj
@@ -1,16 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <IsUnitTestProject>true</IsUnitTestProject>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\components\Microsoft.DotNet.UpgradeAssistant\Microsoft.DotNet.UpgradeAssistant.csproj" />
     <ProjectReference Include="..\..\Microsoft.DotNet.UpgradeAssistant.TestHelpers\Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj" />

--- a/tests/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic.Tests/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic.Tests.csproj
+++ b/tests/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic.Tests/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic.Tests.csproj
@@ -1,20 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <IsUnitTestProject>true</IsUnitTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq">
-      <Version>6.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\extensions\vb\Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic\Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic.csproj" />
+    <ProjectReference Include="..\..\..\Microsoft.DotNet.UpgradeAssistant.TestHelpers\Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests.csproj
+++ b/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests.csproj
@@ -1,18 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsUnitTestProject>true</IsUnitTestProject>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq">
-      <Version>6.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\extensions\web\Microsoft.DotNet.UpgradeAssistant.Extensions.Web\Microsoft.DotNet.UpgradeAssistant.Extensions.Web.csproj" />
     <ProjectReference Include="..\..\..\Microsoft.DotNet.UpgradeAssistant.TestHelpers\Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj" />

--- a/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Steps.Razor.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Razor.Tests.csproj
+++ b/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Steps.Razor.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Razor.Tests.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsTestProject>true</IsTestProject>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="**/*.cshtml" />
@@ -18,19 +16,6 @@
     <Content Include="MappedSubTextTestData.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq">
-      <Version>6.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="AutoFixture">
-      <Version>4.15.0</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\extensions\web\Microsoft.DotNet.UpgradeAssistant.Steps.Razor\Microsoft.DotNet.UpgradeAssistant.Steps.Razor.csproj" />

--- a/tests/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.Tests.csproj
+++ b/tests/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.Tests.csproj
@@ -1,20 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsUnitTestProject>true</IsUnitTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq">
-      <Version>6.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\common\Microsoft.DotNet.UpgradeAssistant.Abstractions\Microsoft.DotNet.UpgradeAssistant.Abstractions.csproj" />
     <ProjectReference Include="..\..\..\src\extensions\windows\Microsoft.DotNet.UpgradeAssistant.Extensions.Windows\Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.csproj" />
     <ProjectReference Include="..\..\Microsoft.DotNet.UpgradeAssistant.TestHelpers\Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj" />
   </ItemGroup>

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Backup.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Backup.Tests.csproj
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Backup.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Backup.Tests.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsTestProject>true</IsTestProject>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="TestAssets/**/*.*">
@@ -17,19 +15,6 @@
     <None Remove="TestAssets\B.backup\B.0\upgrade.backup" />
     <None Remove="TestAssets\B.backup\B\B.txt" />
     <None Remove="TestAssets\B\Project1\B.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq">
-      <Version>6.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="AutoFixture">
-      <Version>4.15.0</Version>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Backup\Microsoft.DotNet.UpgradeAssistant.Steps.Backup.csproj" />

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests.csproj
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.Tests.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsTestProject>true</IsTestProject>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="TestConfig.xml" />
@@ -11,21 +9,6 @@
     <Content Include="TestConfig.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq">
-      <Version>6.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="AutoFixture">
-      <Version>4.15.0</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Configuration\Microsoft.DotNet.UpgradeAssistant.Steps.Configuration.csproj" />

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests.csproj
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Tests.csproj
@@ -1,24 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsTestProject>true</IsTestProject>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq">
-      <Version>6.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="AutoFixture">
-      <Version>4.15.0</Version>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Packages\Microsoft.DotNet.UpgradeAssistant.Steps.Packages.csproj" />
   </ItemGroup>

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.Tests.csproj
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.Tests.csproj
@@ -1,21 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="AutoFixture">
-      <Version>4.15.0</Version>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\steps\Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat\Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.csproj" />
     <ProjectReference Include="..\..\Microsoft.DotNet.UpgradeAssistant.TestHelpers\Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj" />

--- a/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Solution.Tests.csproj
+++ b/tests/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Solution.Tests/Microsoft.DotNet.UpgradeAssistant.Steps.Solution.Tests.csproj
@@ -1,21 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="AutoFixture">
-      <Version>4.15.0</Version>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\steps\Microsoft.DotNet.UpgradeAssistant.Steps.Solution\Microsoft.DotNet.UpgradeAssistant.Steps.Solution.csproj" />
     <ProjectReference Include="..\..\Microsoft.DotNet.UpgradeAssistant.TestHelpers\Microsoft.DotNet.UpgradeAssistant.TestHelpers.csproj" />

--- a/tests/tool/Integration.Tests/Integration.Tests.csproj
+++ b/tests/tool/Integration.Tests/Integration.Tests.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <IsUnitTestProject>true</IsUnitTestProject>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="IntegrationScenarios\**" />
@@ -11,13 +9,6 @@
     <Content Include="IntegrationScenarios\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-      <Version>3.0.2</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\cli\Microsoft.DotNet.UpgradeAssistant.Cli\Microsoft.DotNet.UpgradeAssistant.Cli.csproj" />


### PR DESCRIPTION
This change moves all PackageReferences for test utilities to the Directory.Build.targets. This will ensure all tests have the same mocking/fixture/etc library.