### PR TITLE
bump Newtonsoft.Json to 13.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,8 +21,9 @@
       - Newtonsoft.Json versions 9.0.1 and 12.0.2 are built by source-build
       - Version 12.0.2 is written to Version.props
       - Arcade needs to use 9.0.1 so we need to override Version.props value here
+      - Security vuln flagged 6/23/2022 for <13.0.1
     -->
-    <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
+    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotNetBuildOffline)' == 'true'">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,7 +43,6 @@
     <MoqVersion>4.8.3</MoqVersion>
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
     <McMasterExtensionsCommandLineUtils>2.3.0</McMasterExtensionsCommandLineUtils>
-    <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <SystemTextJsonVersion>4.7.0</SystemTextJsonVersion>
     <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
     <NuGetVersion>5.6.0-preview.2.6489</NuGetVersion>
@@ -91,7 +90,7 @@
     <MicrosoftBuildLocatorVersion>1.4.1</MicrosoftBuildLocatorVersion>
     <MicrosoftBuildVersion>16.7</MicrosoftBuildVersion>
     <MicrosoftWin32RegistryVersion>5.0.0-rc.1.20451.14</MicrosoftWin32RegistryVersion>
-    <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
+    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <NuGetVersioningVersion>5.8.0-preview.3.6823</NuGetVersioningVersion>
     <SystemCollectionsImmutableVersion>5.0.0-rc.1.20451.14</SystemCollectionsImmutableVersion>
     <SystemCommandLineVersion>2.0.0-beta1.20371.2</SystemCommandLineVersion>


### PR DESCRIPTION
We have to get Newtonsoft up to 13.0.1+ due to [a security vulnerability](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).