### PR TITLE
Fix relative urls in extensibility.md

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -210,8 +210,8 @@ Roslyn analyzers and code fix providers. Upgrade Assistant's source updater step
 
 Upgrade Assistant follows this naming pattern for DiagnosticID for Analyzers added: `UAXXX`. Below is a list of default analyzers and extension analyzers currently implemented. When adding a new Analyzer, pick the next value for ID and update the section below with the newly added Analyzer information.
 
-- [Default Analyzers List](..\src\extensions\default\analyzers\Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers/AnalyzerReleases.Unshipped.md)
-- [.NET MAUI Extension Analyzers List](..\src\extensions\maui\Microsoft.DotNet.UpgradeAssistant.Extensions.Maui\AnalyzerReleases.Unshipped.md)
+- [Default Analyzers List](../src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers/AnalyzerReleases.Unshipped.md)
+- [.NET MAUI Extension Analyzers List](../src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/AnalyzerReleases.Unshipped.md)
 
 ## Updaters
 Various services may request an implementation of `IUpdater<TUpdater>` which provides a way to update an object of type `TUpdater`. An example is a `IUpdater<ConfigFile>` that will provide updates for configuration files (`app.config`, `web.config`).


### PR DESCRIPTION
I didn't open an issue for this as it is such a small thing but the relative urls in `extensibility.md` weren't working when viewing the markdown in GitHub - as they had a mix of forward and backward slashes.  

Have updated the markdown to use forward slashes as per https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes#relative-links-and-image-paths-in-readme-files
