### PR TITLE
Do not clear console output

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Upgrade/ConsoleUpgrade.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Upgrade/ConsoleUpgrade.cs
@@ -98,11 +98,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
                 _io.Output.WriteLine($"Command ({command.CommandText}) did not succeed");
                 Console.ResetColor();
             }
-            else if (await _input.WaitToProceedAsync(token))
-            {
-                ConsoleUtils.Clear();
-            }
-            else
+            else if (!await _input.WaitToProceedAsync(token))
             {
                 _logger.LogWarning("Upgrade process was canceled. Quitting....");
             }
@@ -120,6 +116,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
         private async Task ShowUpgradeStepsAsync(IEnumerable<UpgradeStep> steps, IUpgradeContext context, CancellationToken token, UpgradeStep? currentStep = null, int offset = 0)
         {
+            if (!_input.IsInteractive)
+            {
+                return;
+            }
+
             if (steps is null || !steps.Any())
             {
                 return;

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/ConsoleUtils.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/ConsoleUtils.cs
@@ -19,13 +19,5 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
                 return Console.WindowWidth;
             }
         }
-
-        public static void Clear()
-        {
-            if (!Console.IsOutputRedirected)
-            {
-                Console.Clear();
-            }
-        }
     }
 }

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/UpgradeAssistantHostExtensions.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/UpgradeAssistantHostExtensions.cs
@@ -175,7 +175,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
                 throw new ArgumentNullException(nameof(options));
             }
 
-            ConsoleUtils.Clear();
             Program.ShowHeader();
 
             const string LogFilePath = "log.txt";


### PR DESCRIPTION
This ends up hiding things that we can't get access to again. This also hides the menu output if running as non-interactive