### PR TITLE
Match VS supplied path with version

### DIFF
--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildRegistrationStartup.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildRegistrationStartup.cs
@@ -50,8 +50,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
             _telemetry.TrackEvent("msbuild", new Dictionary<string, string> { { "MSBuild Version", version } });
 
-            _logger.LogInformation("Registered MSBuild at {Path}", msbuildPath);
-
             return true;
         }
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceOptionsConfigure.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceOptionsConfigure.cs
@@ -21,17 +21,13 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public void Configure(WorkspaceOptions options)
         {
-            if (options.MSBuildPath is string expectedPath)
-            {
-                _logger.LogInformation("Using supplied path for MSBuild [{Path}]", expectedPath);
-            }
-            else
+            if (options.MSBuildPath is null)
             {
                 options.MSBuildPath = FindMSBuildPath();
             }
         }
 
-        public string FindMSBuildPath()
+        private string FindMSBuildPath()
         {
             // TODO : Harden this and allow MSBuild location to be read from env vars.
             var msBuildInstances = FilterForBitness(MSBuildLocator.QueryVisualStudioInstances())
@@ -47,12 +43,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             {
                 foreach (var instance in msBuildInstances)
                 {
-                    _logger.LogInformation("Found candidate MSBuild instances: {Path}", instance.MSBuildPath);
+                    _logger.LogTrace("Found candidate MSBuild instances: {Path}", instance.MSBuildPath);
                 }
 
                 var selected = msBuildInstances.First();
-
-                _logger.LogInformation("MSBuild registered from {MSBuildPath}", selected.MSBuildPath);
 
                 return selected.MSBuildPath;
             }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/UpgraderMsBuildExtensions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/UpgraderMsBuildExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.DotNet.UpgradeAssistant.MSBuild;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.DotNet.UpgradeAssistant
@@ -19,7 +20,15 @@ namespace Microsoft.DotNet.UpgradeAssistant
         {
             services.AddOptions<WorkspaceOptions>()
                 .Configure(configure)
-                .ValidateDataAnnotations();
+                .PostConfigure<ILogger<WorkspaceOptions>>((options, logger) =>
+                {
+                    logger.LogInformation("Using MSBuild from {Path}", options.MSBuildPath);
+
+                    if (options.VisualStudioPath is string vsPath)
+                    {
+                        logger.LogInformation("Using Visual Studio install from {Path} [v{Version}]", options.VisualStudioPath, options.VisualStudioVersion);
+                    }
+                });
 
             services.AddTransient<Factories>();
 


### PR DESCRIPTION
A recent change fixed up the issue where using VS2022 with MSBuild 5.x caused issues with the VisualStudioVersion string by passing that through. However, that did not match supplied `--vs-path` values with its version.

This change also cleans up the logging so it doesn't output too much unnecessary logs without verbose