### PR TITLE
Add NuGet.org source to install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ Download this free e-book on [Porting existing ASP.NET apps to .NET Core](https:
 The tool can be installed [from NuGet](https://www.nuget.org/packages/upgrade-assistant/) as a .NET CLI tool by running:
 
 ```
-dotnet tool install -g upgrade-assistant
+dotnet tool install -g --add-source 'https://api.nuget.org/v3/index.json' --ignore-failed-sources upgrade-assistant
 ```
 
 Similarly, because the Upgrade Assistant is installed as a .NET CLI tool, it can be easily updated from the command line:
 
 ```
-dotnet tool install -g --add-source 'https://api.nuget.org/v3/index.json' --ignore-failed-sources upgrade-assistant
+dotnet tool update -g --add-source 'https://api.nuget.org/v3/index.json' --ignore-failed-sources upgrade-assistant
 ```
 
 Upgrade-assistant is installed as a NuGet package, so invalid or authenticated sources in [NuGet configuration](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior) can cause installation problems.

--- a/README.md
+++ b/README.md
@@ -112,13 +112,7 @@ dotnet tool install -g upgrade-assistant
 Similarly, because the Upgrade Assistant is installed as a .NET CLI tool, it can be easily updated from the command line:
 
 ```
-dotnet tool update -g upgrade-assistant
-```
-
-If installation fails, trying running the install command with the `--ignore-failed-sources` parameter:
-
-```
-dotnet tool install -g upgrade-assistant --ignore-failed-sources
+dotnet tool install -g --add-source 'https://api.nuget.org/v3/index.json' --ignore-failed-sources upgrade-assistant
 ```
 
 Upgrade-assistant is installed as a NuGet package, so invalid or authenticated sources in [NuGet configuration](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior) can cause installation problems.


### PR DESCRIPTION
Some people may have NuGet.org removed as a source from their machine for one reason or another. This updates the install command to be a single one that ensures failed sources are ignored and NuGet.org is used.

See #1137 for an example