### PR TITLE
Fixing analyzebinaries command fails with p windows

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Analyze/ConsoleAnalyzeCommand.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Analyze/ConsoleAnalyzeCommand.cs
@@ -1,14 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
-using System.Threading;
-using System.Threading.Tasks;
 
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.DotNet.UpgradeAssistant.Analysis;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/AnalyzeBinaries/ConsoleAnalyzeBinaries.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/AnalyzeBinaries/ConsoleAnalyzeBinaries.cs
@@ -21,20 +21,17 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
         private readonly IAnalyzeResultWriterProvider _writerProvider;
         private readonly ILogger<ConsoleAnalyzeBinaries> _logger;
         private readonly IExtensionProvider _extensionProvider;
-        private readonly ITargetFrameworkSelector _tfmSelector;
 
         public ConsoleAnalyzeBinaries(IOptions<AnalysisOptions> analysisOptions,
             IBinaryAnalysisExecutor apiChecker,
             IAnalyzeResultWriterProvider writerProvider,
             IExtensionProvider extensionProvider,
-            ITargetFrameworkSelector tfmSelector,
             ILogger<ConsoleAnalyzeBinaries> logger)
         {
             _analysisOptions = analysisOptions ?? throw new ArgumentNullException(nameof(analysisOptions));
             _apiChecker = apiChecker ?? throw new ArgumentNullException(nameof(apiChecker));
             _writerProvider = writerProvider ?? throw new ArgumentNullException(nameof(writerProvider));
             _extensionProvider = extensionProvider ?? throw new ArgumentNullException(nameof(extensionProvider));
-            _tfmSelector = tfmSelector ?? throw new ArgumentNullException(nameof(tfmSelector));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/AnalyzeBinaries/ConsoleAnalyzeBinariesCommand.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/AnalyzeBinaries/ConsoleAnalyzeBinariesCommand.cs
@@ -1,18 +1,13 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
 
 using Microsoft.DotNet.UpgradeAssistant.Cli.Commands;
 using Microsoft.DotNet.UpgradeAssistant.Cli.Commands.AnalyzeBinaries;
-using Microsoft.DotNet.UpgradeAssistant.Extensions;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-
-using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Cli
 {
@@ -34,7 +29,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
             AddOption(new Option<bool>(new[] { "--allow-prerelease", "-pre" }, LocalizedStrings.BinaryAnalysisAllowPrereleaseHelp));
             AddOption(new Option<bool>(new[] { "--obsoletion", "-obs" }, LocalizedStrings.BinaryAnalysisObsoletedApisHelp));
-            AddOption(new Option(new[] { "--platform", "-p" }, LocalizedStrings.BinaryAnalysisPlatformHelp, typeof(Platform), () => Platform.Linux, ArgumentArity.OneOrMore));
+
+            var platformOption = new Option<Platform>(
+                aliases: new[] { "--platform", "-p" },
+                getDefaultValue: () => Platform.Linux,
+                description: LocalizedStrings.BinaryAnalysisPlatformHelp);
+            AddOption(platformOption);
             this.AddUniversalOptions(enableOutputFormatting: true);
         }
     }

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/AnalyzeBinaries/ConsoleAnalyzeBinariesCommand.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/AnalyzeBinaries/ConsoleAnalyzeBinariesCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
                     throw new ArgumentException(@"Must specify target file/directory for analysis");
                 }
 
