### PR TITLE
Adding .NET 6 installation to pipeline tasks to solve for Arcade builds

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -83,7 +83,13 @@ stages:
           displayName: 'Use .NET Core sdk'
           inputs:
             packageType: sdk
-            version: 5.0.400
+            version: 5.0.x
+            installationPath: $(Build.SourcesDirectory)/.dotnet
+        - task: UseDotNet@2
+          displayName: 'Use .NET Core sdk'
+          inputs:
+            packageType: sdk
+            version: 6.0.100
             installationPath: $(Build.SourcesDirectory)/.dotnet
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           - task: PowerShell@2

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -80,13 +80,13 @@ stages:
           clean: true
           submodules: true
         - task: UseDotNet@2
-          displayName: 'Use .NET Core sdk'
+          displayName: 'Use .NET Core 5.0.x'
           inputs:
             packageType: sdk
             version: 5.0.x
             installationPath: $(Build.SourcesDirectory)/.dotnet
         - task: UseDotNet@2
-          displayName: 'Use .NET Core sdk'
+          displayName: 'Use .NET Core 6.0.100'
           inputs:
             packageType: sdk
             version: 6.0.100


### PR DESCRIPTION
Arcade builds are failing .NET 6 Integration tests because they are now installing .NET 7 onto boxes instead of .NET 6. So, we need to forcefully (and side-by-side) install .NET 6 so these ITs can still execute.

This change adds a new build task that does this and so should unblock arcade builds.