### PR TITLE
Add .NET MAUI support version doc

### DIFF
--- a/docs/maui_support.md
+++ b/docs/maui_support.md
@@ -4,6 +4,7 @@ We are currently building out support for upgrade-assistant to handle Xamarin.Fo
 
 ## Supported Project types and minimum requirements
 
+- The latest version of .NET Upgrade Assistant from the [Azure Devops Pipeline](https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-tools)
 - Xamarin.Forms app using Xamarin.Forms 5.0 or higher
   - ✅ iOS project
   - ✅ Android project


### PR DESCRIPTION
## Description

Added to the requirement that it is available from the Azure DevOps Pipeline version as well as UWP support for the following reasons:

- .NET MAUI support is not available in stable as of today, it appears to be available only from the development version of Azure DevOps Pipeline.
- Functions related to UWP are specified to use the development version version, but there is no description for Xamarin.Forms

Addresses #1265