-                return r.Tokens.Select<Token, FileSystemInfo>(i =>
+                return r.Tokens.Select<Token, FileSystemInfo?>(i =>
                 {
                     var path = i.Value;
                     if (string.IsNullOrEmpty(path))
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
                     {
                         return new FileInfo(path);
                     }
-                }).ToArray();
+                }).Where(i => i is not null).Cast<FileSystemInfo>().ToArray();
             }, description: LocalizedStrings.BinaryAnalysisContentHelp)
             {
                 Arity = ArgumentArity.OneOrMore,

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/ExtensionManagement/ExtensionManagementCommand.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/ExtensionManagement/ExtensionManagementCommand.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
 
 using Microsoft.DotNet.UpgradeAssistant.Extensions;

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/FeatureFlagCommand.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/FeatureFlagCommand.cs
@@ -1,15 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.DotNet.UpgradeAssistant.Extensions;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/UpgradeAssistantCommand{TAppCommand,TOptions}.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/UpgradeAssistantCommand{TAppCommand,TOptions}.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
 
 using Microsoft.DotNet.UpgradeAssistant.Cli.Commands;

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/ConsoleRunner.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/ConsoleRunner.cs
@@ -40,7 +40,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "This method should not throw any exceptions.")]
         public async Task StartAsync(CancellationToken token)
         {
             try

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Microsoft.DotNet.UpgradeAssistant.Cli.csproj
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Microsoft.DotNet.UpgradeAssistant.Cli.csproj
@@ -47,7 +47,7 @@
       <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.CommandLine">
-      <Version>2.0.0-beta1.21216.1</Version>
+      <Version>2.0.0-beta4.22272.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
@@ -88,6 +88,7 @@
     <PackageReference Include="NuGet.Versioning" ExcludeAssets="runtime">
       <Version>5.8.0</Version>
     </PackageReference>
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Program.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Program.cs
@@ -42,7 +42,16 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
 
             return new CommandLineBuilder(root)
                 .UseDefaults()
-                .UseHelpBuilder(b => new HelpWithHeader(b.Console))
+                .UseHelp(ctx => ctx.HelpBuilder.CustomizeLayout(_ =>
+                    HelpBuilder.Default
+                    .GetLayout()
+                    .Skip(1)
+                    .Prepend(_ =>
+                    {
+                        ShowHeader();
+
+                        _.Output.WriteLine(LocalizedStrings.UpgradeAssistantHeaderDetails);
+                    })))
                 .Build()
                 .InvokeAsync(args);
 
@@ -66,21 +75,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             Console.WriteLine(survey);
             Console.WriteLine(bar);
             Console.WriteLine();
-        }
-
-        private class HelpWithHeader : HelpBuilder
-        {
-            public HelpWithHeader(IConsole console)
-                : base(console, maxWidth: ConsoleUtils.Width)
-            {
-            }
-
-            protected override void AddSynopsis(ICommand command)
-            {
-                ShowHeader();
-
-                WriteHeading(LocalizedStrings.UpgradeAssistantHeaderDetails, null);
-            }
         }
     }
 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/TargetFramework/DefaultTfmOptions.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/TargetFramework/DefaultTfmOptions.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.DotNet.UpgradeAssistant
 {
-    public record DefaultTfmOptions
+    public class DefaultTfmOptions
     {
         [Required]
         public string Current { get; set; } = null!;

--- a/src/extensions/binaryanalysis/Microsoft.DotNet.UpgradeAssistant.Extensions.BinaryAnalysis/Analysis/ApiChecker.cs
+++ b/src/extensions/binaryanalysis/Microsoft.DotNet.UpgradeAssistant.Extensions.BinaryAnalysis/Analysis/ApiChecker.cs
@@ -24,12 +24,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.BinaryAnalysis.Analysis
 {
     public sealed class ApiChecker : IBinaryAnalysisExecutor
     {
-        private readonly ILogger<ApiChecker> _logger;
         private readonly IBinaryAnalysisExecutorOptions _options;
         private readonly DefaultTfmOptions _tfmSelector;
+        private readonly ILogger<ApiChecker> _logger;
 
         public ApiChecker(IBinaryAnalysisExecutorOptions options,
-            ITargetFrameworkSelector tfmSelector,
             IOptions<DefaultTfmOptions> selectorOptions,
             ILogger<ApiChecker> logger)
         {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the upgrade-assistant repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- IMPORTANT -->
**For PRs which target a specific extension within UA, you _must_ add the appropriate reviewer group _manually_** \
since GH does not support doing this based on repo paths (yet)

|Extension|Reviewer group to request|
--|--
UWP|`dotnet-upgrade-assistant-uwp`
MAUI|`dotnet-upgrade-assistant-maui`
WCF|`dotnet-upgrade-assistant-wcf`

Extension changes won't be approved by a member of the `dotnet-upgrade-assistant-admin` group until a member of one of those has approved, when required.

- [x] You have requested the appropriate reviewer group for your extension code, or it is platform-level code.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Resolving parameter parsing of Binary Analysis platform arg (`-p`)

**PR Description**
This resolves the exception thrown by the parsing of the platform argument by upgrading `System.CommandLine` and resolving breaks. Additionally, I found in my testing that `record` types had issues with the DI container and surfaced as effectively a race condition w/ resolving the `IOptions<DefaultTfmOptions>`.

Fixes #1253

