### PR TITLE
Fix #1127

### DIFF
--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.cs
@@ -90,9 +90,24 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 {
                     return Context.ProjectCollection.LoadProject(FileInfo.FullName);
                 }
-                catch (InvalidProjectFileException ex)
+                catch (InvalidProjectFileException)
                 {
-                    throw new UpgradeException(LocalizedStrings.InvalidProjectError, ex);
+                    // TODO Delete obj file retry - a change in platform version may cause load to fail for UWP/WinUI apps
+                    var fileDirectory = FileInfo.Directory;
+                    var dirToDelete = fileDirectory?.EnumerateDirectories().Where(directory => directory.Name == "obj").FirstOrDefault();
+                    if (dirToDelete != null)
+                    {
+                        dirToDelete.Delete(true);
+                    }
+
+                    try
+                    {
+                        return Context.ProjectCollection.LoadProject(FileInfo.FullName);
+                    }
+                    catch (InvalidProjectFileException e)
+                    {
+                        throw new UpgradeException(LocalizedStrings.InvalidProjectError, e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR fixes #1127 where the project fails to load the project if the platform version is updated.
It adds a fallback option when the project loading fails and flushes out the old obj data before trying again.