### PR TITLE
Pass through package analysis warnings to analysis report

### DIFF
--- a/shared/Common/SR.cs
+++ b/shared/Common/SR.cs
@@ -7,5 +7,8 @@ namespace System
     {
         public static string Format(string str, object? arg0)
             => string.Format(System.Globalization.CultureInfo.InvariantCulture, str, arg0);
+
+        public static string Format(string str, object? arg0, object? arg1, object? arg2)
+            => string.Format(System.Globalization.CultureInfo.InvariantCulture, str, arg0, arg1, arg2);
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/AnalyzeResult.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/AnalyzeResult.cs
@@ -10,6 +10,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Analysis
     {
         public string FileLocation { get; init; } = string.Empty;
 
-        public IReadOnlyCollection<string> Results { get; init; } = Array.Empty<string>();
+        public HashSet<string> Results { get; init; } = new HashSet<string>();
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Dependencies/IDependencyCollection.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Dependencies/IDependencyCollection.cs
@@ -1,18 +1,40 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Dependencies
 {
     public interface IDependencyCollection<T> : IEnumerable<T>
     {
-        bool Add(T item, BuildBreakRisk risk = BuildBreakRisk.None);
+        bool Add(T item, OperationDetails details);
 
-        bool Remove(T item, BuildBreakRisk risk = BuildBreakRisk.None);
+        bool Remove(T item, OperationDetails details);
 
-        IReadOnlyCollection<T> Additions { get; }
+        IReadOnlyCollection<Operation<T>> Additions { get; }
 
-        IReadOnlyCollection<T> Deletions { get; }
+        IReadOnlyCollection<Operation<T>> Deletions { get; }
+    }
+
+    public record OperationDetails
+    {
+        public BuildBreakRisk Risk { get; init; } = BuildBreakRisk.None;
+
+        public IEnumerable<string> Details { get; init; } = Enumerable.Empty<string>();
+    }
+
+    public record Operation<T>
+    {
+        public Operation(T item, OperationDetails details)
+        {
+            Item = item;
+            Action = details;
+        }
+
+        public T Item { get; }
+
+        public OperationDetails Action { get; }
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Dependencies/IDependencyCollection.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Dependencies/IDependencyCollection.cs
@@ -14,11 +14,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Dependencies
 
         bool Remove(T item, OperationDetails details);
 
-        [Obsolete("Use the newer Add API", error: false)]
+        [Obsolete("This API will be removed sometime after September 1, 2021. Please refactor to use a supported overload", error: false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         bool Add(T item, BuildBreakRisk risk = BuildBreakRisk.None);
 
-        [Obsolete("Use the newer Remove API", error: false)]
+        [Obsolete("This API will be removed sometime after September 1, 2021. Please refactor to use a supported overload", error: false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         bool Remove(T item, BuildBreakRisk risk = BuildBreakRisk.None);
 
@@ -39,11 +39,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Dependencies
         public Operation(T item, OperationDetails details)
         {
             Item = item;
-            Action = details;
+            OperationDetails = details;
         }
 
         public T Item { get; }
 
-        public OperationDetails Action { get; }
+        public OperationDetails OperationDetails { get; }
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Dependencies/IDependencyCollection.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/Dependencies/IDependencyCollection.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Dependencies
@@ -12,6 +13,14 @@ namespace Microsoft.DotNet.UpgradeAssistant.Dependencies
         bool Add(T item, OperationDetails details);
 
         bool Remove(T item, OperationDetails details);
+
+        [Obsolete("Use the newer Add API", error: false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool Add(T item, BuildBreakRisk risk = BuildBreakRisk.None);
+
+        [Obsolete("Use the newer Remove API", error: false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool Remove(T item, BuildBreakRisk risk = BuildBreakRisk.None);
 
         IReadOnlyCollection<Operation<T>> Additions { get; }
 

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/NuGetReference.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/NuGetReference.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.DotNet.UpgradeAssistant
 {
@@ -18,5 +19,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
         }
 
         public string? PrivateAssets { get; set; }
+
+        public IEnumerable<string>? ActionDetails { get; set; }
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/NuGetReference.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/NuGetReference.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 
 namespace Microsoft.DotNet.UpgradeAssistant
 {

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/NuGetReference.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/NuGetReference.cs
@@ -19,7 +19,5 @@ namespace Microsoft.DotNet.UpgradeAssistant
         }
 
         public string? PrivateAssets { get; set; }
-
-        public IEnumerable<string>? ActionDetails { get; set; }
     }
 }

--- a/src/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic/MyDotAnalyzer.cs
+++ b/src/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic/MyDotAnalyzer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic
                     // 1>C:\{ProjectDir}\My Project\Settings.Designer.vb(57,10): error BC30002: Type 'Global.System.Configuration.UserScopedSettingAttribute' is not defined.
                     // 1>C:\{ProjectDir}\My Project\Settings.Designer.vb(59,10): error BC30002: Type 'Global.System.Configuration.DefaultSettingValueAttribute' is not defined.
                     _logger.LogInformation("Reference to configuration package ({SystemConfigurationPackageName}, version {SystemConfigurationPackageVersion}) needs added", SystemConfigurationPackageName, systemConfigurationPackage.Version);
-                    state.Packages.Add(systemConfigurationPackage, new());
+                    state.Packages.Add(systemConfigurationPackage, new OperationDetails());
                 }
                 else
                 {

--- a/src/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic/MyDotAnalyzer.cs
+++ b/src/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic/MyDotAnalyzer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic
                     // 1>C:\{ProjectDir}\My Project\Settings.Designer.vb(57,10): error BC30002: Type 'Global.System.Configuration.UserScopedSettingAttribute' is not defined.
                     // 1>C:\{ProjectDir}\My Project\Settings.Designer.vb(59,10): error BC30002: Type 'Global.System.Configuration.DefaultSettingValueAttribute' is not defined.
                     _logger.LogInformation("Reference to configuration package ({SystemConfigurationPackageName}, version {SystemConfigurationPackageVersion}) needs added", SystemConfigurationPackageName, systemConfigurationPackage.Version);
-                    state.Packages.Add(systemConfigurationPackage);
+                    state.Packages.Add(systemConfigurationPackage, new());
                 }
                 else
                 {

--- a/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/NewtonsoftReferenceAnalyzer.cs
+++ b/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/NewtonsoftReferenceAnalyzer.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web
                 if (newtonsoftPackage is not null)
                 {
                     _logger.LogInformation("Reference to Newtonsoft package ({NewtonsoftPackageName}, version {NewtonsoftPackageVersion}) needs added", NewtonsoftPackageName, newtonsoftPackage.Version);
-                    state.Packages.Add(newtonsoftPackage, new());
+                    state.Packages.Add(newtonsoftPackage, new OperationDetails());
                 }
                 else
                 {

--- a/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/NewtonsoftReferenceAnalyzer.cs
+++ b/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/NewtonsoftReferenceAnalyzer.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web
                 if (newtonsoftPackage is not null)
                 {
                     _logger.LogInformation("Reference to Newtonsoft package ({NewtonsoftPackageName}, version {NewtonsoftPackageVersion}) needs added", NewtonsoftPackageName, newtonsoftPackage.Version);
-                    state.Packages.Add(newtonsoftPackage);
+                    state.Packages.Add(newtonsoftPackage, new());
                 }
                 else
                 {

--- a/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/WebSdkCleanupAnalyzer.cs
+++ b/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/WebSdkCleanupAnalyzer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web
             if (aspNetCoreReference is not null)
             {
                 _logger.LogInformation("Removing framework reference Microsoft.AspNetCore.App it is already included as part of the Microsoft.NET.Sdk.Web SDK");
-                state.FrameworkReferences.Remove(aspNetCoreReference, new());
+                state.FrameworkReferences.Remove(aspNetCoreReference, new OperationDetails());
             }
 
             return Task.FromResult(state);

--- a/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/WebSdkCleanupAnalyzer.cs
+++ b/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/WebSdkCleanupAnalyzer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web
             if (aspNetCoreReference is not null)
             {
                 _logger.LogInformation("Removing framework reference Microsoft.AspNetCore.App it is already included as part of the Microsoft.NET.Sdk.Web SDK");
-                state.FrameworkReferences.Remove(aspNetCoreReference);
+                state.FrameworkReferences.Remove(aspNetCoreReference, new());
             }
 
             return Task.FromResult(state);

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/AnalyzePackageStatus.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/AnalyzePackageStatus.cs
@@ -95,20 +95,19 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
                 GetResults("Framework Reference to ", " needs to be deleted ", analysisState.FrameworkReferences.Deletions);
                 GetResults("Framework Reference to ", " needs to be added ", analysisState.FrameworkReferences.Additions);
 
-                void GetResults<T>(string name, string action, IReadOnlyCollection<T> collection)
+                void GetResults<T>(string name, string action, IReadOnlyCollection<Operation<T>> collection)
                 {
                     if (collection.Any())
                     {
                         foreach (var s in collection)
                         {
-                            var mc = s as NuGetReference;
-                            if (mc != null && mc.ActionDetails != null && mc.ActionDetails.Any() && !results.Intersect(mc.ActionDetails).Any())
+                            if (s.Action != null && s.Action.Details != null && s.Action.Details.Any() && !results.Intersect(s.Action.Details).Any())
                             {
-                                results.AddRange(mc.ActionDetails);
+                                results.AddRange(s.Action.Details);
                             }
                             else
                             {
-                                results.Add(string.Concat(name, s, action));
+                                results.Add(string.Concat(name, s.Item, action));
                             }
                         }
                     }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/AnalyzePackageStatus.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/AnalyzePackageStatus.cs
@@ -78,9 +78,9 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
             }
         }
 
-        private static IReadOnlyCollection<string> ExtractAnalysisResult(IDependencyAnalysisState? analysisState)
+        private static HashSet<string> ExtractAnalysisResult(IDependencyAnalysisState? analysisState)
         {
-            var results = new List<string>();
+            var results = new HashSet<string>();
 
             if (analysisState is null || !analysisState.AreChangesRecommended)
             {
@@ -101,9 +101,9 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
                     {
                         foreach (var s in collection)
                         {
-                            if (s.Action != null && s.Action.Details != null && s.Action.Details.Any() && !results.Intersect(s.Action.Details).Any())
+                            if (s.OperationDetails is not null && s.OperationDetails.Details is not null && s.OperationDetails.Details.Any())
                             {
-                                results.AddRange(s.Action.Details);
+                                results.UnionWith(s.OperationDetails.Details);
                             }
                             else
                             {

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/AnalyzePackageStatus.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/AnalyzePackageStatus.cs
@@ -101,7 +101,15 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
                     {
                         foreach (var s in collection)
                         {
-                            results.Add(string.Concat(name, s, action));
+                            var mc = s as NuGetReference;
+                            if (mc != null && mc.ActionDetails != null && mc.ActionDetails.Any() && !results.Intersect(mc.ActionDetails).Any())
+                            {
+                                results.AddRange(mc.ActionDetails);
+                            }
+                            else
+                            {
+                                results.Add(string.Concat(name, s, action));
+                            }
                         }
                     }
                 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/DuplicateReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/DuplicateReferenceAnalyzer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 foreach (var package in duplicates.Where(p => p != highestVersion))
                 {
                     _logger.LogInformation("Marking package {NuGetPackage} for removal because it is referenced elsewhere in the project with a higher version", package);
-                    state.Packages.Remove(package, new());
+                    state.Packages.Remove(package, new OperationDetails());
                 }
             }
 

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/DuplicateReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/DuplicateReferenceAnalyzer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 foreach (var package in duplicates.Where(p => p != highestVersion))
                 {
                     _logger.LogInformation("Marking package {NuGetPackage} for removal because it is referenced elsewhere in the project with a higher version", package);
-                    state.Packages.Remove(package);
+                    state.Packages.Remove(package, new());
                 }
             }
 

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/PackageMapReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/PackageMapReferenceAnalyzer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 foreach (var map in packageMaps.Where(m => ContainsPackageReference(m.NetFrameworkPackages, packageReference.Name, packageReference.Version)))
                 {
                     _logger.LogInformation("Marking package {PackageName} for removal based on package mapping configuration {PackageMapSet}", packageReference.Name, map.PackageSetName);
-                    state.Packages.Remove(packageReference, new() { Risk = BuildBreakRisk.Medium });
+                    state.Packages.Remove(packageReference, new OperationDetails() { Risk = BuildBreakRisk.Medium });
                     await AddNetCoreReferences(map, state, token).ConfigureAwait(false);
                 }
             }
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 foreach (var map in packageMaps.Where(m => m.ContainsAssemblyReference(reference.Name)))
                 {
                     _logger.LogInformation("Marking assembly reference {ReferenceName} for removal based on package mapping configuration {PackageMapSet}", reference.Name, map.PackageSetName);
-                    state.References.Remove(reference, new() { Risk = BuildBreakRisk.Medium });
+                    state.References.Remove(reference, new OperationDetails() { Risk = BuildBreakRisk.Medium });
                     await AddNetCoreReferences(map, state, token).ConfigureAwait(false);
                 }
             }
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                     }
                 }
 
-                if (state.Packages.Add(packageToAdd, new()))
+                if (state.Packages.Add(packageToAdd, new OperationDetails()))
                 {
                     _logger.LogInformation("Adding package {PackageName} based on package mapping configuration {PackageMapSet}", packageToAdd.Name, packageMap.PackageSetName);
                 }
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
 
             foreach (var frameworkReference in packageMap.NetCoreFrameworkReferences)
             {
-                if (state.FrameworkReferences.Add(frameworkReference, new()))
+                if (state.FrameworkReferences.Add(frameworkReference, new OperationDetails()))
                 {
                     _logger.LogInformation("Adding framework reference {FrameworkReference} based on package mapping configuration {PackageMapSet}", frameworkReference.Name, packageMap.PackageSetName);
                 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/PackageMapReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/PackageMapReferenceAnalyzer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 foreach (var map in packageMaps.Where(m => ContainsPackageReference(m.NetFrameworkPackages, packageReference.Name, packageReference.Version)))
                 {
                     _logger.LogInformation("Marking package {PackageName} for removal based on package mapping configuration {PackageMapSet}", packageReference.Name, map.PackageSetName);
-                    state.Packages.Remove(packageReference, BuildBreakRisk.Medium);
+                    state.Packages.Remove(packageReference, new() { Risk = BuildBreakRisk.Medium });
                     await AddNetCoreReferences(map, state, token).ConfigureAwait(false);
                 }
             }
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 foreach (var map in packageMaps.Where(m => m.ContainsAssemblyReference(reference.Name)))
                 {
                     _logger.LogInformation("Marking assembly reference {ReferenceName} for removal based on package mapping configuration {PackageMapSet}", reference.Name, map.PackageSetName);
-                    state.References.Remove(reference, BuildBreakRisk.Medium);
+                    state.References.Remove(reference, new() { Risk = BuildBreakRisk.Medium });
                     await AddNetCoreReferences(map, state, token).ConfigureAwait(false);
                 }
             }
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                     }
                 }
 
-                if (state.Packages.Add(packageToAdd))
+                if (state.Packages.Add(packageToAdd, new()))
                 {
                     _logger.LogInformation("Adding package {PackageName} based on package mapping configuration {PackageMapSet}", packageToAdd.Name, packageMap.PackageSetName);
                 }
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
 
             foreach (var frameworkReference in packageMap.NetCoreFrameworkReferences)
             {
-                if (state.FrameworkReferences.Add(frameworkReference))
+                if (state.FrameworkReferences.Add(frameworkReference, new()))
                 {
                     _logger.LogInformation("Adding framework reference {FrameworkReference} based on package mapping configuration {PackageMapSet}", frameworkReference.Name, packageMap.PackageSetName);
                 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TargetCompatibilityReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TargetCompatibilityReferenceAnalyzer.cs
@@ -68,19 +68,21 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
 
                         if (isMajorChange)
                         {
-                            details.Add(string.Concat("Package ", packageReference.Name, " needs to be upgraded across major versions (", packageReference.Version, " -> ", updatedReference.Version, ") which may introduce breaking changes"));
-                            _logger.LogWarning("Package {NuGetPackage} has been upgraded across major versions ({OldVersion} -> {NewVersion}) which may introduce breaking changes", packageReference.Name, packageReference.Version, updatedReference.Version);
+                            var logString = SR.Format("Package {0} needs to be upgraded across major versions ({1} -> {2}) which may introduce breaking changes", packageReference.Name, packageReference.Version, updatedReference.Version);
+                            details.Add(logString);
+                            _logger.LogWarning(logString);
                         }
 
                         if (updatedReference.IsPrerelease)
                         {
-                            details.Add(string.Concat("Package ", packageReference.Name, " needs to be upgraded to a prerelease version (", updatedReference.Version, ") because no released version supports target(s) ", string.Join(", ", state.TargetFrameworks)));
-                            _logger.LogWarning("Package {NuGetPackage} has been upgraded to a prerelease version ({NewVersion}) because no released version supports target(s) {TFM}", packageReference.Name, updatedReference.Version, string.Join(", ", state.TargetFrameworks));
+                            var logString = SR.Format("Package {0} needs to be upgraded to a prerelease version ({1}) because no released version supports target(s) {2}", packageReference.Name, updatedReference.Version, string.Join(", ", state.TargetFrameworks));
+                            details.Add(logString);
+                            _logger.LogWarning(logString);
                         }
 
                         if (!isMajorChange && !updatedReference.IsPrerelease)
                         {
-                            details.Add(string.Concat("Package ", packageReference.Name, " needs to be upgraded from ", packageReference.Version, " to ", updatedReference.Version));
+                            details.Add(SR.Format("Package {0} needs to be upgraded from {1} to {2}.", packageReference.Name, packageReference.Version, updatedReference.Version));
                         }
 
                         state.Packages.Remove(packageReference, new OperationDetails() { Risk = BuildBreakRisk.None, Details = details });

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TargetCompatibilityReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TargetCompatibilityReferenceAnalyzer.cs
@@ -83,10 +83,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                             details.Add(string.Concat("Package ", packageReference.Name, " needs to be upgraded from ", packageReference.Version, " to ", updatedReference.Version));
                         }
 
-                        updatedReference.ActionDetails = packageReference.ActionDetails = details;
-
-                        state.Packages.Remove(packageReference);
-                        state.Packages.Add(updatedReference, isMajorChange ? BuildBreakRisk.Medium : BuildBreakRisk.Low);
+                        state.Packages.Remove(packageReference, new() { Risk = BuildBreakRisk.None, Details = details });
+                        state.Packages.Add(updatedReference, new() { Risk = isMajorChange ? BuildBreakRisk.Medium : BuildBreakRisk.Low, Details = details });
                     }
                 }
             }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TargetCompatibilityReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TargetCompatibilityReferenceAnalyzer.cs
@@ -83,8 +83,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                             details.Add(string.Concat("Package ", packageReference.Name, " needs to be upgraded from ", packageReference.Version, " to ", updatedReference.Version));
                         }
 
-                        state.Packages.Remove(packageReference, new() { Risk = BuildBreakRisk.None, Details = details });
-                        state.Packages.Add(updatedReference, new() { Risk = isMajorChange ? BuildBreakRisk.Medium : BuildBreakRisk.Low, Details = details });
+                        state.Packages.Remove(packageReference, new OperationDetails() { Risk = BuildBreakRisk.None, Details = details });
+                        state.Packages.Add(updatedReference, new OperationDetails() { Risk = isMajorChange ? BuildBreakRisk.Medium : BuildBreakRisk.Low, Details = details });
                     }
                 }
             }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TargetCompatibilityReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TargetCompatibilityReferenceAnalyzer.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.UpgradeAssistant.Dependencies;
@@ -53,6 +55,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                     // If the package won't work on the target Framework, check newer versions of the package
                     var newerVersions = await _packageLoader.GetNewerVersionsAsync(packageReference, state.TargetFrameworks, new() { LatestMinorAndBuildOnly = true }, token).ConfigureAwait(false);
                     var updatedReference = newerVersions.FirstOrDefault();
+                    var details = new List<string>();
 
                     if (updatedReference == null)
                     {
@@ -65,13 +68,22 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
 
                         if (isMajorChange)
                         {
+                            details.Add(string.Concat("Package ", packageReference.Name, " needs to be upgraded across major versions (", packageReference.Version, " -> ", updatedReference.Version, ") which may introduce breaking changes"));
                             _logger.LogWarning("Package {NuGetPackage} has been upgraded across major versions ({OldVersion} -> {NewVersion}) which may introduce breaking changes", packageReference.Name, packageReference.Version, updatedReference.Version);
                         }
 
                         if (updatedReference.IsPrerelease)
                         {
+                            details.Add(string.Concat("Package ", packageReference.Name, " needs to be upgraded to a prerelease version (", updatedReference.Version, ") because no released version supports target(s) ", string.Join(", ", state.TargetFrameworks)));
                             _logger.LogWarning("Package {NuGetPackage} has been upgraded to a prerelease version ({NewVersion}) because no released version supports target(s) {TFM}", packageReference.Name, updatedReference.Version, string.Join(", ", state.TargetFrameworks));
                         }
+
+                        if (!isMajorChange && !updatedReference.IsPrerelease)
+                        {
+                            details.Add(string.Concat("Package ", packageReference.Name, " needs to be upgraded from ", packageReference.Version, " to ", updatedReference.Version));
+                        }
+
+                        updatedReference.ActionDetails = packageReference.ActionDetails = details;
 
                         state.Packages.Remove(packageReference);
                         state.Packages.Add(updatedReference, isMajorChange ? BuildBreakRisk.Medium : BuildBreakRisk.Low);

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TransitiveReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TransitiveReferenceAnalyzer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 if (await project.NuGetReferences.IsTransitiveDependencyAsync(packageReference, token).ConfigureAwait(false))
                 {
                     _logger.LogInformation("Marking package {PackageName} for removal because it appears to be a transitive dependency", packageReference.Name);
-                    state.Packages.Remove(packageReference, new());
+                    state.Packages.Remove(packageReference, new OperationDetails());
                 }
             }
         }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TransitiveReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/TransitiveReferenceAnalyzer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 if (await project.NuGetReferences.IsTransitiveDependencyAsync(packageReference, token).ConfigureAwait(false))
                 {
                     _logger.LogInformation("Marking package {PackageName} for removal because it appears to be a transitive dependency", packageReference.Name);
-                    state.Packages.Remove(packageReference);
+                    state.Packages.Remove(packageReference, new());
                 }
             }
         }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/UpgradeAssistantReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/UpgradeAssistantReferenceAnalyzer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 if (analyzerPackage is not null)
                 {
                     _logger.LogInformation("Reference to .NET Upgrade Assistant analyzer package ({AnalyzerPackageName}, version {AnalyzerPackageVersion}) needs added", AnalyzerPackageName, analyzerPackage.Version);
-                    state.Packages.Add(analyzerPackage with { PrivateAssets = "all" }, new());
+                    state.Packages.Add(analyzerPackage with { PrivateAssets = "all" }, new OperationDetails());
                 }
                 else
                 {

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/UpgradeAssistantReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/UpgradeAssistantReferenceAnalyzer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                 if (analyzerPackage is not null)
                 {
                     _logger.LogInformation("Reference to .NET Upgrade Assistant analyzer package ({AnalyzerPackageName}, version {AnalyzerPackageVersion}) needs added", AnalyzerPackageName, analyzerPackage.Version);
-                    state.Packages.Add(analyzerPackage with { PrivateAssets = "all" });
+                    state.Packages.Add(analyzerPackage with { PrivateAssets = "all" }, new());
                 }
                 else
                 {

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/WindowsCompatReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/WindowsCompatReferenceAnalyzer.cs
@@ -68,12 +68,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                     return;
                 }
 
-                state.Packages.Remove(existing);
+                state.Packages.Remove(existing, new());
             }
 
             _logger.LogInformation("Adding {PackageName} {Version}", PackageName, latestVersion.Version);
 
