### PR TITLE
Add helper to convert GetForCurrentView

### DIFF
--- a/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/Templates/WinAppSDKTemplates/UWPToWinAppSDKUpgradeHelpers.cs
+++ b/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/Templates/WinAppSDKTemplates/UWPToWinAppSDKUpgradeHelpers.cs
@@ -16,4 +16,16 @@ namespace UWPToWinAppSDKUpgradeHelpers
             [System.Runtime.InteropServices.In] ref Guid riid);
         void ShowShareUIForWindow(IntPtr appWindow);
     }
+
+    static class DataTransferManagerHelper
+    {
+        public static Windows.ApplicationModel.DataTransfer.DataTransferManager MarshalledDataTransferManagerFromWindow(IntPtr appWindow)
+        {
+            var _dtm_iid = new Guid(0xa5caee9b, 0x8708, 0x49d1, 0x8d, 0x36, 0x67, 0xd2, 0x5a, 0x8d, 0xa0, 0x0c);
+            var result = Windows.ApplicationModel.DataTransfer.DataTransferManager.As<UWPToWinAppSDKUpgradeHelpers.IDataTransferManagerInterop>()
+                .GetForWindow(appWindow, _dtm_iid);
+
+            return WinRT.MarshalInterface<Windows.ApplicationModel.DataTransfer.DataTransferManager>.FromAbi(result);
+        }
+    }
 }

--- a/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/UWPtoWinAppSDKUpgrade/WinUIDataTransferManagerAnalyzer.cs
+++ b/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/UWPtoWinAppSDKUpgrade/WinUIDataTransferManagerAnalyzer.cs
@@ -45,13 +45,19 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Windows
                 .Select(usingDirective => usingDirective.Name.ToString());
         }
 
+        private bool IsSameCallString(string callString, string expectedNamespace, string expectedCall, IEnumerable<string> allNamespaces)
+        {
+            return callString == $"{expectedNamespace}.{expectedCall}" || (callString == expectedCall && allNamespaces.Contains(expectedNamespace));
+        }
+
         private void AnalyzeObjectCreationExpression(SyntaxNodeAnalysisContext context)
         {
             var node = (InvocationExpressionSyntax)context.Node;
             var namespaces = AllNamespaces(context);
             var firstChildText = node.ChildNodes().First().ToString();
-            if ((firstChildText == "DataTransferManager.ShowShareUI" && namespaces.Contains("Windows.ApplicationModel.DataTransfer"))
-                || firstChildText == "Windows.ApplicationModel.DataTransfer.DataTransferManager.ShowShareUI")
+
+            if (IsSameCallString(firstChildText, "Windows.ApplicationModel.DataTransfer", "DataTransferManager.ShowShareUI", namespaces)
+                || IsSameCallString(firstChildText, "Windows.ApplicationModel.DataTransfer", "DataTransferManager.GetForCurrentView", namespaces))
             {
                 var diagnostic = Diagnostic.Create(Rule, node.GetLocation(), node.GetText().ToString());
                 context.ReportDiagnostic(diagnostic);

--- a/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/UWPtoWinAppSDKUpgrade/WinUIDataTransferManagerCodeFixer.cs
+++ b/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/UWPtoWinAppSDKUpgrade/WinUIDataTransferManagerCodeFixer.cs
@@ -65,9 +65,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Windows
             }
 
             var documentEditor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-            var newExpressionRoot = await CSharpSyntaxTree.ParseText(@"
-                Windows.ApplicationModel.DataTransfer.DataTransferManager.As<UWPToWinAppSDKUpgradeHelpers.IDataTransferManagerInterop>().ShowShareUIForWindow(App.WindowHandle)
-                ", cancellationToken: cancellationToken).GetRootAsync(cancellationToken).ConfigureAwait(false);
+            var newExpressionText = invocationExpressionSyntax.ToString().Contains("GetForCurrentView") ?
+                "\n   UWPToWinAppSDKUpgradeHelpers.DataTransferManagerHelper.MarshalledDataTransferManagerFromWindow(App.WindowHandle)" :
+                "\n   Windows.ApplicationModel.DataTransfer.DataTransferManager.As<UWPToWinAppSDKUpgradeHelpers.IDataTransferManagerInterop>().ShowShareUIForWindow(App.WindowHandle)";
+            var newExpressionRoot = await CSharpSyntaxTree.ParseText(newExpressionText, cancellationToken: cancellationToken).GetRootAsync(cancellationToken).ConfigureAwait(false);
             var newExpression = newExpressionRoot.DescendantNodes().OfType<InvocationExpressionSyntax>().First();
             documentEditor.ReplaceNode(invocationExpressionSyntax, newExpression);
             return document.WithSyntaxRoot(documentEditor.GetChangedRoot());


### PR DESCRIPTION
This PR adds a new helper method to marshal `DataTransferManager `and use it to replace `DataTransferManager.GetForCurrentView()`