### PR TITLE
Fixing integration tests on latest 1ES build pipelines

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -46,10 +46,10 @@ stages:
         pool:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCore1ESPool-Public
-            demands: ImageOverride -equals build.windows.amd64.vs2022.pre.open
+            demands: ImageOverride -equals build.windows.amd64.vs2022.open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals build.windows.amd64.vs2022.pre
+            demands: ImageOverride -equals build.windows.amd64.vs2022
         variables:
         # Enable signing for internal, non-PR builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/tests/tool/Integration.Tests/E2ETest.cs
+++ b/tests/tool/Integration.Tests/E2ETest.cs
@@ -60,7 +60,7 @@ namespace Integration.Tests
             var upgradeRunner = new UpgradeRunner();
 
             // Run upgrade
-            var result = await upgradeRunner.UpgradeAsync(Path.Combine(workingDir, inputFileName), entrypoint, _output, TimeSpan.FromMinutes(5)).ConfigureAwait(false);
+            var result = await upgradeRunner.UpgradeAsync(Path.Combine(workingDir, inputFileName), entrypoint, _output, TimeSpan.FromMinutes(15)).ConfigureAwait(false);
 
             Assert.Equal(ErrorCodes.Success, result);
 

--- a/tests/tool/Integration.Tests/Integration.Tests.csproj
+++ b/tests/tool/Integration.Tests/Integration.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <!-- The test framework brings in an old NuGet.Frameworks that ends up getting used rather than what MSBuild wants. -->
     <!-- Workaround solution, VSTest issue to remove the dependency for long term solution - https://github.com/microsoft/vstest/issues/3154 -->
-    <PackageReference Include="NuGet.Frameworks" Version="6.*" Condition=" '$(TargetFramework)' == 'net6.0' "/>
+    <PackageReference Include="NuGet.Frameworks" Version="6.3.0-rc.114" Condition=" '$(TargetFramework)' == 'net6.0' " />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\cli\Microsoft.DotNet.UpgradeAssistant.Cli\Microsoft.DotNet.UpgradeAssistant.Cli.csproj" />

--- a/tests/tool/Integration.Tests/Integration.Tests.csproj
+++ b/tests/tool/Integration.Tests/Integration.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <!-- The test framework brings in an old NuGet.Frameworks that ends up getting used rather than what MSBuild wants. -->
     <!-- Workaround solution, VSTest issue to remove the dependency for long term solution - https://github.com/microsoft/vstest/issues/3154 -->
-    <PackageReference Include="NuGet.Frameworks" Version="6.3.0-rc.114" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <PackageReference Include="NuGet.Frameworks" Version="6.*" Condition=" '$(TargetFramework)' == 'net6.0' "/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\cli\Microsoft.DotNet.UpgradeAssistant.Cli\Microsoft.DotNet.UpgradeAssistant.Cli.csproj" />


### PR DESCRIPTION
Trying a few different things to fix our 1ES builds. Namely, don't use the VS Preview when building.
Ideally we _would_ catch if this causes problems, but not in a CI that would potentially gate our releases.