### PR TITLE
Updates PR template with reviewer group information

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,20 @@ below to ensure a smooth review and merge process for your PR. -->
 - [ ] You've included inline docs for your change, where applicable.
 - [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
 
+<!-- IMPORTANT -->
+**For PRs which target a specific extension within UA, you _must_ add the appropriate reviewer group _manually_** \
+since GH does not support doing this based on repo paths (yet)
+
+|Extension|Reviewer group to request|
+--|--
+UWP|`dotnet-upgrade-assistant-uwp`
+MAUI|`dotnet-upgrade-assistant-maui`
+WCF|`dotnet-upgrade-assistant-wcf`
+
+Extension changes won't be approved by a member of the `dotnet-upgrade-assistant-admin` group until a member of one of those has approved, when required.
+
+- [ ] You have requested the appropriate reviewer group for your extension code, or it is platform-level code.
+
 <!-- Once all that is done, you're ready to go. Open the PR with the content below. -->
 
 **PR Title**


### PR DESCRIPTION
This adds text to our PR template directing users to add the appropriate 
extension reviewer group to their PRs, based on the extension their PR is updating
and adds a ✅ signifying this has been done
