### PR TITLE
Fixing TFM selection for VB projects

### DIFF
--- a/src/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic/MyTypeTargetFrameworkSelectorFilter.cs
+++ b/src/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic/MyTypeTargetFrameworkSelectorFilter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic
@@ -37,11 +38,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic
 
             if (_windowsMyTypes.Contains(myType))
             {
-                var final = tfm.AppBase with { Platform = TargetFrameworkSelector.Platforms.Windows };
+                var final = tfm.AppBase with { Platform = TargetFrameworkMoniker.Platforms.Windows };
                 _logger.LogInformation("Project {Name} contains MyType node that requires at least {framework}", tfm.Project, final);
-                
-                tfm.TryUpdate(final);
 
+                tfm.TryUpdate(final);
             }
         }
     }

--- a/src/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic/MyTypeTargetFrameworkSelectorFilter.cs
+++ b/src/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic/MyTypeTargetFrameworkSelectorFilter.cs
@@ -37,7 +37,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic
 
             if (_windowsMyTypes.Contains(myType))
             {
-                _logger.LogInformation("Project {Name} contains MyType node that requires at least {framework}-windows.", tfm.Project, tfm.AppBase);
+                var final = tfm.AppBase with { Platform = TargetFrameworkSelector.Platforms.Windows };
+                _logger.LogInformation("Project {Name} contains MyType node that requires at least {framework}", tfm.Project, final);
+                
+                tfm.TryUpdate(final);
 
                 tfm.TryUpdate(tfm.AppBase);
             }

--- a/src/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic/MyTypeTargetFrameworkSelectorFilter.cs
+++ b/src/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic/MyTypeTargetFrameworkSelectorFilter.cs
@@ -37,9 +37,9 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic
 
             if (_windowsMyTypes.Contains(myType))
             {
-                _logger.LogInformation("Project {Name} contains MyType node that requires at least net5.0-windows.", tfm.Project);
+                _logger.LogInformation("Project {Name} contains MyType node that requires at least {framework}-windows.", tfm.Project, tfm.AppBase);
 
-                tfm.TryUpdate(TargetFrameworkMoniker.Net50_Windows);
+                tfm.TryUpdate(tfm.AppBase);
             }
         }
     }

--- a/src/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic/MyTypeTargetFrameworkSelectorFilter.cs
+++ b/src/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic/MyTypeTargetFrameworkSelectorFilter.cs
@@ -42,7 +42,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic
                 
                 tfm.TryUpdate(final);
 
-                tfm.TryUpdate(tfm.AppBase);
             }
         }
     }

--- a/tests/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic.Tests/MyTypeTargetFrameworkSelectorFilterTests.cs
+++ b/tests/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic.Tests/MyTypeTargetFrameworkSelectorFilterTests.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Autofac.Extras.Moq;
+
 using Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic;
+
 using Moq;
+
 using Xunit;
 
 namespace Microsoft.DotNet.UpgradeAssistant.VisualBasic.Tests
@@ -21,6 +24,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.VisualBasic.Tests
             // Arrange
             using var mock = AutoMock.GetLoose();
             var state = new Mock<ITargetFrameworkSelectorFilterState>();
+            state.Setup(s => s.AppBase).Returns(TargetFrameworkMoniker.Net60);
 
             var project = new Mock<IProject>();
             state.Setup(s => s.Project).Returns(project.Object);
@@ -35,7 +39,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.VisualBasic.Tests
 
             // Assert
             var expectedTimes = update ? Times.Once() : Times.Never();
-            state.Verify(s => s.TryUpdate(TargetFrameworkMoniker.Net50_Windows), expectedTimes);
+            state.Verify(s => s.TryUpdate(TargetFrameworkMoniker.Net60), expectedTimes);
         }
     }
 }

--- a/tests/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic.Tests/MyTypeTargetFrameworkSelectorFilterTests.cs
+++ b/tests/extensions/vb/Microsoft.DotNet.UpgradeAssistant.Extensions.VisualBasic.Tests/MyTypeTargetFrameworkSelectorFilterTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.VisualBasic.Tests
 
             // Assert
             var expectedTimes = update ? Times.Once() : Times.Never();
-            state.Verify(s => s.TryUpdate(TargetFrameworkMoniker.Net60), expectedTimes);
+            state.Verify(s => s.TryUpdate(TargetFrameworkMoniker.Net60_Windows), expectedTimes);
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the upgrade-assistant repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- IMPORTANT -->
**For PRs which target a specific extension within UA, you _must_ add the appropriate reviewer group _manually_** \
since GH does not support doing this based on repo paths (yet)

|Extension|Reviewer group to request|
--|--
UWP|`dotnet-upgrade-assistant-uwp`
MAUI|`dotnet-upgrade-assistant-maui`
WCF|`dotnet-upgrade-assistant-wcf`

Extension changes won't be approved by a member of the `dotnet-upgrade-assistant-admin` group until a member of one of those has approved, when required.

- [x] You have requested the appropriate reviewer group for your extension code, or it is platform-level code.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Remove previous hard-coding of TFM for VB projects

**PR Description**
The code for TFM application for VB projects was hard-coded against .NET 5. This needs to accept the input from the TargetSelectionFilter object and apply via `.AppBase`. This change does that

Fixes #1031
