### PR TITLE
Fix Razor source updater issues

### DIFF
--- a/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Steps.Razor/RazorSourceUpdater.cs
+++ b/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Steps.Razor/RazorSourceUpdater.cs
@@ -161,7 +161,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Razor
 
             // Identify changed code sections
             var textReplacements = await GetReplacements(originalProject, project.Documents.Where(d => generatedFilePaths.Contains(d.FilePath)), token).ConfigureAwait(false);
-            var z = project.Documents.Where(d => generatedFilePaths.Contains(d.FilePath)).Select(d => d.GetTextAsync().Result.ToString()).ToArray();
 
             // Update cshtml based on changes made to generated source code
             // These are applied after finding all of them so that they can be applied in reverse line order


### PR DESCRIPTION
I found a few Razor source updater issues while investigating #856. This addresses them by making sure that source updates are correctly able to edit parts of the project other than cshtml files if needed and by improving the logic for mapping changed code back to cshtml files.

Fixes #856 
Fixes #914 
Fixes #915 
