### PR TITLE
Refactor extension provider to separate out loading from managing

### DIFF
--- a/Extensions.targets
+++ b/Extensions.targets
@@ -83,6 +83,7 @@
     <!-- Create a list of all assemblies included by host and framework -->
     <ItemGroup>
       <_ExcludeFromExtension Include="Microsoft.DotNet.UpgradeAssistant.Abstractions.dll" />
+      <_ExcludeFromExtension Include="Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal.dll" />
       <_ExcludeFromExtension Include="System.ComponentModel.Annotations.dll" />
       <_ExcludeFromExtension Include="System.Memory.dll" />
       <_ExcludeFromExtension Include="System.Numerics.Vectors.dll" />

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Analyze/ConsoleAnalyze.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Analyze/ConsoleAnalyze.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.UpgradeAssistant.Analysis;
 using Microsoft.DotNet.UpgradeAssistant.Extensions;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Cli
 {
@@ -16,25 +15,22 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
     {
         private readonly IUpgradeContextFactory _contextFactory;
         private readonly IUpgradeStateManager _stateManager;
-        private readonly ILogger<ConsoleAnalyze> _logger;
         private readonly IEnumerable<IAnalyzeResultProvider> _providers;
         private readonly IAnalyzeResultWriter _writer;
-        private readonly IExtensionManager _extensionManager;
+        private readonly IExtensionProvider _extensionProvider;
 
         public ConsoleAnalyze(
             IEnumerable<IAnalyzeResultProvider> analysisProviders,
             IUpgradeContextFactory contextFactory,
             IUpgradeStateManager stateManager,
             IAnalyzeResultWriter writer,
-            IExtensionManager extensionManager,
-            ILogger<ConsoleAnalyze> logger)
+            IExtensionProvider extensionProvider)
         {
             _providers = analysisProviders ?? throw new ArgumentNullException(nameof(analysisProviders));
             _writer = writer ?? throw new ArgumentNullException(nameof(writer));
-            _extensionManager = extensionManager ?? throw new ArgumentNullException(nameof(extensionManager));
+            _extensionProvider = extensionProvider ?? throw new ArgumentNullException(nameof(extensionProvider));
             _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
             _stateManager = stateManager ?? throw new ArgumentNullException(nameof(stateManager));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task RunAsync(CancellationToken token)
@@ -63,7 +59,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
         {
             const string NullVersion = "0.0.0";
 
-            if (_extensionManager.TryGetExtension(provider, out var extension))
+            if (_extensionProvider.TryGetExtension(provider, out var extension))
             {
                 return extension.Version?.ToString() ?? NullVersion;
             }

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/ExtensionManagement/ExtensionManagementCommand.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/ExtensionManagement/ExtensionManagementCommand.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli.Commands.ExtensionManagement
                                   services.AddOptions<ExtensionNameOptions>()
                                     .Configure<IOptions<ExtensionOptions>>((options, extensionOptions) =>
                                     {
-                                        options.Path = opts.Path;
+                                        options.Path = opts.ExtensionPath;
 
                                         if (opts.Name is not null)
                                         {
@@ -132,23 +132,23 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli.Commands.ExtensionManagement
                 : base("create")
             {
                 AddHandler<CreateExtensionAppCommand>();
-                AddArgument(new Argument<string>("path", LocalizedStrings.ExtensionManagementName));
+                AddArgument(new Argument<string>("extensionPath", LocalizedStrings.ExtensionManagementName));
             }
 
             private class CreateExtensionAppCommand : IAppCommand
             {
-                private readonly IExtensionManager _extensionManager;
+                private readonly IExtensionProvider _extensionProvider;
                 private readonly IExtensionCreator _extensionCreator;
                 private readonly IOptions<ExtensionNameOptions> _options;
                 private readonly ILogger<CreateExtensionAppCommand> _logger;
 
                 public CreateExtensionAppCommand(
-                    IExtensionManager extensionManager,
+                    IExtensionProvider extensionProvider,
                     IExtensionCreator extensionCreator,
                     IOptions<ExtensionNameOptions> options,
                     ILogger<CreateExtensionAppCommand> logger)
                 {
-                    _extensionManager = extensionManager ?? throw new ArgumentNullException(nameof(extensionManager));
+                    _extensionProvider = extensionProvider ?? throw new ArgumentNullException(nameof(extensionProvider));
                     _extensionCreator = extensionCreator ?? throw new ArgumentNullException(nameof(extensionCreator));
                     _options = options ?? throw new ArgumentNullException(nameof(options));
                     _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -164,7 +164,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli.Commands.ExtensionManagement
                         return Task.CompletedTask;
                     }
 
-                    var extension = _extensionManager.OpenExtension(options.Path);
+                    var extension = _extensionProvider.OpenExtension(options.Path);
 
                     if (extension?.Version is null)
                     {
@@ -199,12 +199,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli.Commands.ExtensionManagement
 
             private class ListExtensionAppCommand : IAppCommand
             {
-                private readonly IExtensionManager _extensionManager;
+                private readonly IExtensionProvider _extensionProvider;
                 private readonly ILogger<ListExtensionAppCommand> _logger;
 
-                public ListExtensionAppCommand(IExtensionManager extensionManager, ILogger<ListExtensionAppCommand> logger)
+                public ListExtensionAppCommand(IExtensionProvider extensionProvider, ILogger<ListExtensionAppCommand> logger)
                 {
-                    _extensionManager = extensionManager;
+                    _extensionProvider = extensionProvider;
                     _logger = logger;
                 }
 
@@ -212,7 +212,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli.Commands.ExtensionManagement
                 {
                     _logger.LogInformation(LocalizedStrings.ListExtensionDetails);
 
-                    foreach (var n in _extensionManager.Registered)
+                    foreach (var n in _extensionProvider.Registered)
                     {
                         _logger.LogInformation(LocalizedStrings.ListExtensionItem, n.Name, n.Source);
                     }
@@ -299,14 +299,16 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli.Commands.ExtensionManagement
             private class UpdateExtensionAppCommand : IAppCommand
             {
                 private readonly IOptions<ExtensionNameOptions> _options;
+                private readonly IExtensionProvider _extensionProvider;
                 private readonly IExtensionManager _extensionManager;
                 private readonly ILogger<UpdateExtensionAppCommand> _logger;
 
-                public UpdateExtensionAppCommand(IOptions<ExtensionNameOptions> options, IExtensionManager extensionManager, ILogger<UpdateExtensionAppCommand> logger)
+                public UpdateExtensionAppCommand(IOptions<ExtensionNameOptions> options, IExtensionProvider extensionProvider, IExtensionManager extensionManager, ILogger<UpdateExtensionAppCommand> logger)
                 {
-                    _options = options;
-                    _extensionManager = extensionManager;
-                    _logger = logger;
+                    _options = options ?? throw new ArgumentNullException(nameof(options));
+                    _extensionProvider = extensionProvider ?? throw new ArgumentNullException(nameof(extensionProvider));
+                    _extensionManager = extensionManager ?? throw new ArgumentNullException(nameof(extensionManager));
+                    _logger = logger ?? throw new ArgumentNullException(nameof(logger));
                 }
 
                 public async Task RunAsync(CancellationToken token)
@@ -339,7 +341,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli.Commands.ExtensionManagement
                             return requested.Select(r => r.Name);
                         }
 
-                        return _extensionManager.Registered.Select(e => e.Name);
+                        return _extensionProvider.Registered.Select(e => e.Name);
                     }
                 }
             }
@@ -366,7 +368,9 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli.Commands.ExtensionManagement
 
             public string? Version { get; set; }
 
-            public string? Path { get; set; }
+            public string? ExtensionPath { get; set; }
+
+            public string? Path => null;
 
             public bool IgnoreUnsupportedFeatures { get; set; }
 

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/ConsoleRunner.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/ConsoleRunner.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
                 using var scope = _services.GetAutofacRoot().BeginLifetimeScope(builder =>
                 {
-                    foreach (var extension in _services.GetRequiredService<IExtensionManager>().Instances)
+                    foreach (var extension in _services.GetRequiredService<IExtensionProvider>().Instances)
                     {
                         var services = new ServiceCollection();
                         extension.AddServices(services);

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/Extensions/IExtensionManager.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/Extensions/IExtensionManager.cs
@@ -1,19 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 {
+    /// <summary>
+    /// An abstraction that allows managing extensions used in the system.
+    /// </summary>
     public interface IExtensionManager
     {
-        IEnumerable<IExtensionInstance> Instances { get; }
-
-        IEnumerable<ExtensionSource> Registered { get; }
-
         Task<bool> RemoveAsync(string name, CancellationToken token);
 
         Task<ExtensionSource?> UpdateAsync(string name, CancellationToken token);
@@ -21,15 +18,5 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
         Task<ExtensionSource?> AddAsync(ExtensionSource n, CancellationToken token);
 
         Task<bool> RestoreExtensionsAsync(CancellationToken token);
-
-        IExtensionInstance? OpenExtension(string path);
-
-        /// <summary>
-        /// Attempts to find the extension in which a service is registered.
-        /// </summary>
-        /// <param name="service">Service to search for.</param>
-        /// <param name="extensionInstance">An extension if it is defined in one.</param>
-        /// <returns><c>true</c> if an extension is found; otherwise <c>false</c>.</returns>
-        bool TryGetExtension(object service, [MaybeNullWhen(false)] out IExtensionInstance extensionInstance);
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/Extensions/IExtensionProvider.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/Extensions/IExtensionProvider.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions
+{
+    /// <summary>
+    /// An abstraction that provides information about the currently available extensions.
+    /// </summary>
+    public interface IExtensionProvider
+    {
+        IEnumerable<IExtensionInstance> Instances { get; }
+
+        IEnumerable<ExtensionSource> Registered { get; }
+
+        /// <summary>
+        /// Attempts to find the extension in which a service is registered.
+        /// </summary>
+        /// <param name="service">Service to search for.</param>
+        /// <param name="extensionInstance">An extension if it is defined in one.</param>
+        /// <returns><c>true</c> if an extension is found; otherwise <c>false</c>.</returns>
+        bool TryGetExtension(object service, [MaybeNullWhen(false)] out IExtensionInstance extensionInstance);
+
+        IExtensionInstance? OpenExtension(string path);
+    }
+}

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/WorkspaceOptions.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/WorkspaceOptions.cs
@@ -1,13 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel.DataAnnotations;
-
 namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 {
     public class WorkspaceOptions
     {
-        [Required]
         public string InputPath { get; set; } = null!;
 
         public string? MSBuildPath { get; set; }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/AggregateExtensionConfigureOptions{TOption}.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/AggregateExtensionConfigureOptions{TOption}.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
         private readonly IEnumerable<IExtensionInstance> _extensions;
         private readonly Lazy<Mapper> _mapper;
 
-        public AggregateExtensionConfigureOptions(string sectionName, IExtensionManager extensions)
+        public AggregateExtensionConfigureOptions(string sectionName, IExtensionProvider extensions)
         {
             _sectionName = sectionName;
             _extensions = extensions.Instances;

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionInstanceFactory.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionInstanceFactory.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions
+{
+    public class ExtensionInstanceFactory
+    {
+        private readonly ILogger<ExtensionInstance> _logger;
+        private readonly string _instanceKey;
+
+        public ExtensionInstanceFactory(ILogger<ExtensionInstance> logger)
+        {
+            _logger = logger;
+            _instanceKey = Guid.NewGuid().ToString("N");
+        }
+
+        public ExtensionInstance Create(IFileProvider fileProvider, string location, IConfiguration configuration)
+            => new ExtensionInstance(_instanceKey, fileProvider, location, configuration, _logger);
+
+        public ExtensionInstance Create(IFileProvider fileProvider, string location)
+            => Create(fileProvider, location, CreateConfiguration(fileProvider));
+
+        private static IConfiguration CreateConfiguration(IFileProvider fileProvider)
+        {
+            try
+            {
+                return new ConfigurationBuilder()
+                    .AddJsonFile(fileProvider, ExtensionInstance.ManifestFileName, optional: false, reloadOnChange: false)
+                    .Build();
+            }
+            catch (FileNotFoundException e)
+            {
+                throw new UpgradeException("Could not find manifest file", e);
+            }
+        }
+    }
+}

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionLoaders/DirectoryExtensionLoader.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionLoaders/DirectoryExtensionLoader.cs
@@ -8,12 +8,19 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 {
     internal class DirectoryExtensionLoader : IExtensionLoader
     {
+        private readonly ExtensionInstanceFactory _factory;
+
+        public DirectoryExtensionLoader(ExtensionInstanceFactory factory)
+        {
+            _factory = factory;
+        }
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The file provider will be disposed when the extension instance is disposed.")]
         public ExtensionInstance? LoadExtension(string path)
         {
             if (Directory.Exists(path))
             {
-                return new ExtensionInstance(new PhysicalFileProvider(path), path);
+                return _factory.Create(new PhysicalFileProvider(path), path);
             }
 
             return null;

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionLoaders/ManifestDirectoryExtensionLoader.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionLoaders/ManifestDirectoryExtensionLoader.cs
@@ -9,6 +9,13 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 {
     internal class ManifestDirectoryExtensionLoader : IExtensionLoader
     {
+        private readonly ExtensionInstanceFactory _factory;
+
+        public ManifestDirectoryExtensionLoader(ExtensionInstanceFactory factory)
+        {
+            _factory = factory;
+        }
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The file provider will be disposed when the extension instance is disposed.")]
         public ExtensionInstance? LoadExtension(string path)
         {
@@ -21,7 +28,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
             if (ExtensionInstance.ManifestFileName.Equals(filename, StringComparison.OrdinalIgnoreCase))
             {
                 var dir = Path.GetDirectoryName(path) ?? string.Empty;
-                return new ExtensionInstance(new PhysicalFileProvider(dir), dir);
+                return _factory.Create(new PhysicalFileProvider(dir), dir);
             }
 
             return null;

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionLoaders/ZipExtensionLoader.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionLoaders/ZipExtensionLoader.cs
@@ -8,6 +8,13 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 {
     internal class ZipExtensionLoader : IExtensionLoader
     {
+        private readonly ExtensionInstanceFactory _factory;
+
+        public ZipExtensionLoader(ExtensionInstanceFactory factory)
+        {
+            _factory = factory;
+        }
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The file provider will be disposed when the extension instance is disposed.")]
         public ExtensionInstance? LoadExtension(string path)
         {
@@ -22,7 +29,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 
                 try
                 {
-                    return new ExtensionInstance(provider, path);
+                    return _factory.Create(provider, path);
                 }
 
                 // If the manifest file couldn't be found, let's try looking at one layer deep with the name
@@ -32,7 +39,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
                 {
                     var subpath = Path.GetFileNameWithoutExtension(path);
                     var subprovider = new SubFileProvider(provider, subpath);
-                    return new ExtensionInstance(subprovider, path);
+                    return _factory.Create(subprovider, path);
                 }
             }
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionLocator.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionLocator.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions
+{
+    public class ExtensionLocator : IExtensionLocator
+    {
+        private readonly IOptions<ExtensionOptions> _options;
+
+        public ExtensionLocator(IOptions<ExtensionOptions> options)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        public string GetInstallPath(ExtensionSource extensionSource)
+        {
+            if (extensionSource is null)
+            {
+                throw new ArgumentNullException(nameof(extensionSource));
+            }
+
+            if (string.IsNullOrEmpty(extensionSource.Version))
+            {
+                throw new UpgradeException("Cannot get path of source without version");
+            }
+
+            var sourcePath = GetSourceForPath(extensionSource.Source);
+
+            return Path.Combine(_options.Value.ExtensionCachePath, sourcePath, extensionSource.Name, extensionSource.Version);
+        }
+
+        /// <summary>
+        /// Sources will usually be URL-style strings, which cannot be put into a filename. Instead, we take a hash of it and use that as the source parameter.
+        /// </summary>
+        /// <param name="source">Original source path</param>
+        /// <returns>A hashed source suitable for insertion into a path</returns>
+        private string GetSourceForPath(string source)
+        {
+            Span<byte> stringBytes = stackalloc byte[source.Length];
+            Encoding.UTF8.GetBytes(source, stringBytes);
+
+            Span<byte> hash = stackalloc byte[32];
+            SHA256.HashData(stringBytes, hash);
+
+            return Convert.ToBase64String(hash);
+        }
+    }
+}

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionManager.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionManager.cs
@@ -15,118 +15,23 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 {
-    public sealed class ExtensionManager : IDisposable, IExtensionManager
+    public sealed class ExtensionManager : IExtensionManager
     {
-        private readonly IUpgradeAssistantConfigurationLoader _configurationLoader;
-        private readonly IExtensionDownloader _extensionDownloader;
-        private readonly IEnumerable<IExtensionLoader> _loaders;
+        private readonly Lazy<IExtensionDownloader> _extensionDownloader;
         private readonly ILogger<ExtensionManager> _logger;
-        private readonly ExtensionOptions _options;
-        private readonly Lazy<IEnumerable<ExtensionInstance>> _extensions;
+        private readonly IExtensionProvider _extensionProvider;
+        private readonly IUpgradeAssistantConfigurationLoader _configurationLoader;
 
         public ExtensionManager(
-            IEnumerable<IExtensionLoader> loaders,
+            IExtensionProvider extensionProvider,
             IUpgradeAssistantConfigurationLoader configurationLoader,
-            IExtensionDownloader extensionDownloader,
-            IOptions<ExtensionOptions> options,
+            Lazy<IExtensionDownloader> extensionDownloader,
             ILogger<ExtensionManager> logger)
         {
-            if (loaders is null)
-            {
-                throw new ArgumentNullException(nameof(loaders));
-            }
-
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-
+            _extensionProvider = extensionProvider ?? throw new ArgumentNullException(nameof(extensionProvider));
             _configurationLoader = configurationLoader ?? throw new ArgumentNullException(nameof(configurationLoader));
-            _extensionDownloader = extensionDownloader;
-            _loaders = loaders;
+            _extensionDownloader = extensionDownloader ?? throw new ArgumentNullException(nameof(extensionDownloader));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _options = options.Value;
-            _extensions = new Lazy<IEnumerable<ExtensionInstance>>(() =>
-            {
-                if (!_options.LoadExtensions)
-                {
-                    return Enumerable.Empty<ExtensionInstance>();
-                }
-
-                var list = new List<ExtensionInstance>();
-
-                foreach (var path in _options.ExtensionPaths)
-                {
-                    LoadPath(path, isDefault: false);
-                }
-
-                foreach (var path in _options.DefaultExtensions)
-                {
-                    LoadPath(path, isDefault: true);
-                }
-
-                foreach (var path in Registered.Select(_extensionDownloader.GetInstallPath))
-                {
-                    LoadPath(path, isDefault: false);
-                }
-
-                logger.LogInformation("Loaded {Count} extensions", list.Count);
-
-                if (_options.AdditionalOptions.Any())
-                {
-                    list.Add(LoadOptionsExtension(_options.AdditionalOptions));
-                }
-
-                list.AddRange(_options.Extensions);
-
-                return list;
-
-                void LoadPath(string path, bool isDefault)
-                {
-                    if (OpenExtension(path) is ExtensionInstance extension)
-                    {
-                        if (isDefault)
-                        {
-                            extension = extension with { Version = _options.CurrentVersion };
-                        }
-
-                        if (_options.CheckMinimumVersion && extension.MinUpgradeAssistantVersion is Version minVersion && minVersion > _options.CurrentVersion)
-                        {
-                            logger.LogWarning("Could not load extension from {Path}. Requires at least v{Version} of Upgrade Assistant and current version is {UpgradeAssistantVersion}.", path, minVersion, _options.CurrentVersion);
-                        }
-                        else
-                        {
-                            list.Add(extension);
-                        }
-                    }
-                    else
-                    {
-                        logger.LogWarning("Could not load extension from {Path}", path);
-                    }
-                }
-            });
-        }
-
-        public void Dispose()
-        {
-            if (_extensions.IsValueCreated)
-            {
-                foreach (var extension in _extensions.Value)
-                {
-                    extension.Dispose();
-                }
-            }
-        }
-
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The extension instance will dispose of this.")]
-        private static ExtensionInstance LoadOptionsExtension(IEnumerable<AdditionalOption> values)
-        {
-            var collection = values.Select(v => new KeyValuePair<string, string>(v.Name, v.Value));
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(collection)
-                .Build();
-
-            return new ExtensionInstance(new PhysicalFileProvider(Environment.CurrentDirectory), Environment.CurrentDirectory, config);
         }
 
         public Task<bool> RemoveAsync(string name, CancellationToken token)
@@ -160,7 +65,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
                 return null;
             }
 
-            var latestVersion = await _extensionDownloader.GetLatestVersionAsync(existing with { Version = null }, token).ConfigureAwait(false);
+            var latestVersion = await _extensionDownloader.Value.GetLatestVersionAsync(existing with { Version = null }, token).ConfigureAwait(false);
 
             if (latestVersion is null)
             {
@@ -172,7 +77,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 
             _logger.LogInformation("Updating to latest version {Version} of extension '{Extension}'", latest.Version, latest.Name);
 
-            await _extensionDownloader.RestoreAsync(latest, token).ConfigureAwait(false);
+            await _extensionDownloader.Value.RestoreAsync(latest, token).ConfigureAwait(false);
 
             var updated = config with
             {
@@ -193,7 +98,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 
             if (string.IsNullOrEmpty(n.Version))
             {
-                var version = await _extensionDownloader.GetLatestVersionAsync(n, token).ConfigureAwait(false);
+                var version = await _extensionDownloader.Value.GetLatestVersionAsync(n, token).ConfigureAwait(false);
 
                 if (version is null)
                 {
@@ -206,7 +111,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
                 _logger.LogInformation("Found version for extension {Name}: {Version}", n.Name, n.Version);
             }
 
-            var path = await _extensionDownloader.RestoreAsync(n, token).ConfigureAwait(false);
+            var path = await _extensionDownloader.Value.RestoreAsync(n, token).ConfigureAwait(false);
 
             if (path is null)
             {
@@ -230,11 +135,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
         {
             var success = true;
 
-            foreach (var extension in Registered)
+            foreach (var extension in _extensionProvider.Registered)
             {
                 _logger.LogInformation("Restoring {Extension}", extension.Name);
 
-                if (await _extensionDownloader.RestoreAsync(extension, token).ConfigureAwait(false) is null)
+                if (await _extensionDownloader.Value.RestoreAsync(extension, token).ConfigureAwait(false) is null)
                 {
                     success = false;
                 }
@@ -242,56 +147,5 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 
             return success;
         }
-
-        public bool TryGetExtension(object service, [MaybeNullWhen(false)] out IExtensionInstance extensionInstance)
-        {
-            if (service is null)
-            {
-                throw new ArgumentNullException(nameof(service));
-            }
-
-            var assembly = service.GetType().Assembly;
-            extensionInstance = Instances.FirstOrDefault(i => i.IsInExtension(assembly));
-
-            return extensionInstance is not null;
-        }
-
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Loading an extension should not propagate any exceptions.")]
-        public IExtensionInstance? OpenExtension(string path)
-        {
-            path = Path.GetFullPath(path);
-
-            foreach (var loader in _loaders)
-            {
-                try
-                {
-                    if (loader.LoadExtension(path) is ExtensionInstance instance)
-                    {
-                        if (instance.Version is Version version)
-                        {
-                            _logger.LogDebug("Found extension '{Name}' v{Version} [{Location}]", instance.Name, version, instance.Location);
-                        }
-                        else
-                        {
-                            _logger.LogDebug("Found extension '{Name}' [{Location}]", instance.Name, instance.Location);
-                        }
-
-                        return instance;
-                    }
-                }
-                catch (Exception e)
-                {
-                    _logger.LogError(e, "There was an error loading an extension from {Path}", path);
-                }
-            }
-
-            return null;
-        }
-
-        IEnumerable<IExtensionInstance> IExtensionManager.Instances => Instances;
-
-        private IEnumerable<ExtensionInstance> Instances => _extensions.Value;
-
-        public IEnumerable<ExtensionSource> Registered => _configurationLoader.Load().Extensions;
     }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionOptionsBuilder.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionOptionsBuilder.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
             // Since not all TOption instances will implement IFileOption, this is to ensure we are able to access an IFileProvider from the extension
             _services.Services.AddTransient<IConfigureOptions<ICollection<FileOption<TOption>>>>(ctx =>
             {
-                var extensions = ctx.GetRequiredService<IExtensionManager>();
+                var extensions = ctx.GetRequiredService<IExtensionProvider>();
 
                 return new AggregateExtensionConfigureOptions<TOption>(_sectionName, extensions);
             });

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionProvider.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionProvider.cs
@@ -1,0 +1,181 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions
+{
+    public sealed class ExtensionProvider : IDisposable, IExtensionProvider
+    {
+        private readonly Lazy<IEnumerable<ExtensionInstance>> _extensions;
+        private readonly IUpgradeAssistantConfigurationLoader _configurationLoader;
+        private readonly IEnumerable<IExtensionLoader> _loaders;
+        private readonly ILogger<ExtensionProvider> _logger;
+        private readonly ExtensionInstanceFactory _factory;
+
+        public ExtensionProvider(
+            IEnumerable<IExtensionLoader> loaders,
+            IUpgradeAssistantConfigurationLoader configurationLoader,
+            ExtensionInstanceFactory factory,
+            IExtensionLocator extensionLocator,
+            IOptions<ExtensionOptions> options,
+            ILogger<ExtensionProvider> logger)
+        {
+            if (extensionLocator is null)
+            {
+                throw new ArgumentNullException(nameof(extensionLocator));
+            }
+
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+            _loaders = loaders ?? throw new ArgumentNullException(nameof(loaders));
+            _configurationLoader = configurationLoader ?? throw new ArgumentNullException(nameof(configurationLoader));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            _extensions = new Lazy<IEnumerable<ExtensionInstance>>(() =>
+            {
+                var opts = options.Value;
+
+                if (!opts.LoadExtensions)
+                {
+                    return Enumerable.Empty<ExtensionInstance>();
+                }
+
+                var list = new List<ExtensionInstance>();
+
+                foreach (var path in opts.ExtensionPaths)
+                {
+                    LoadPath(path, isDefault: false);
+                }
+
+                foreach (var path in opts.DefaultExtensions)
+                {
+                    LoadPath(path, isDefault: true);
+                }
+
+                foreach (var path in Registered.Select(extensionLocator.GetInstallPath))
+                {
+                    LoadPath(path, isDefault: false);
+                }
+
+                logger.LogInformation("Loaded {Count} extensions", list.Count);
+
+                if (opts.AdditionalOptions.Any())
+                {
+                    list.Add(LoadOptionsExtension(opts.AdditionalOptions));
+                }
+
+                list.AddRange(opts.Extensions);
+
+                return list;
+
+                void LoadPath(string path, bool isDefault)
+                {
+                    if (OpenExtension(path) is ExtensionInstance extension)
+                    {
+                        if (isDefault)
+                        {
+                            extension = extension with { Version = opts.CurrentVersion };
+                        }
+
+                        if (opts.CheckMinimumVersion && extension.MinUpgradeAssistantVersion is Version minVersion && minVersion > opts.CurrentVersion)
+                        {
+                            logger.LogWarning("Could not load extension from {Path}. Requires at least v{Version} of Upgrade Assistant and current version is {UpgradeAssistantVersion}.", path, minVersion, opts.CurrentVersion);
+                        }
+                        else
+                        {
+                            list.Add(extension);
+                        }
+                    }
+                    else
+                    {
+                        logger.LogWarning("Could not load extension from {Path}", path);
+                    }
+                }
+            });
+        }
+
+        public void Dispose()
+        {
+            if (_extensions.IsValueCreated)
+            {
+                foreach (var extension in _extensions.Value)
+                {
+                    extension.Dispose();
+                }
+            }
+        }
+
+        public bool TryGetExtension(object service, [MaybeNullWhen(false)] out IExtensionInstance extensionInstance)
+        {
+            if (service is null)
+            {
+                throw new ArgumentNullException(nameof(service));
+            }
+
+            var assembly = service.GetType().Assembly;
+            extensionInstance = Instances.FirstOrDefault(i => i.IsInExtension(assembly));
+
+            return extensionInstance is not null;
+        }
+
+        private ExtensionInstance LoadOptionsExtension(IEnumerable<AdditionalOption> values)
+        {
+            var collection = values.Select(v => new KeyValuePair<string, string>(v.Name, v.Value));
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(collection)
+                .Build();
+
+            return _factory.Create(new PhysicalFileProvider(Environment.CurrentDirectory), Environment.CurrentDirectory, config);
+        }
+
+        public IExtensionInstance? OpenExtension(string path)
+        {
+            path = Path.GetFullPath(path);
+
+            foreach (var loader in _loaders)
+            {
+                try
+                {
+                    if (loader.LoadExtension(path) is ExtensionInstance instance)
+                    {
+                        if (instance.Version is Version version)
+                        {
+                            _logger.LogDebug("Found extension '{Name}' v{Version} [{Location}]", instance.Name, version, instance.Location);
+                        }
+                        else
+                        {
+                            _logger.LogDebug("Found extension '{Name}' [{Location}]", instance.Name, instance.Location);
+                        }
+
+                        return instance;
+                    }
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "There was an error loading an extension from {Path}", path);
+                }
+            }
+
+            return null;
+        }
+
+        IEnumerable<IExtensionInstance> IExtensionProvider.Instances => Instances;
+
+        private IEnumerable<ExtensionInstance> Instances => _extensions.Value;
+
+        public IEnumerable<ExtensionSource> Registered => _configurationLoader.Load().Extensions;
+    }
+}

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionServiceCollection.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionServiceCollection.cs
@@ -26,14 +26,14 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 
             Services.AddTransient<IConfigureOptions<TOption>>(ctx =>
             {
-                var extensions = ctx.GetRequiredService<IExtensionManager>();
+                var extensions = ctx.GetRequiredService<IExtensionProvider>();
 
                 return new AggregateExtensionConfigureOptions<TOption>(sectionName, extensions);
             });
 
             Services.AddTransient<IConfigureOptions<ICollection<TOption>>>(ctx =>
             {
-                var extensions = ctx.GetRequiredService<IExtensionManager>();
+                var extensions = ctx.GetRequiredService<IExtensionProvider>();
 
                 return new AggregateExtensionConfigureOptions<TOption>(sectionName, extensions);
             });

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/IExtensionDownloader.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/IExtensionDownloader.cs
@@ -8,8 +8,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
 {
     public interface IExtensionDownloader
     {
-        string GetInstallPath(ExtensionSource extensionSource);
-
         Task<string?> GetLatestVersionAsync(ExtensionSource n, CancellationToken token);
 
         Task<string?> RestoreAsync(ExtensionSource source, CancellationToken token);

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/IExtensionLocator.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/IExtensionLocator.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.UpgradeAssistant.Extensions
+{
+    public interface IExtensionLocator
+    {
+        string GetInstallPath(ExtensionSource extensionSource);
+    }
+}

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Extensions.Tests/ExtensionConfigurationTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Extensions.Tests/ExtensionConfigurationTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using AutoFixture;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -113,7 +114,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Tests
 
             var extensions = manifests.Select(CreateExtension).ToList();
 
-            var extensionManager = new Mock<IExtensionManager>();
+            var extensionManager = new Mock<IExtensionProvider>();
             extensionManager.Setup(m => m.Instances).Returns(extensions);
 
             services.AddSingleton(extensionManager.Object);
@@ -133,7 +134,9 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Tests
 
                 fileProvider.Setup(f => f.GetFileInfo(ExtensionInstance.ManifestFileName)).Returns(file.Object);
 
-                return new ExtensionInstance(fileProvider.Object, string.Empty);
+                var factory = new ExtensionInstanceFactory(new Mock<ILogger<ExtensionInstance>>().Object);
+
+                return factory.Create(fileProvider.Object, string.Empty);
             }
         }
 


### PR DESCRIPTION
This change enables a separation between just loading extensions and
actually managing them. Extension loading itself is more limited in what
services are available as nothing from extensions are available yet and
must not use any such service.