-            state.Packages.Add(new NuGetReference(PackageName, latestVersion.Version));
+            state.Packages.Add(new NuGetReference(PackageName, latestVersion.Version), new());
         }
     }
 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/WindowsCompatReferenceAnalyzer.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/Analyzers/WindowsCompatReferenceAnalyzer.cs
@@ -68,12 +68,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages.Analyzers
                     return;
                 }
 
-                state.Packages.Remove(existing, new());
+                state.Packages.Remove(existing, new OperationDetails());
             }
 
             _logger.LogInformation("Adding {PackageName} {Version}", PackageName, latestVersion.Version);
 
-            state.Packages.Add(new NuGetReference(PackageName, latestVersion.Version), new());
+            state.Packages.Add(new NuGetReference(PackageName, latestVersion.Version), new OperationDetails());
         }
     }
 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/DependencyCollection{T}.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/DependencyCollection{T}.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
             return false;
         }
 
-        bool IDependencyCollection<T>.Add(T item, OperationDetails od)
+        public bool Add(T item, OperationDetails od)
         {
             var operation = new Operation<T>(item, od);
 
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
             return false;
         }
 
-        bool IDependencyCollection<T>.Remove(T item, OperationDetails od)
+        public bool Remove(T item, OperationDetails od)
         {
             var operation = new Operation<T>(item, od);
 
@@ -89,42 +89,18 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        [Obsolete("Use the newer Add API", error: false)]
+        [Obsolete("This API will be removed sometime after September 1, 2021. Please refactor to use a supported overload", error: false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         bool IDependencyCollection<T>.Add(T item, BuildBreakRisk risk)
         {
-            var operation = new Operation<T>(item, new() { Risk = risk });
-            if (Contains(item))
-            {
-                return false;
-            }
-
-            if (Additions.Add(operation))
-            {
-                _setRisk(operation.Action.Risk);
-                return true;
-            }
-
-            return false;
+            return Add(item, new() { Risk = risk });
         }
 
-        [Obsolete("Use the newer Remove API", error: false)]
+        [Obsolete("This API will be removed sometime after September 1, 2021. Please refactor to use a supported overload", error: false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         bool IDependencyCollection<T>.Remove(T item, BuildBreakRisk risk)
         {
-            var operation = new Operation<T>(item, new() { Risk = risk });
-            if (!Contains(item))
-            {
-                return false;
-            }
-
-            if (Deletions.Add(operation))
-            {
-                _setRisk(operation.Action.Risk);
-                return true;
-            }
-
-            return false;
+            return Remove(item, new() { Risk = risk });
         }
 
         public bool HasChanges => Additions.Any() || Deletions.Any();

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/DependencyCollection{T}.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/DependencyCollection{T}.cs
@@ -11,45 +11,59 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
 {
     internal class DependencyCollection<T> : IDependencyCollection<T>
     {
-        private readonly IEnumerable<T> _initial;
+        private readonly IEnumerable<Operation<T>> _initial;
         private readonly Action<BuildBreakRisk> _setRisk;
 
         public DependencyCollection(IEnumerable<T> initial, Action<BuildBreakRisk> setRisk)
         {
-            _initial = initial;
+            _initial = initial.Select(i => new Operation<T>(i, new()));
             _setRisk = setRisk;
         }
 
-        public HashSet<T> Additions { get; } = new HashSet<T>();
+        public HashSet<Operation<T>> Additions { get; } = new HashSet<Operation<T>>();
 
-        public HashSet<T> Deletions { get; } = new HashSet<T>();
+        public HashSet<Operation<T>> Deletions { get; } = new HashSet<Operation<T>>();
 
-        bool IDependencyCollection<T>.Add(T item, BuildBreakRisk risk)
+        public bool Contains(T item)
         {
-            if (_initial.Contains(item))
+            if (_initial.Any(i => i.Item != null && i.Item.Equals(item)))
             {
-                return false;
-            }
-
-            if (Additions.Add(item))
-            {
-                _setRisk(risk);
                 return true;
             }
 
             return false;
         }
 
-        bool IDependencyCollection<T>.Remove(T item, BuildBreakRisk risk)
+        bool IDependencyCollection<T>.Add(T item, OperationDetails od)
         {
-            if (!_initial.Contains(item))
+            var operation = new Operation<T>(item, od);
+
+            if (Contains(item))
             {
                 return false;
             }
 
-            if (Deletions.Add(item))
+            if (Additions.Add(operation))
             {
-                _setRisk(risk);
+                _setRisk(od.Risk);
+                return true;
+            }
+
+            return false;
+        }
+
+        bool IDependencyCollection<T>.Remove(T item, OperationDetails od)
+        {
+            var operation = new Operation<T>(item, od);
+
+            if (!Contains(item))
+            {
+                return false;
+            }
+
+            if (Deletions.Add(operation))
+            {
+                _setRisk(od.Risk);
                 return true;
             }
 
@@ -62,22 +76,32 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
             {
                 if (!Deletions.Contains(item))
                 {
-                    yield return item;
+                    yield return item.Item;
                 }
             }
 
             foreach (var additions in Additions)
             {
-                yield return additions;
+                yield return additions.Item;
             }
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+        public bool Add(T item, OperationDetails details)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Remove(T item, OperationDetails details)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool HasChanges => Additions.Any() || Deletions.Any();
 
-        IReadOnlyCollection<T> IDependencyCollection<T>.Additions => Additions;
+        IReadOnlyCollection<Operation<T>> IDependencyCollection<T>.Additions => Additions;
 
-        IReadOnlyCollection<T> IDependencyCollection<T>.Deletions => Deletions;
+        IReadOnlyCollection<Operation<T>> IDependencyCollection<T>.Deletions => Deletions;
     }
 }

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/DependencyCollection{T}.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/DependencyCollection{T}.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Microsoft.DotNet.UpgradeAssistant.Dependencies;
 
@@ -88,14 +89,42 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public bool Add(T item, OperationDetails details)
+        [Obsolete("Use the newer Add API", error: false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool IDependencyCollection<T>.Add(T item, BuildBreakRisk risk)
         {
-            throw new NotImplementedException();
+            var operation = new Operation<T>(item, new() { Risk = risk });
+            if (Contains(item))
+            {
+                return false;
+            }
+
+            if (Additions.Add(operation))
+            {
+                _setRisk(operation.Action.Risk);
+                return true;
+            }
+
+            return false;
         }
 
-        public bool Remove(T item, OperationDetails details)
+        [Obsolete("Use the newer Remove API", error: false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool IDependencyCollection<T>.Remove(T item, BuildBreakRisk risk)
         {
-            throw new NotImplementedException();
+            var operation = new Operation<T>(item, new() { Risk = risk });
+            if (!Contains(item))
+            {
+                return false;
+            }
+
+            if (Deletions.Add(operation))
+            {
+                _setRisk(operation.Action.Risk);
+                return true;
+            }
+
+            return false;
         }
 
         public bool HasChanges => Additions.Any() || Deletions.Any();

--- a/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageUpdaterStep.cs
+++ b/src/steps/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageUpdaterStep.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.UpgradeAssistant.Dependencies;
@@ -144,13 +145,13 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
 
                     if (_analysisState is not null)
                     {
-                        projectFile.RemoveReferences(_analysisState.References.Deletions);
+                        projectFile.RemoveReferences(_analysisState.References.Deletions.Select(i => i.Item));
 
-                        projectFile.RemovePackages(_analysisState.Packages.Deletions);
-                        projectFile.AddPackages(_analysisState.Packages.Additions);
+                        projectFile.RemovePackages(_analysisState.Packages.Deletions.Select(i => i.Item));
+                        projectFile.AddPackages(_analysisState.Packages.Additions.Select(i => i.Item));
 
-                        projectFile.RemoveFrameworkReferences(_analysisState.FrameworkReferences.Deletions);
-                        projectFile.AddFrameworkReferences(_analysisState.FrameworkReferences.Additions);
+                        projectFile.RemoveFrameworkReferences(_analysisState.FrameworkReferences.Deletions.Select(i => i.Item));
+                        projectFile.AddFrameworkReferences(_analysisState.FrameworkReferences.Additions.Select(i => i.Item));
 
                         await projectFile.SaveAsync(token).ConfigureAwait(false);
                         count++;

--- a/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests/NewtonsoftReferenceAnalyzerTests.cs
+++ b/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests/NewtonsoftReferenceAnalyzerTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests
             await analyzer.AnalyzeAsync(project.Object, packageState.Object, default).ConfigureAwait(false);
 
             // Assert
-            packages.Verify(p => p.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), BuildBreakRisk.None));
+            packages.Verify(p => p.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), new() { Risk = BuildBreakRisk.None }));
             packageLoader.Verify(pl => pl.GetLatestVersionAsync(It.IsAny<string>(), It.IsAny<IEnumerable<TargetFrameworkMoniker>>(), It.IsAny<PackageSearchOptions>(), It.IsAny<CancellationToken>()),
                 Times.Once());
         }
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests
             await analyzer.AnalyzeAsync(project.Object, packageState.Object, default).ConfigureAwait(false);
 
             // Assert
-            packageState.Verify(p => p.Packages.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), BuildBreakRisk.None), Times.Never);
+            packageState.Verify(p => p.Packages.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), new() { Risk = BuildBreakRisk.None }), Times.Never);
             packageLoader.Verify(pl => pl.GetLatestVersionAsync(It.IsAny<string>(), It.IsAny<IEnumerable<TargetFrameworkMoniker>>(), It.IsAny<PackageSearchOptions>(), It.IsAny<CancellationToken>()),
                 Times.Never());
         }
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests
             await analyzer.AnalyzeAsync(project.Object, packageState.Object, default).ConfigureAwait(false);
 
             // Assert
-            packageState.Verify(p => p.Packages.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), BuildBreakRisk.None), Times.Never);
+            packageState.Verify(p => p.Packages.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), new() { Risk = BuildBreakRisk.None }), Times.Never);
             packageLoader.Verify(pl => pl.GetLatestVersionAsync(It.IsAny<string>(), It.IsAny<IEnumerable<TargetFrameworkMoniker>>(), It.IsAny<PackageSearchOptions>(), It.IsAny<CancellationToken>()),
                 Times.Never());
         }
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests
             await analyzer.AnalyzeAsync(project.Object, packageState.Object, default).ConfigureAwait(false);
 
             // Assert
