### PR TITLE
Fix extension version check

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/UpgradeAssistantHostExtensions.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/UpgradeAssistantHostExtensions.cs
@@ -74,6 +74,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
                         .Configure(options =>
                         {
                             options.AdditionalOptions = upgradeOptions.AdditionalOptions;
+                            options.IsDevelopment = UpgradeVersion.Current.IsDevelopment;
                             options.CurrentVersion = UpgradeVersion.Current.Version;
 
                             foreach (var path in upgradeOptions.Extension)

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/UpgradeAssistantHostExtensions.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/UpgradeAssistantHostExtensions.cs
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
                         .Configure(options =>
                         {
                             options.AdditionalOptions = upgradeOptions.AdditionalOptions;
-                            options.IsDevelopment = UpgradeVersion.Current.IsDevelopment;
+                            options.CheckMinimumVersion = !UpgradeVersion.Current.IsDevelopment;
                             options.CurrentVersion = UpgradeVersion.Current.Version;
 
                             foreach (var path in upgradeOptions.Extension)

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/UpgradeVersion.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/UpgradeVersion.cs
@@ -32,5 +32,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
             return Version.Parse(newVersionString);
         }
+
+        public bool IsDevelopment => FullVersion.EndsWith("dev", StringComparison.Ordinal);
     }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionManager.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionManager.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
                             extension = extension with { Version = _options.CurrentVersion };
                         }
 
-                        if (!_options.IsDevelopment && extension.MinUpgradeAssistantVersion is Version minVersion && minVersion > _options.CurrentVersion)
+                        if (_options.CheckMinimumVersion && extension.MinUpgradeAssistantVersion is Version minVersion && minVersion > _options.CurrentVersion)
                         {
                             logger.LogWarning("Could not load extension from {Path}. Requires at least v{Version} of Upgrade Assistant and current version is {UpgradeAssistantVersion}.", path, minVersion, _options.CurrentVersion);
                         }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionManager.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionManager.cs
@@ -90,9 +90,9 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
                             extension = extension with { Version = _options.CurrentVersion };
                         }
 
-                        if (extension.MinUpgradeAssistantVersion is Version minVersion && minVersion < _options.CurrentVersion)
+                        if (!_options.IsDevelopment && extension.MinUpgradeAssistantVersion is Version minVersion && minVersion > _options.CurrentVersion)
                         {
-                            logger.LogWarning("Could not load extension from {Path}. Requires at least v{Version} of Upgrade Assistant.", path, minVersion);
+                            logger.LogWarning("Could not load extension from {Path}. Requires at least v{Version} of Upgrade Assistant and current version is {UpgradeAssistantVersion}.", path, minVersion, _options.CurrentVersion);
                         }
                         else
                         {

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionOptions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionOptions.cs
@@ -20,6 +20,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 
         public ICollection<ExtensionInstance> Extensions { get; } = new List<ExtensionInstance>();
 
+        public bool IsDevelopment { get; set; } = true;
+
         public Version CurrentVersion { get; set; } = null!;
 
         public bool LoadExtensions { get; set; } = true;

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionOptions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 
         public ICollection<ExtensionInstance> Extensions { get; } = new List<ExtensionInstance>();
 
-        public bool IsDevelopment { get; set; } = true;
+        public bool CheckMinimumVersion { get; set; } = true;
 
         public Version CurrentVersion { get; set; } = null!;
 


### PR DESCRIPTION
The comparison was reversed as to what actually should be checked. This change updates that so that the required minimum check works as expected, but is also bypassed on dev builds since the version number there doesn't mean as much.