### PR TITLE
Retry on analyzer reference assembly failure

### DIFF
--- a/tests/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers.Test/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers.Test.csproj
+++ b/tests/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers.Test/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers.Test.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit">
       <Version>1.0.1-beta1.21265.1</Version>
     </PackageReference>
+    <PackageReference Include="Polly" Version="7.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\src\extensions\default\analyzers\Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers\Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers.csproj" />


### PR DESCRIPTION
There's a transient error that occurs while running analyzer tests as they try to download reference assemblies. This will add a retry to recover from that.