-            packageState.Verify(p => p.Packages.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), BuildBreakRisk.None), Times.Never);
+            packageState.Verify(p => p.Packages.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), new() { Risk = BuildBreakRisk.None }), Times.Never);
             packageLoader.Verify(pl => pl.GetLatestVersionAsync(It.IsAny<string>(), It.IsAny<IEnumerable<TargetFrameworkMoniker>>(), It.IsAny<PackageSearchOptions>(), It.IsAny<CancellationToken>()),
                 Times.Never());
         }

--- a/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests/NewtonsoftReferenceAnalyzerTests.cs
+++ b/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests/NewtonsoftReferenceAnalyzerTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests
             await analyzer.AnalyzeAsync(project.Object, packageState.Object, default).ConfigureAwait(false);
 
             // Assert
-            packages.Verify(p => p.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), new() { Risk = BuildBreakRisk.None }));
+            packages.Verify(p => p.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), new OperationDetails() { Risk = BuildBreakRisk.None }));
             packageLoader.Verify(pl => pl.GetLatestVersionAsync(It.IsAny<string>(), It.IsAny<IEnumerable<TargetFrameworkMoniker>>(), It.IsAny<PackageSearchOptions>(), It.IsAny<CancellationToken>()),
                 Times.Once());
         }
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests
             await analyzer.AnalyzeAsync(project.Object, packageState.Object, default).ConfigureAwait(false);
 
             // Assert
