### PR TITLE
Improve PackageUpdaterStep logging

### DIFF
--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageUpdaterStep.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.Packages/PackageUpdaterStep.cs
@@ -107,11 +107,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Packages
                 LogDetails("Framework references to be added: {FrameworkReference}", _analysisState.FrameworkReferences.Additions);
                 LogDetails("Framework references to be removed: {FrameworkReference}", _analysisState.FrameworkReferences.Deletions);
 
-                void LogDetails<T>(string name, IReadOnlyCollection<T> collection)
+                void LogDetails<T>(string name, IReadOnlyCollection<Operation<T>> collection)
                 {
                     if (collection.Count > 0)
                     {
-                        Logger.LogInformation(name, string.Join(Environment.NewLine, collection));
+                        Logger.LogInformation(name, string.Join(Environment.NewLine, collection.Select(o => o.Item)));
                     }
                 }
 


### PR DESCRIPTION
Update PackageUpdaterStep to log better messages for packages to be added/removed

Previously, this was logging `Operation<T>` which doesn't have a ToString method, so Serilog just serialized the objects, which was unsightly.

Instead, this updates the step to log the items in the operations, as well, which have friendly ToString implementations.

Fixes #912 