### PR TITLE
Write reports to stream

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Analyze/ConsoleAnalyze.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Analyze/ConsoleAnalyze.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -62,8 +63,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
             if (_writerProvider.TryGetWriter(_options.Value.Format, out var writer))
             {
-                _logger.LogInformation("Writing to output format {Format}", _options.Value.Format);
-                await writer.WriteAsync(analyzeResultMap.ToAsyncEnumerable(), _options.Value.Format, token).ConfigureAwait(false);
+                var output = Path.Combine(Directory.GetCurrentDirectory(), $"AnalysisReport.{_options.Value.Format}");
+
+                _logger.LogInformation("Writing output to {File}", output);
+
+                using var stream = File.OpenWrite(output);
+                await writer.WriteAsync(analyzeResultMap.ToAsyncEnumerable(), stream, token).ConfigureAwait(false);
             }
             else
             {

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IAnalyzeResultWriter.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IAnalyzeResultWriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,7 +10,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Analysis
 {
     public interface IAnalyzeResultWriter
     {
-        Task WriteAsync(IAsyncEnumerable<AnalyzeResultDefinition> results, string? format, CancellationToken token);
+        Task WriteAsync(IAsyncEnumerable<AnalyzeResultDefinition> results, Stream stream, CancellationToken token);
 
         string Format { get; }
     }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Analysis/ISerializer.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Analysis/ISerializer.cs
@@ -1,16 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
+
 namespace Microsoft.DotNet.UpgradeAssistant.Analysis
 {
     public interface ISerializer
     {
-        T Deserialize<T>(string content);
-
-        string Serialize<T>(T obj);
-
-        T Read<T>(string filePath);
-
-        void Write<T>(string filePath, T obj);
+        void Write<T>(TextWriter writer, T obj);
     }
 }

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Analysis.Tests/HtmlAnalyzeResultWriterTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Analysis.Tests/HtmlAnalyzeResultWriterTests.cs
@@ -43,13 +43,13 @@ namespace Microsoft.DotNet.UpgradeAssistant.Analysis.Tests
                 }
             };
 
-            await writer.WriteAsync(analyzeResultMap.ToAsyncEnumerable(), "html", CancellationToken.None).ConfigureAwait(false);
+            using var ms = new MemoryStream();
+            await writer.WriteAsync(analyzeResultMap.ToAsyncEnumerable(), ms, CancellationToken.None).ConfigureAwait(false);
 
-            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "AnalysisReport.html");
-            if (!File.Exists(filePath))
-            {
-                Assert.True(false, "File wasn't exported successfully.");
-            }
+            // Attempt to move position to ensure stream is still open
+            ms.Position = 0;
+
+            Assert.NotEmpty(ms.ToArray());
         }
     }
 }

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Analysis.Tests/SarifAnalyzeResultWriterTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Analysis.Tests/SarifAnalyzeResultWriterTests.cs
@@ -23,9 +23,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Analysis.Tests
 
             _ = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-                await writer.WriteAsync(null, null, source.Token).ConfigureAwait(false);
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+                await writer.WriteAsync(null!, null!, source.Token).ConfigureAwait(false);
             }).ConfigureAwait(false);
         }
 
@@ -60,15 +58,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Analysis.Tests
                 }
             };
 
-            await writer.WriteAsync(analyzeResultMap.ToAsyncEnumerable(), null, CancellationToken.None).ConfigureAwait(false);
+            using var ms = new MemoryStream();
+            await writer.WriteAsync(analyzeResultMap.ToAsyncEnumerable(), ms, CancellationToken.None).ConfigureAwait(false);
 
-            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "AnalysisReport.sarif");
-            if (!File.Exists(filePath))
-            {
-                Assert.True(false, "File wasn't exported successfully.");
-            }
+            ms.Position = 0;
 
-            var sarifLog = SarifLog.Load(filePath);
+            var sarifLog = SarifLog.Load(ms);
             Assert.Equal("https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json", sarifLog.SchemaUri.OriginalString);
             Assert.Equal(SarifVersion.Current, sarifLog.Version);
 
@@ -121,15 +116,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Analysis.Tests
                 }
             };
 
-            await writer.WriteAsync(analyzeResultMap.ToAsyncEnumerable(), null, source.Token).ConfigureAwait(false);
+            using var ms = new MemoryStream();
+            await writer.WriteAsync(analyzeResultMap.ToAsyncEnumerable(), ms, source.Token).ConfigureAwait(false);
 
-            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "AnalysisReport.sarif");
-            if (!File.Exists(filePath))
-            {
-                Assert.True(false, "File wasn't exported successfully.");
-            }
+            ms.Position = 0;
 
-            var sarifLog = SarifLog.Load(filePath);
+            var sarifLog = SarifLog.Load(ms);
             Assert.Equal("https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json", sarifLog.SchemaUri.OriginalString);
             Assert.Equal(SarifVersion.Current, sarifLog.Version);
 


### PR DESCRIPTION
This change changes writers to operate on streams rather than writing to some place on disk. This provides the following benefits:

- Negotiation of file when run from the console is done once and can centrally locate things like verifying it's not overwriting something
- Tests can operate in memory rather than looking for something on disk