-            packageState.Verify(p => p.Packages.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), new() { Risk = BuildBreakRisk.None }), Times.Never);
+            packageState.Verify(p => p.Packages.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), new OperationDetails() { Risk = BuildBreakRisk.None }), Times.Never);
             packageLoader.Verify(pl => pl.GetLatestVersionAsync(It.IsAny<string>(), It.IsAny<IEnumerable<TargetFrameworkMoniker>>(), It.IsAny<PackageSearchOptions>(), It.IsAny<CancellationToken>()),
                 Times.Never());
         }
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests
             await analyzer.AnalyzeAsync(project.Object, packageState.Object, default).ConfigureAwait(false);
 
             // Assert
-            packageState.Verify(p => p.Packages.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), new() { Risk = BuildBreakRisk.None }), Times.Never);
+            packageState.Verify(p => p.Packages.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), new OperationDetails() { Risk = BuildBreakRisk.None }), Times.Never);
             packageLoader.Verify(pl => pl.GetLatestVersionAsync(It.IsAny<string>(), It.IsAny<IEnumerable<TargetFrameworkMoniker>>(), It.IsAny<PackageSearchOptions>(), It.IsAny<CancellationToken>()),
                 Times.Never());
         }
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests
             await analyzer.AnalyzeAsync(project.Object, packageState.Object, default).ConfigureAwait(false);
 
             // Assert
