### PR TITLE
Add feature flag to enable running on non-Windows machines

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Program.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Program.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
     {
         public static Task<int> Main(string[] args)
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (FeatureFlags.IsWindowsCheckEnabled && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Console.WriteLine(LocalizedStrings.NonWindowsWarning);
                 return Task.FromResult(ErrorCodes.PlatformNotSupported);

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/FeatureFlags.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions.Internal/FeatureFlags.cs
@@ -25,6 +25,8 @@ namespace Microsoft.DotNet.UpgradeAssistant
             return new HashSet<string>(features.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries), StringComparer.OrdinalIgnoreCase);
         }
 
+        public static bool IsWindowsCheckEnabled => !_features.Contains("ENABLE_CROSS_PLATFORM");
+
         public static bool IsAnalyzeFormatEnabled => _features.Contains("ANALYZE_OUTPUT_FORMAT");
 
         public static bool IsSolutionWideSdkConversionEnabled => _features.Contains("SOLUTION_WIDE_SDK_CONVERSION");


### PR DESCRIPTION
This change adds a feature flag that allows someone to opt into running on non-Windows platforms. This will likely cause some problems, but will allow us to gather some information about what issues people are running into.
