### PR TITLE
Used FirstOrDefault() to avoid assumption FindToken will return an item…

### DIFF
--- a/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/UWPtoWinAppSDKUpgrade/WinUIApiAlertCodeFixer.cs
+++ b/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/UWPtoWinAppSDKUpgrade/WinUIApiAlertCodeFixer.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Windows
             var diagnostic = context.Diagnostics.First();
             var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-            var declaration = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<StatementSyntax>().First();
+            var declaration = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<StatementSyntax>().FirstOrDefault();
 
             if (declaration is null)
             {


### PR DESCRIPTION
**PR Title**
Used FirstOrDefault to avoid error finding type StatementSyntax in WinUiApiAlertCodeFixer.cs

**PR Description**
Used FirstOrDefault() to avoid assumption FindToken will return an item

This avoids errors such as:

Applying upgrade step Apply fix for [UA306_A1, UA306_A2, UA306_A3, UA306_A4, UA306_B, UA306_C, UA306_D, UA306_E, UA306_F, UA306_G, UA306_H, UA306_I]: Replace usage of Windows.UI.Core.CoreDispatcher, Replace usage of Window.Current.Dispatcher, Replace usage of App.Window.Dispatcher, Replace usage of Window.Dispatcher, Replace usage of Windows.Media.Capture.CameraCaptureUI, Replace usage of Micorsoft.UI.Xaml.Controls.InkCanvas, Replace usage of Microsoft.UI.Xaml.Controls.Maps.MapControl, Replace usage of Microsoft.UI.Xaml.Controls.MediaElement, Replace usage of Windows.Graphics.Printing.PrintManager, Replace usage of Windows.Security.Authentication.Web.WebAuthenticationBroker, Replace usage of Windows.UI.Xaml.Media.AcrylicBrush.BackgroundSource, Replace usage of Windows.UI.Shell.TaskbarManager
[22:52:33 ERR] Unexpected error applying step
System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.WinUIApiAlertCodeFixer.RegisterCodeFixesAsync(CodeFixContext context)
   at Microsoft.DotNet.UpgradeAssistant.Steps.Source.CodeFixerStep.TryFixDiagnosticAsync(Diagnostic diagnostic, Document document, CancellationToken token)
   at Microsoft.DotNet.UpgradeAssistant.Steps.Source.CodeFixerStep.ApplyImplAsync(IUpgradeContext context, CancellationToken token)
   at Microsoft.DotNet.UpgradeAssistant.UpgradeStep.ApplyAsync(IUpgradeContext context, CancellationToken token) in C:\Code_Tmp\dotnet\upgrade-assistant\src\common\Microsoft.DotNet.UpgradeAssistant.Abstractions\UpgradeStep.cs:line 178

![image](https://user-images.githubusercontent.com/107234768/172991719-9bbde740-dcec-4c3c-9437-9a25fa916c24.png)


...with stack traces such as:

   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.WinUIApiAlertCodeFixer.<RegisterCodeFixesAsync>d__5.MoveNext() in C:\Code_Tmp\dotnet\upgrade-assistant\src\extensions\windows\Microsoft.DotNet.UpgradeAssistant.Extensions.Windows\UWPtoWinAppSDKUpgrade\WinUIApiAlertCodeFixer.cs:line 69
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.DotNet.UpgradeAssistant.Steps.Source.CodeFixerStep.<TryFixDiagnosticAsync>d__17.MoveNext() in C:\Code_Tmp\dotnet\upgrade-assistant\src\extensions\default\Microsoft.DotNet.UpgradeAssistant.Steps.Source\CodeFixerStep.cs:line 172
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.DotNet.UpgradeAssistant.Steps.Source.CodeFixerStep.<ApplyImplAsync>d__16.MoveNext() in C:\Code_Tmp\dotnet\upgrade-assistant\src\extensions\default\Microsoft.DotNet.UpgradeAssistant.Steps.Source\CodeFixerStep.cs:line 105
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.DotNet.UpgradeAssistant.UpgradeStep.<ApplyAsync>d__46.MoveNext() in C:\Code_Tmp\dotnet\upgrade-assistant\src\common\Microsoft.DotNet.UpgradeAssistant.Abstractions\UpgradeStep.cs:line 178

Addresses #1156

![image](https://user-images.githubusercontent.com/107234768/172991752-de3c5115-6124-4b14-a56a-d43eb2155354.png)