-            packageState.Verify(p => p.Packages.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), new() { Risk = BuildBreakRisk.None }), Times.Never);
+            packageState.Verify(p => p.Packages.Add(new NuGetReference(NewtonsoftPackageName, NewtonsoftPackageNameVersion), new OperationDetails() { Risk = BuildBreakRisk.None }), Times.Never);
             packageLoader.Verify(pl => pl.GetLatestVersionAsync(It.IsAny<string>(), It.IsAny<IEnumerable<TargetFrameworkMoniker>>(), It.IsAny<PackageSearchOptions>(), It.IsAny<CancellationToken>()),
                 Times.Never());
         }

--- a/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests/WebSdkCleanupAnalyzerTests.cs
+++ b/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests/WebSdkCleanupAnalyzerTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests
             // Assert
             foreach (var expected in expectedReferencesToRemove)
             {
-                dependency.Verify(d => d.Remove(new Reference(expected), new() { Risk = BuildBreakRisk.None }));
+                dependency.Verify(d => d.Remove(new Reference(expected), new OperationDetails() { Risk = BuildBreakRisk.None }));
             }
         }
 

--- a/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests/WebSdkCleanupAnalyzerTests.cs
+++ b/tests/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests/WebSdkCleanupAnalyzerTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web.Tests
             // Assert
             foreach (var expected in expectedReferencesToRemove)
             {
-                dependency.Verify(d => d.Remove(new Reference(expected), BuildBreakRisk.None));
+                dependency.Verify(d => d.Remove(new Reference(expected), new() { Risk = BuildBreakRisk.None }));
             }
         }
 

--- a/tests/tool/Integration.Tests/IntegrationScenarios/PCL/Upgraded/SamplePCL.csproj
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/PCL/Upgraded/SamplePCL.csproj
@@ -4,15 +4,15 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.2.222702">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
     <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.2.222702">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
This change is to pass through the useful warnings in the `TargetCompatibilityReferenceAnalyzer` to the AnalysisReport
