### PR TITLE
Add PCL workload to .vsconfig

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -11,6 +11,7 @@
     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
     "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
     "Microsoft.VisualStudio.Component.FSharp",
+    "Microsoft.VisualStudio.Component.PortableLibrary",
     "Microsoft.ComponentGroup.ClickOnce.Publish",
     "Microsoft.NetCore.Component.DevelopmentTools",
     "Microsoft.VisualStudio.Component.FSharp.WebTemplates",


### PR DESCRIPTION
Without this Visual Studio workload, the PCL upgrade scenario test will fail. Add it to .vsconfig to give a hint as to what might be wrong.
