### PR TITLE
Add solution wide project file conversion behind feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ When run on a solution in order to analyze dependencies prior to upgrade, the to
 
 Extensions may be managed centrally for a project as described [here](docs/design/Extension_Management.md).
 
+### Experimental features
+
+Feature flags can be used to turn some experimental features on or off. Functionality behind feature flags may or may not be made public and are considered a way to test features that may be unstable. In order to enable a feature, set an environment variable to a semi-colon delimited list of feature names. For example: `$env:UA_FEATURES="FEATURE1;FEATURE2"`.
+
+Current features that are available to try out include:
+
+- `ANALYZE_OUTPUT_FORMAT`: Enables a `--format` flag for the `analyze` command that can take other options. Currently restricted to `sarif` and `html`
+- `SOLUTION_WIDE_SDK_CONVERSION`: Switches project format conversion from old style project files to SDK style to be solution wide first before any other changes to the project files.
+
 ### Optional Features
 
 Some features within Upgrade Assistant may be enabled by adding extensions. Available extensions can be viewed on [here](https://www.nuget.org/packages?packagetype=UpgradeAssistantExtension&sortby=relevance&q=&prerel=True).

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Analyze/ConsoleAnalyzeCommand.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Analyze/ConsoleAnalyzeCommand.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
                     .UseConsoleUpgradeAssistant<ConsoleAnalyze>(options, result)
                     .RunUpgradeAssistantAsync(token));
 
-            if (FeatureFlags.IsAnalyzeFormatEnabled())
+            if (FeatureFlags.IsAnalyzeFormatEnabled)
             {
                 AddOption(new Option<string>(new[] { "--format", "--f" }, LocalizedStrings.UpgradeAssistantCommandFormat));
             }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/FeatureFlags.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/FeatureFlags.cs
@@ -6,9 +6,12 @@ using System.Collections.Generic;
 
 namespace Microsoft.DotNet.UpgradeAssistant
 {
+    /// <summary>
+    /// A system to track experimental features. Please keep in sync with the README section 'Experimental features'.
+    /// </summary>
     public static class FeatureFlags
     {
-        private static ICollection<string> _features = CreateFeatures();
+        private static readonly ICollection<string> _features = CreateFeatures();
 
         private static ICollection<string> CreateFeatures()
         {
@@ -22,8 +25,8 @@ namespace Microsoft.DotNet.UpgradeAssistant
             return new HashSet<string>(features.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries), StringComparer.OrdinalIgnoreCase);
         }
 
-        public static bool IsRequested(string name) => _features.Contains(name);
+        public static bool IsAnalyzeFormatEnabled => _features.Contains("ANALYZE_OUTPUT_FORMAT");
 
-        public static bool IsAnalyzeFormatEnabled() => _features.Contains("FORMAT");
+        public static bool IsSolutionWideSdkConversionEnabled => _features.Contains("SOLUTION_WIDE_SDK_CONVERSION");
     }
 }

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/GraphTraversalExtensions.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/GraphTraversalExtensions.cs
@@ -4,15 +4,25 @@
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
+namespace Microsoft.DotNet.UpgradeAssistant
 {
-    internal static class GraphTraversalExtensions
+    public static class GraphTraversalExtensions
     {
         public static IEnumerable<T> PostOrderTraversal<T>(this T initial, Func<T, IEnumerable<T>> selector, IEqualityComparer<T>? comparer = null)
             => new[] { initial }.PostOrderTraversal(selector, comparer);
 
         public static IEnumerable<T> PostOrderTraversal<T>(this IEnumerable<T> initial, Func<T, IEnumerable<T>> selector, IEqualityComparer<T>? comparer = null)
         {
+            if (initial is null)
+            {
+                throw new ArgumentNullException(nameof(initial));
+            }
+
+            if (selector is null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
             var result = new List<T>();
             var visited = new HashSet<T>(comparer);
 

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/MSBuild/WorkspaceOptions.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/MSBuild/WorkspaceOptions.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.UpgradeAssistant
+namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 {
     public class WorkspaceOptions
     {

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/WorkspaceOptions.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/WorkspaceOptions.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
+namespace Microsoft.DotNet.UpgradeAssistant
 {
     public class WorkspaceOptions
     {

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IUpgradeContext.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IUpgradeContext.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
         IEnumerable<IProject> EntryPoints { get; set; }
 
         /// <summary>
-        /// This property is intended for query operations only and will be updated by UpgraderManager. Changing this property will not change the control flow.
+        /// Gets or sets the current step. This property is intended for query operations only and will be updated by UpgraderManager. Changing this property will not change the control flow.
         /// </summary>
         UpgradeStep? CurrentStep { get; set; }
 
@@ -29,6 +29,8 @@ namespace Microsoft.DotNet.UpgradeAssistant
         void SetCurrentProject(IProject? project);
 
         IEnumerable<IProject> Projects { get; }
+
+        IProject GetProject(string path);
 
         bool InputIsSolution { get; }
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 throw new InvalidOperationException("Could not find project path for reference");
             }
 
-            return Context.GetOrAddProject(new FileInfo(project.FilePath));
+            return Context.GetProject(project.FilePath);
         });
 
         public Language Language => ParseLanguageByProjectFileExtension(FileInfo.Extension);

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
@@ -86,16 +86,16 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             ProjectCollection.Dispose();
         }
 
-        public IProject GetOrAddProject(FileInfo path)
+        public IProject GetProject(string path)
         {
-            if (_projectCache.TryGetValue(path.FullName, out var cached))
+            if (_projectCache.TryGetValue(path, out var cached))
             {
                 return cached;
             }
 
-            var project = new MSBuildProject(this, _componentIdentifiers, _factories, _restorer, _comparer, path, _logger);
+            var project = new MSBuildProject(this, _componentIdentifiers, _factories, _restorer, _comparer, new FileInfo(path), _logger);
 
-            _projectCache.Add(path.FullName, project);
+            _projectCache.Add(path, project);
 
             return project;
         }
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
                 foreach (var path in _entryPointPaths)
                 {
-                    yield return GetOrAddProject(path);
+                    yield return GetProject(path.FullName);
                 }
             }
 
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                     }
                     else
                     {
-                        yield return GetOrAddProject(new FileInfo(project.FilePath));
+                        yield return GetProject(project.FilePath);
                     }
                 }
             }
