### PR TITLE
Disabling integration tests for Maui due to missing Xamarin workload

### DIFF
--- a/tests/tool/Integration.Tests/E2ETest.cs
+++ b/tests/tool/Integration.Tests/E2ETest.cs
@@ -35,17 +35,13 @@ namespace Integration.Tests
 
         [InlineData("PCL", "SamplePCL.csproj", "")]
         [InlineData("WpfSample/csharp", "BeanTrader.sln", "BeanTraderClient.csproj")]
-
-        // Skip on theories has issues in XUnit: https://github.com/xunit/visualstudio.xunit/issues/266
-#if !NET5_0
-        // Using statements are different for some reason on .NET 5 and .NET 6 after Roslyn runs
         [InlineData("WebLibrary/csharp", "WebLibrary.csproj", "")]
         [InlineData("AspNetSample/csharp", "TemplateMvc.csproj", "")]
         [InlineData("WpfSample/vb", "WpfApp1.sln", "")]
+/* Maui/Xamarin workload regression in Arcade build agents; temporarily disabling these tests
         [InlineData("MauiSample/droid", "EwDavidForms.sln", "EwDavidForms.Android.csproj")]
         [InlineData("MauiSample/ios", "EwDavidForms.sln", "EwDavidForms.iOS.csproj")]
-#endif
-
+*/
         [Theory]
         public async Task UpgradeTest(string scenarioPath, string inputFileName, string entrypoint)
         {


### PR DESCRIPTION
Arcade build agents currently have a regression where the Xamarin workload is missing, causing Maui ITs to fail.

So we can continue building & releasing UA, we're going to disable these ITs until the problem is resolved.