### PR TITLE
Fixing #1297

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/UpgradeAssistantCommand{TAppCommand,TOptions}.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/UpgradeAssistantCommand{TAppCommand,TOptions}.cs
@@ -29,9 +29,9 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
                     .RunUpgradeAssistantAsync(token));
 
             AddArgument(new Argument<FileInfo>("project", LocalizedStrings.UpgradeAssistantCommandProject) { Arity = ArgumentArity.ExactlyOne }.ExistingOnly());
-            AddOption(new Option<IReadOnlyCollection<string>>(new[] { "--extension", "-x" }, LocalizedStrings.UpgradeAssistantCommandExtension));
-            AddOption(new Option<IReadOnlyCollection<string>>(new[] { "--option", "-o" }, LocalizedStrings.UpgradeAssistantCommandOption));
-            AddOption(new Option<IReadOnlyCollection<string>>(new[] { "--entry-point", "-e" }, LocalizedStrings.UpgradeAssistantCommandEntrypoint));
+            AddOption(new Option<ICollection<string>>(new[] { "--extension", "-x" }, LocalizedStrings.UpgradeAssistantCommandExtension));
+            AddOption(new Option<ICollection<string>>(new[] { "--option", "-o" }, LocalizedStrings.UpgradeAssistantCommandOption));
+            AddOption(new Option<ICollection<string>>(new[] { "--entry-point", "-e" }, LocalizedStrings.UpgradeAssistantCommandEntrypoint));
             AddOption(new Option<bool>(new[] { "--ignore-unsupported-features", "-i" }, LocalizedStrings.UpgradeAssistantCommandIgnoreUnsupported));
             AddOption(new Option<DirectoryInfo>(new[] { "--vs-path" }, LocalizedStrings.UpgradeAssistantCommandVS));
             AddOption(new Option<DirectoryInfo>(new[] { "--msbuild-path" }, LocalizedStrings.UpgradeAssistantCommandMsbuild));


### PR DESCRIPTION
System.Commandline no longer supports IReadOnlyCollection, it seems. Pivoted to ICollection<T> but still assigning to an IReadOnlyCollection which solves the parsing, but still protects the collection from modification

cc @twsouthwick @mjrousos @sunandabalu for review