### PR TITLE
We should use Newtonsoft.Json packaged in extensions rather than provide it

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/appsettings.json
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/appsettings.json
@@ -23,7 +23,6 @@
       "default",
       "vb",
       "web",
-      "maui",
       "windows"
     ]
   }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionAssemblyLoadContext.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Extensions/ExtensionAssemblyLoadContext.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
         {
             // If available in the default, we want to ensure that is used.
             var inDefault = Default.Assemblies
-                .Where(a => !a.GetName().Name!.Contains("NuGet", StringComparison.OrdinalIgnoreCase))
+                .Where(a => IsHostProvided(a.GetName().Name))
                 .FirstOrDefault(a => string.Equals(a.GetName().Name, assemblyName.Name, StringComparison.Ordinal));
 
             if (inDefault is Assembly existing)
@@ -123,6 +123,25 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions
             ms.Position = 0;
             assemblyStream.Dispose();
             return ms;
+        }
+
+        private bool IsHostProvided(string? name)
+        {
+            if (name is null)
+            {
+                return false;
+            }
+
+            if (name.Contains("NuGet", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return name switch
+            {
+                "Newtonsoft.Json" => false,
+                _ => true,
+            };
         }
     }
 }


### PR DESCRIPTION
This change fixes a couple of things:

- We have been loading Newtonsoft.Json from the host, which we should not do
- Removes MAUI from the list of default extensions.