@@ -223,7 +223,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                     return null;
                 }
 
-                return GetOrAddProject(_projectPath);
+                return GetProject(_projectPath.FullName);
             }
         }
 

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildWorkspaceUpgradeContext.cs
@@ -88,14 +88,17 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         public IProject GetProject(string path)
         {
-            if (_projectCache.TryGetValue(path, out var cached))
+            // Normalize to ensure we're always getting the same path
+            var normalizedPath = Path.GetFullPath(path);
+
+            if (_projectCache.TryGetValue(normalizedPath, out var cached))
             {
                 return cached;
             }
 
-            var project = new MSBuildProject(this, _componentIdentifiers, _factories, _restorer, _comparer, new FileInfo(path), _logger);
+            var project = new MSBuildProject(this, _componentIdentifiers, _factories, _restorer, _comparer, new FileInfo(normalizedPath), _logger);
 
-            _projectCache.Add(path, project);
+            _projectCache.Add(normalizedPath, project);
 
             return project;
         }

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/ProjectFormatStepsExtensions.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/ProjectFormatStepsExtensions.cs
@@ -20,8 +20,18 @@ namespace Microsoft.DotNet.UpgradeAssistant
             }
 
             services.Services.AddUpgradeStep<SetTFMStep>();
-            services.Services.AddUpgradeStep<TryConvertProjectConverterStep>();
+
+            if (FeatureFlags.IsSolutionWideSdkConversionEnabled)
+            {
+                services.Services.AddUpgradeStep<SdkStyleConversionSolutionWideStep>();
+            }
+            else
+            {
+                services.Services.AddUpgradeStep<TryConvertProjectConverterStep>();
+            }
+
             services.Services.AddTransient<ITryConvertTool, TryConvertInProcessTool>();
