### PR TITLE
Add ability to remove item from IProjectFile

### DIFF
--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IProjectFile.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IProjectFile.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
         void AddItem(string name, string path);
 
-        void RemoveItem(ProjectItemType? itemType = null, string? includePath = null, string? excludePath = null, string? elementName = null);
+        bool RemoveItem(ProjectItemType? itemType = null, string? includePath = null, string? excludePath = null, string? elementName = null);
 
         bool ContainsItem(string itemName, ProjectItemType? itemType, CancellationToken token);
 

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IProjectFile.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/IProjectFile.cs
@@ -35,6 +35,8 @@ namespace Microsoft.DotNet.UpgradeAssistant
 
         void AddItem(string name, string path);
 
+        void RemoveItem(ProjectItemType? itemType = null, string? includePath = null, string? excludePath = null, string? elementName = null);
+
         bool ContainsItem(string itemName, ProjectItemType? itemType, CancellationToken token);
 
         string GetPropertyValue(string propertyName);

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
@@ -158,6 +158,39 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
         public void AddItem(string name, string path)
             => ProjectRoot.AddItem(name, path);
 
+        public void RemoveItem(ProjectItemType? itemType = null, string? includePath = null, string? excludePath = null, string? elementName = null)
+        {
+            var items = ProjectRoot.Items.Where(item =>
+            {
+                if (itemType != null && item.ItemType != itemType.Name)
+                {
+                    return false;
+                }
+
+                if (includePath != null && item.Include != includePath)
+                {
+                    return false;
+                }
+
+                if (excludePath != null && item.Exclude != excludePath)
+                {
+                    return false;
+                }
+
+                if (elementName != null && item.ElementName != elementName)
+                {
+                    return false;
+                }
+
+                return true;
+            });
+
+            foreach (var item in items)
+            {
+                item.Parent.RemoveChild(item);
+            }
+        }
+
         public bool ContainsItem(string itemName, ProjectItemType? itemType, CancellationToken token)
         {
             var targetItemPath = GetPathRelativeToProject(itemName, FileInfo.DirectoryName ?? string.Empty);

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
@@ -158,7 +158,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
         public void AddItem(string name, string path)
             => ProjectRoot.AddItem(name, path);
 
-        public void RemoveItem(ProjectItemType? itemType = null, string? includePath = null, string? excludePath = null, string? elementName = null)
+        public bool RemoveItem(ProjectItemType? itemType = null, string? includePath = null, string? excludePath = null, string? elementName = null)
         {
             var items = ProjectRoot.Items.Where(item =>
             {
@@ -189,6 +189,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             {
                 item.Parent.RemoveChild(item);
             }
+
+            return items.Any();
         }
 
         public bool ContainsItem(string itemName, ProjectItemType? itemType, CancellationToken token)


### PR DESCRIPTION
Addresses #1050 
This PR adds RemoveItem method to IProjectFile and its implementation to MSBuildProject

**Possible breaking changes**: Any class implementing IProjectFIle outside the project (In extensions etc) might break until they implement this new method.