+            services.Services.AddTransient<TryConvertRunner>();
 
             return services.Services.AddOptions<TryConvertOptions>()
                 .PostConfigure(options =>

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/SdkStyleConversionSolutionWideStep.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/SdkStyleConversionSolutionWideStep.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
+{
+    public class SdkStyleConversionSolutionWideStep : UpgradeStep
+    {
+        private readonly TryConvertRunner _runner;
+
+        private IEnumerable<UpgradeStep>? _substeps;
+
+        public override string Description => $"Use the try-convert tool ({_runner.Path}{_runner.VersionString}) to convert the projects in a solution";
+
+        public override string Title => $"Convert projects in a solution to SDK style";
+
+        public override string Id => WellKnownStepIds.TryConvertProjectConverterStepId;
+
+        public override IEnumerable<string> DependsOn { get; } = new[]
+        {
+            WellKnownStepIds.EntrypointSelectionStepId,
+        };
+
+        public override IEnumerable<string> DependencyOf { get; } = new[]
+        {
+            WellKnownStepIds.CurrentProjectSelectionStepId,
+        };
+
+        public SdkStyleConversionSolutionWideStep(
+            TryConvertRunner runner,
+            ILogger<SdkStyleConversionSolutionWideStep> logger)
+            : base(logger)
+        {
+            _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+        }
+
+        protected override Task<bool> IsApplicableImplAsync(IUpgradeContext context, CancellationToken token) => Task.FromResult(true);
+
+        public override IEnumerable<UpgradeStep> SubSteps => _substeps ?? Enumerable.Empty<UpgradeStep>();
+
+        protected override Task<UpgradeStepInitializeResult> InitializeImplAsync(IUpgradeContext context, CancellationToken token)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (_substeps is null)
+            {
+                _substeps = context.EntryPoints.PostOrderTraversal(t => t.ProjectReferences)
+                    .Select(p => new ProjectSdkConversionStep(_runner, p.FileInfo, Logger))
+                    .ToList();
+
+                return Task.FromResult(new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, "Some projects may need to be converted to SDK style.", BuildBreakRisk.High));
+            }
+            else
+            {
+                return Task.FromResult(new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "Projects have already been converted to SDK style projects.", BuildBreakRisk.None));
+            }
+        }
+
+        protected override Task<UpgradeStepApplyResult> ApplyImplAsync(IUpgradeContext context, CancellationToken token)
+            => Task.FromResult(new UpgradeStepApplyResult(UpgradeStepStatus.Complete, "All projects in solution are now updated to SDK style project."));
+
+        private class ProjectSdkConversionStep : UpgradeStep
+        {
+            private readonly TryConvertRunner _runner;
+            private readonly FileInfo _project;
+
+            public ProjectSdkConversionStep(TryConvertRunner runner, FileInfo project, ILogger logger)
+                : base(logger)
+            {
+                _project = project;
+                _runner = runner;
+            }
+
+            public override string Title => $"Update {_project.Name} project format";
+
+            public override string Description => $"Convert {_project.Name} from old-style project format to SDK style project.";
+
+            protected override Task<UpgradeStepApplyResult> ApplyImplAsync(IUpgradeContext context, CancellationToken token)
+                => _runner.ApplyAsync(context, context.GetProject(_project.FullName), token);
+
+            protected override Task<UpgradeStepInitializeResult> InitializeImplAsync(IUpgradeContext context, CancellationToken token)
+                => _runner.InitializeAsync(context.GetProject(_project.FullName), token);
+
+            protected override Task<bool> IsApplicableImplAsync(IUpgradeContext context, CancellationToken token)
+                => Task.FromResult(true);
+        }
+    }
+}

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertRunner.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertRunner.cs
@@ -1,0 +1,119 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
+{
+    public class TryConvertRunner
+    {
+        private readonly ITryConvertTool _runner;
+        private readonly IPackageRestorer _restorer;
+        private readonly ILogger _logger;
+
+        public TryConvertRunner(ITryConvertTool runner, IPackageRestorer restorer, ILogger<TryConvertRunner> logger)
+        {
+            _runner = runner;
+            _restorer = restorer;
+            _logger = logger;
+        }
+
+        public string VersionString => _runner?.Version is null ? string.Empty : $", version {_runner.Version}";
+
+        public string Path => _runner.Path;
+
+        public async Task<UpgradeStepApplyResult> ApplyAsync(IUpgradeContext context, IProject project, CancellationToken token)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (project is null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            var components = await project.GetComponentsAsync(token).ConfigureAwait(false);
+            if (components.HasFlag(ProjectComponents.XamarinAndroid) || components.HasFlag(ProjectComponents.XamariniOS))
+            {
+                context.Properties.SetPropertyValue("componentFlag", components.ToString(), true);
+            }
+
+            var result = await RunTryConvertAsync(context, project, token).ConfigureAwait(false);
+
+            await _restorer.RestorePackagesAsync(context, project, token).ConfigureAwait(false);
+
+            return result;
+        }
+
+        public async Task<UpgradeStepInitializeResult> InitializeAsync(IProject project, CancellationToken token)
+        {
+            if (project is null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            if (!_runner.IsAvailable)
+            {
+                throw new UpgradeException($"try-convert not found: {_runner.Path}");
+            }
+
+            var projectFile = project.GetFile();
+
+            try
+            {
+                // SDK-style projects should reference the Microsoft.NET.Sdk SDK
+                if (!projectFile.IsSdk)
+                {
+                    _logger.LogDebug("Project {ProjectPath} not yet converted", projectFile.FilePath);
+
+                    var components = await project.GetComponentsAsync(token).ConfigureAwait(false);
+
+                    return new UpgradeStepInitializeResult(
+                        UpgradeStepStatus.Incomplete,
+                        $"Project {projectFile.FilePath} is not an SDK project. Applying this step will convert the project to SDK style.",
+                        components.HasFlag(ProjectComponents.AspNetCore) ? BuildBreakRisk.High : BuildBreakRisk.Medium);
+                }
+                else
+                {
+                    _logger.LogDebug("Project {ProjectPath} already targets SDK {SDK}", projectFile.FilePath, projectFile.Sdk);
+                    return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, $"Project already targets {projectFile.Sdk} SDK", BuildBreakRisk.None);
+                }
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception exc)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                _logger.LogError(exc, "Failed to open project {ProjectPath}", projectFile.FilePath);
+                return new UpgradeStepInitializeResult(UpgradeStepStatus.Failed, $"Failed to open project {projectFile.FilePath}", BuildBreakRisk.Unknown);
+            }
+        }
+
+        private async Task<UpgradeStepApplyResult> RunTryConvertAsync(IUpgradeContext context, IProject project, CancellationToken token)
+        {
+            _logger.LogInformation($"Converting project file format with try-convert{VersionString}");
+
+            var result = await _runner.RunAsync(context, project, token).ConfigureAwait(false);
+
+            // Reload the workspace since an external process worked on and
+            // may have changed the workspace's project.
+            await context.ReloadWorkspaceAsync(token).ConfigureAwait(false);
+
+            if (!result)
+            {
+                _logger.LogCritical("Conversion with try-convert failed.");
+                return new UpgradeStepApplyResult(UpgradeStepStatus.Failed, $"Conversion with try-convert failed.");
+            }
+            else
+            {
+                _logger.LogInformation("Project file converted successfully! The project may require additional changes to build successfully against the new .NET target.");
+                return new UpgradeStepApplyResult(UpgradeStepStatus.Complete, "Project file converted successfully");
+            }
+        }
+    }
+}

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertRunner.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat/TryConvertRunner.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -11,20 +10,20 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
 {
     public class TryConvertRunner
     {
-        private readonly ITryConvertTool _runner;
+        private readonly ITryConvertTool _tool;
         private readonly IPackageRestorer _restorer;
         private readonly ILogger _logger;
 
-        public TryConvertRunner(ITryConvertTool runner, IPackageRestorer restorer, ILogger<TryConvertRunner> logger)
+        public TryConvertRunner(ITryConvertTool tool, IPackageRestorer restorer, ILogger<TryConvertRunner> logger)
         {
-            _runner = runner;
+            _tool = tool;
             _restorer = restorer;
             _logger = logger;
         }
 
-        public string VersionString => _runner?.Version is null ? string.Empty : $", version {_runner.Version}";
+        public string VersionString => _tool?.Version is null ? string.Empty : $", version {_tool.Version}";
 
-        public string Path => _runner.Path;
+        public string Path => _tool.Path;
 
         public async Task<UpgradeStepApplyResult> ApplyAsync(IUpgradeContext context, IProject project, CancellationToken token)
         {
@@ -58,9 +57,9 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
                 throw new ArgumentNullException(nameof(project));
             }
 
-            if (!_runner.IsAvailable)
+            if (!_tool.IsAvailable)
             {
-                throw new UpgradeException($"try-convert not found: {_runner.Path}");
+                throw new UpgradeException($"try-convert not found: {_tool.Path}");
             }
 
             var projectFile = project.GetFile();
@@ -98,7 +97,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat
         {
             _logger.LogInformation($"Converting project file format with try-convert{VersionString}");
 
-            var result = await _runner.RunAsync(context, project, token).ConfigureAwait(false);
+            var result = await _tool.RunAsync(context, project, token).ConfigureAwait(false);
 
             // Reload the workspace since an external process worked on and
             // may have changed the workspace's project.

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/Microsoft.DotNet.UpgradeAssistant.Steps.Solution.csproj
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/Microsoft.DotNet.UpgradeAssistant.Steps.Solution.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\common\Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal\Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal.csproj" />
     <ProjectReference Include="..\..\..\common\Microsoft.DotNet.UpgradeAssistant.Abstractions\Microsoft.DotNet.UpgradeAssistant.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This change enables a user to run conversions to SDK style as a unit of work before continuing on to additional code changes. Currently set behind a feature flag so SOLUTION_WIDE_SDK_CONVERSION must be enabled for the solution wide conversion to be used.
