### PR TITLE
Fixes for MAUI, logging, failed step repetitions, etc.

### DIFF
--- a/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Upgrade/ConsoleUpgrade.cs
+++ b/src/cli/Microsoft.DotNet.UpgradeAssistant.Cli/Commands/Upgrade/ConsoleUpgrade.cs
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Cli
             if (!await ExecuteAndTimeCommand(context, step, command, token))
             {
                 Console.ForegroundColor = ConsoleColor.Yellow;
-                await _io.Output.WriteAsync($"Command ({command.CommandText}) did not succeed");
+                await _io.Output.WriteLineAsync($"Command ({command.CommandText}) did not succeed");
                 Console.ResetColor();
             }
             else if (!await _input.WaitToProceedAsync(token))

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/OutputLevel.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/OutputLevel.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.DotNet.UpgradeAssistant
+{
+    public enum OutputLevel
+    {
+        Info,
+        Warning,
+        Error
+    }
+}

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/OutputResult.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/OutputResult.cs
@@ -7,6 +7,8 @@ namespace Microsoft.DotNet.UpgradeAssistant
 {
     public record OutputResult
     {
+        public OutputLevel Level { get; init; } = OutputLevel.Info;
+
         public string RuleId { get; init; } = string.Empty;
 
         public string RuleName { get; init; } = string.Empty;
@@ -19,7 +21,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
         /// <summary>
         /// Gets the link to the documentation.
         /// </summary>
-        public Uri HelpUri { get; init; } = new("about:blank");
+        public Uri? HelpUri { get; init; }
 
         public int LineNumber { get; init; }
 

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TestOptions.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/TestOptions.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.UpgradeAssistant
+{
+    public class TestOptions
+    {
+        public bool IsRunningTest { get; set; }
+    }
+}

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/UpgradeStep.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/UpgradeStep.cs
@@ -85,7 +85,6 @@ namespace Microsoft.DotNet.UpgradeAssistant
         public bool IsDone => Status switch
         {
             UpgradeStepStatus.Complete => true,
-            UpgradeStepStatus.Failed => true,
             UpgradeStepStatus.Skipped => true,
             _ => false,
         };

--- a/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/UpgradeStep.cs
+++ b/src/common/Microsoft.DotNet.UpgradeAssistant.Abstractions/UpgradeStep.cs
@@ -80,11 +80,12 @@ namespace Microsoft.DotNet.UpgradeAssistant
         public BuildBreakRisk Risk { get; private set; }
 
         /// <summary>
-        /// Gets a value indicating whether the upgrade is done (has completed successfully or was skipped).
+        /// Gets a value indicating whether the upgrade is done (has completed successfully, failed, or was skipped).
         /// </summary>
         public bool IsDone => Status switch
         {
             UpgradeStepStatus.Complete => true,
+            UpgradeStepStatus.Failed => true,
             UpgradeStepStatus.Skipped => true,
             _ => false,
         };
@@ -97,7 +98,7 @@ namespace Microsoft.DotNet.UpgradeAssistant
         /// <summary>
         /// Implementers should use this method to indicate whether the upgrade step applies to a given upgrade context.
         /// Note that applicability is not about whether the step is complete or not (InitializeImplAsync should check that),
-        /// rather it is about whether it would ever make sense to run the migraiton step on the given context or not.
+        /// rather it is about whether it would ever make sense to run the migration step on the given context or not.
         /// For example, a upgrade step that acts at the project level would be inapplicable when a solution is selected
         /// rather than a project.
         /// </summary>
@@ -196,8 +197,9 @@ namespace Microsoft.DotNet.UpgradeAssistant
             catch (Exception e)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                (Status, StatusDetails) = (UpgradeStepStatus.Failed, "Unexpected error applying step.");
-                Logger.LogError(e, "Unexpected error applying step");
+                (Status, StatusDetails) = (UpgradeStepStatus.Failed, $"Unexpected error applying upgrade step '{Title}'");
+                Logger.LogError(e, "Unexpected error applying upgrade step {StepTitle}", Title);
+                context.AddResultForStep(this, context.CurrentProject?.GetFile()?.FilePath ?? string.Empty, Status, StatusDetails, details: e.ToString(), outputLevel: OutputLevel.Error);
                 return false;
             }
         }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.Analysis/SarifAnalyzeResultWriter.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.Analysis/SarifAnalyzeResultWriter.cs
@@ -97,6 +97,17 @@ namespace Microsoft.DotNet.UpgradeAssistant.Analysis
 
         private static IList<Result> ExtractResults(IList<OutputResult> analyzeResults)
         {
+            FailureLevel GetFailureLevel(OutputLevel level)
+            {
+                return level switch
+                {
+                    OutputLevel.Info => FailureLevel.Note,
+                    OutputLevel.Warning => FailureLevel.Warning,
+                    OutputLevel.Error => FailureLevel.Error,
+                    _ => throw new ArgumentException($"Invalid {nameof(OutputLevel)}", nameof(level))
+                };
+            }
+
             var results = new List<Result>();
             foreach (var r in analyzeResults)
             {
@@ -104,6 +115,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Analysis
                 {
                     RuleId = r.RuleId,
                     Message = r.ResultMessage.ToMessage(),
+                    Level = GetFailureLevel(r.Level),
                     Locations = new List<Location>()
                     {
                         new()

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/MSBuildProject.File.cs
@@ -132,7 +132,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
             var backupName = $"{Path.GetFileNameWithoutExtension(fileName)}.old{Path.GetExtension(fileName)}";
             var counter = 0;
 
-            while (File.Exists(backupName))
+            while (File.Exists(Path.Combine(Path.GetDirectoryName(filePath)!, backupName)))
             {
                 backupName = $"{Path.GetFileNameWithoutExtension(fileName)}.old.{counter++}{Path.GetExtension(fileName)}";
             }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/TargetFramework/DependencyMinimumTargetFrameworkSelectorFilter.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/TargetFramework/DependencyMinimumTargetFrameworkSelectorFilter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.TargetFramework
 
             if (tfm.Components.HasFlag(ProjectComponents.MauiAndroid) || tfm.Components.HasFlag(ProjectComponents.MauiiOS) || tfm.Components.HasFlag(ProjectComponents.Maui))
             {
-                _logger.LogInformation("Skip minimum dependency check because .NET MAUI support multiple TFMs.");
+                _logger.LogInformation("Skip minimum dependency check because .NET MAUI supports multiple TFMs.");
             }
             else if (tfm.Components.HasFlag(ProjectComponents.WinUI))
             {
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.TargetFramework
                     {
                         if (tfm.TryUpdate(min))
                         {
-                            _logger.LogInformation("Recommending TFM {TFM} because of dependency on project {Dependency}", min, dep.GetFile().FilePath);
+                            _logger.LogInformation("Recommending TFM {TFM} for project {Name} because of dependency on project {Dependency}", min, tfm.Project, dep.GetFile().FilePath);
                         }
                     }
                 }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/TargetFramework/ExecutableTargetFrameworkSelectorFilter.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/TargetFramework/ExecutableTargetFrameworkSelectorFilter.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.TargetFramework
             {
                 if (tfm.TryUpdate(tfm.AppBase))
                 {
-                    _logger.LogInformation("Recommending executable TFM {TFM} because the project builds to an executable", tfm.AppBase);
+                    _logger.LogInformation("Recommending executable TFM {TFM} for project {Name} because the project builds to an executable", tfm.AppBase, tfm.Project);
                 }
             }
         }

--- a/src/components/Microsoft.DotNet.UpgradeAssistant/UpgraderManager.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant/UpgraderManager.cs
@@ -15,15 +15,18 @@ namespace Microsoft.DotNet.UpgradeAssistant
     {
         private readonly IUpgradeStepOrderer _orderer;
         private readonly ITelemetry _telemetry;
+        private readonly IUserInput _userInput;
         private readonly ILogger _logger;
 
         public UpgraderManager(
             IUpgradeStepOrderer orderer,
             ITelemetry telemetry,
+            IUserInput userInput,
             ILogger<UpgraderManager> logger)
         {
             _orderer = orderer ?? throw new ArgumentNullException(nameof(orderer));
             _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+            _userInput = userInput ?? throw new ArgumentNullException(nameof(userInput));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -153,6 +156,12 @@ namespace Microsoft.DotNet.UpgradeAssistant
                     {
                         return nextSubStep;
                     }
+                }
+
+                if (step.Status == UpgradeStepStatus.Failed && !_userInput.IsInteractive)
+                {
+                    // Don't return failed steps in non-interactive mode
+                    continue;
                 }
 
                 if (!step.IsDone)

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.Solution/CurrentProjectSelectionStep.cs
@@ -101,8 +101,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
 
             if (allProjectsAreUpgraded)
             {
-                Logger.LogInformation("No projects need upgraded for selected entrypoint");
-                return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "No projects need upgraded", BuildBreakRisk.None);
+                Logger.LogInformation("No projects need to be upgraded for selected entrypoint");
+                return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, "No projects need to be upgraded", BuildBreakRisk.None);
             }
 
             // If no project is selected, and at least one still needs upgraded, identify the next project to upgrade
@@ -129,7 +129,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             {
                 if (await IsCompletedAsync(context, newCurrentProject, token).ConfigureAwait(false))
                 {
-                    Logger.LogDebug("Project {Project} does not need upgraded", newCurrentProject.FileInfo);
+                    Logger.LogDebug("Project {Project} does not need to be upgraded", newCurrentProject.FileInfo);
                 }
                 else if (!(await RunChecksAsync(newCurrentProject, token).ConfigureAwait(false)))
                 {
@@ -140,6 +140,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
                     context.SetCurrentProject(newCurrentProject);
                 }
 
+                Logger.LogInformation("Project {Name} was selected", newCurrentProject.GetRoslynProject().Name);
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, $"Project {newCurrentProject.GetRoslynProject().Name} was selected", BuildBreakRisk.None);
             }
         }
@@ -160,6 +161,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Solution
             else
             {
                 context.SetCurrentProject(selectedProject);
+                Logger.LogInformation("Project {Name} was selected", selectedProject.GetRoslynProject().Name);
                 return new UpgradeStepApplyResult(UpgradeStepStatus.Complete, $"Project {selectedProject.GetRoslynProject().Name} was selected.");
             }
         }

--- a/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.Source/CodeFixerStep.cs
+++ b/src/extensions/default/Microsoft.DotNet.UpgradeAssistant.Steps.Source/CodeFixerStep.cs
@@ -165,7 +165,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Steps.Source
 
         private void AddResultToContext(IUpgradeContext context, string diagnosticId, string location, UpgradeStepStatus status, string resultMessage)
         {
-            context.AddResult(Title, location, diagnosticId, status, resultMessage);
+            context.AddResult(Title, Description, location, diagnosticId, status, resultMessage);
         }
 
         private async Task<Solution?> TryFixDiagnosticAsync(Diagnostic diagnostic, Document document, CancellationToken token)

--- a/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiComponentIdentifier.cs
+++ b/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiComponentIdentifier.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
                 }
             }
 
-            if (project.NuGetReferences.PackageReferences.Any(x => x.Name.Equals(_xamarinFormsPackage, StringComparison.OrdinalIgnoreCase)) && project.TargetFrameworks.FirstOrDefault().Equals(TargetFrameworkMoniker.NetStandard20))
+            if (project.NuGetReferences.PackageReferences.Any(x => x.Name.Equals(_xamarinFormsPackage, StringComparison.OrdinalIgnoreCase)) && project.IsNetStandard())
             {
                 components |= ProjectComponents.Maui;
             }

--- a/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiPlatformTargetFrameworkUpgradeStep.cs
+++ b/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiPlatformTargetFrameworkUpgradeStep.cs
@@ -46,38 +46,38 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
             var project = context.CurrentProject.Required();
             var file = project.GetFile();
             var components = await project.GetComponentsAsync(token).ConfigureAwait(false);
-            var projectproperties = project.GetProjectPropertyElements();
 
-            // This block checks TFMs for .NET MAUI Head Project
+            // This block checks TFMs for .NET MAUI project
             if (components.HasFlag(ProjectComponents.Maui) && file.IsSdk)
             {
-                if (string.Equals(projectproperties.GetProjectPropertyValue("TargetFramework").FirstOrDefault(), TargetFrameworkMoniker.NetStandard20.ToString(), StringComparison.OrdinalIgnoreCase))
+                if (project.IsNetStandard())
                 {
-                    projectproperties.RemoveProjectProperty("TargetFramework");
+                    var projectProperties = project.GetProjectPropertyElements();
+                    projectProperties.RemoveProjectProperty("TargetFramework");
                     file.SetPropertyValue("UseMaui", "true");
                     file.SetPropertyValue("TargetFrameworks", "net7.0-android;net7.0-ios");
                     await file.SaveAsync(token).ConfigureAwait(false);
-                    Logger.LogInformation("Added TFMs to .NET MAUI project");
-                    return new UpgradeStepApplyResult(UpgradeStepStatus.Complete, $"Added TFMs to .NET MAUI Head project");
+                    Logger.LogInformation("Added TFMs to .NET MAUI project {ProjectName}", project);
+                    return context.CreateAndAddStepApplyResult(this, UpgradeStepStatus.Complete, $"Added TFMs to .NET MAUI project {project}");
                 }
                 else
                 {
-                    return new UpgradeStepApplyResult(UpgradeStepStatus.Failed, "Project is not of type Maui Head Project");
+                    return context.CreateAndAddStepApplyResult(this, UpgradeStepStatus.Failed, $"Project {project} is not recognized as a .NET MAUI project (TargetFrameworks: {string.Join(", ", project.TargetFrameworks)})");
                 }
             }
 
+            // If we're getting here we are dealing with a head project, which received its "componentFlag" in the TryConvertRunner
             var componentFlagProperty = context.Properties.GetPropertyValue("componentFlag");
             if (componentFlagProperty is null)
             {
-                return new UpgradeStepApplyResult(UpgradeStepStatus.Failed, $"componentFlag Context property was null.");
+                return context.CreateAndAddStepApplyResult(this, UpgradeStepStatus.Failed, $"componentFlag Context property was null");
             }
 
             var targetTfm = GetExpectedTargetFramework(componentFlagProperty);
             file.SetTFM(targetTfm);
-            Logger.LogInformation("TFM set to {TargetTFM}", targetTfm);
-
             await file.SaveAsync(token).ConfigureAwait(false);
-            return new UpgradeStepApplyResult(UpgradeStepStatus.Complete, $"Added TFM {targetTfm} to .NET MAUI project ");
+            Logger.LogInformation("Added TFM {TargetTFM} to .NET MAUI head project {ProjectName}", targetTfm, project);
+            return context.CreateAndAddStepApplyResult(this, UpgradeStepStatus.Complete, $"Added TFM {targetTfm} to .NET MAUI head project {project}");
         }
 
         protected async override Task<UpgradeStepInitializeResult> InitializeImplAsync(IUpgradeContext context, CancellationToken token)
@@ -89,16 +89,15 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
 
             var project = context.CurrentProject.Required();
             var components = await project.GetComponentsAsync(token).ConfigureAwait(false);
-            var projectproperties = project.GetProjectPropertyElements();
 
             // This block checks TFMs for .NET MAUI Head Project
             if (components.HasFlag(ProjectComponents.Maui))
             {
-                if (project.TargetFrameworks.Any(x => x.IsNetStandard))
+                if (project.IsNetStandard())
                 {
-                    Logger.LogInformation("TFM needs updated to .NET MAUI TFMs");
+                    Logger.LogInformation("TFM needs to be updated to .NET MAUI TFMs");
 
-                    return new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, "TFM needs to be updated to .NET MAUI Targetframeworks", BuildBreakRisk.High);
+                    return new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, "TFM needs to be updated to .NET MAUI TargetFrameworks", BuildBreakRisk.High);
                 }
                 else
                 {
@@ -120,7 +119,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
             }
             else
             {
-                Logger.LogInformation("TFM needs updated to {TargetTFM}", targetTfm);
+                Logger.LogInformation("TFM needs to be updated to {TargetTFM}", targetTfm);
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"TFM needs to be updated to {targetTfm}", BuildBreakRisk.High);
             }
         }

--- a/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiTargetFrameworkSelectorFilter.cs
+++ b/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiTargetFrameworkSelectorFilter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
@@ -25,39 +26,36 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
 
             if (tfm.Components.HasFlag(ProjectComponents.XamarinAndroid))
             {
-                _logger.LogInformation("Project {Name} is of type Xamarin.Android, migration to .NET MAUI recommends net7.0-android.", tfm.Project);
+                _logger.LogInformation("Recommending TFM {TFM} for project {Name} because project is of type Xamarin.Android", TargetFrameworkMoniker.Net70_Android, tfm.Project);
                 tfm.TryUpdate(TargetFrameworkMoniker.Net70_Android);
             }
 
             if (tfm.Components.HasFlag(ProjectComponents.XamariniOS))
             {
-                _logger.LogInformation("Project {Name} is of type Xamarin.iOS, migration to .NET MAUI recommends net7.0-ios.", tfm.Project);
+                _logger.LogInformation("Recommending TFM {TFM} for project {Name} because project is of type Xamarin.iOS", TargetFrameworkMoniker.Net70_iOS, tfm.Project);
                 tfm.TryUpdate(TargetFrameworkMoniker.Net70_iOS);
             }
 
-            if (tfm.Components.HasFlag(ProjectComponents.MauiAndroid))
+            if (tfm.Components.HasFlag(ProjectComponents.Maui) && tfm.Project?.TargetFrameworks.Count > 1)
             {
-                _logger.LogInformation("Project {Name} is of type .NET MAUI Target:Android, migration to .NET MAUI recommends net7.0-android.", tfm.Project);
+                TargetFrameworkMoniker targetFrameworkMoniker = tfm.Project.TargetFrameworks.FirstOrDefault();
+                _logger.LogInformation("Recommending TFM {TFM} for project {Name} because project is of type .NET MAUI with multiple TFMs: {TFMs}", targetFrameworkMoniker, tfm.Project, string.Join(", ", tfm.Project.TargetFrameworks));
+                tfm.TryUpdate(targetFrameworkMoniker);
+            }
+            else if (tfm.Components.HasFlag(ProjectComponents.MauiAndroid))
+            {
+                _logger.LogInformation("Recommending TFM {TFM} for project {Name} because project is of type .NET MAUI Target:Android", TargetFrameworkMoniker.Net70_Android, tfm.Project);
                 tfm.TryUpdate(TargetFrameworkMoniker.Net70_Android);
             }
-
-            if (tfm.Components.HasFlag(ProjectComponents.MauiiOS))
+            else if (tfm.Components.HasFlag(ProjectComponents.MauiiOS))
             {
-                _logger.LogInformation("Project {Name} is of type .NET MAUI Target:iOS, migration to .NET MAUI recommends net7.0-ios.", tfm.Project);
+                _logger.LogInformation("Recommending TFM {TFM} for project {Name} because project is of type .NET MAUI Target:iOS", TargetFrameworkMoniker.Net70_Android, tfm.Project);
                 tfm.TryUpdate(TargetFrameworkMoniker.Net70_iOS);
             }
-
-            if (tfm.Components.HasFlag(ProjectComponents.Maui))
+            else if (tfm.Components.HasFlag(ProjectComponents.Maui))
             {
-                if (tfm.Project?.TargetFrameworks.Count > 1)
-                {
-                    tfm.TryUpdate(tfm.Project.TargetFrameworks.FirstOrDefault());
-                }
-                else
-                {
-                    _logger.LogInformation("Project {Name} is of type .NET MAUI Target: MAUI head, migration to .NET MAUI requires to be multiplatform", tfm.Project);
-                    tfm.TryUpdate(TargetFrameworkMoniker.Net70_Android);
-                }
+                _logger.LogInformation("Recommending TFM {TFM} for project {Name} because project is of type .NET MAUI", TargetFrameworkMoniker.Net70_Android, tfm.Project);
+                tfm.TryUpdate(TargetFrameworkMoniker.Net70_Android);
             }
         }
     }

--- a/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiWorkloadUpgradeStep.cs
+++ b/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiWorkloadUpgradeStep.cs
@@ -139,10 +139,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
         // Check if this is a MAUI conversion
         protected override async Task<bool> IsApplicableImplAsync(IUpgradeContext context, CancellationToken token)
         {
-            //if (_testOptions.Value.IsRunningTest)
-            //{
-            //    return false;
-            //}
+            /* if (_testOptions.Value.IsRunningTest)
+            {
+                return false;
+            }*/
 
             if (context?.CurrentProject is null)
             {

--- a/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiWorkloadUpgradeStep.cs
+++ b/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiWorkloadUpgradeStep.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -20,7 +21,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
             { "maui", ProjectComponents.MauiAndroid | ProjectComponents.MauiiOS },
         };
 
-        private static bool? _infoSucceeded;
+        private static StringBuilder? _infoResult;
         private static bool? _installSucceeded;
         private readonly IProcessRunner _runner;
 
@@ -58,16 +59,20 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
                 return new UpgradeStepApplyResult(UpgradeStepStatus.Skipped, ".NET MAUI workload install has already been run");
             }
 
-            _installSucceeded = await RunDotnetCommandAsync(context, "workload install maui", (_, message) => LogLevel.Information, token).ConfigureAwait(false);
+            StringBuilder resultBuilder = new();
+            _installSucceeded = await RunDotnetCommandAsync(context, "workload install maui", (_, message) =>
+            {
+                resultBuilder.AppendLine(message);
+                return LogLevel.Information;
+            }, token).ConfigureAwait(false);
 
             if (!_installSucceeded.Value)
             {
-                Logger.LogError("Command 'dotnet workload install maui' failed!");
-
-                return new UpgradeStepApplyResult(UpgradeStepStatus.Failed, ".NET MAUI workload installation failed!");
+                return context.CreateAndAddStepApplyResult(this, UpgradeStepStatus.Failed, ".NET MAUI workload installation failed",
+                    details: string.Concat(resultBuilder.ToString(), Environment.NewLine, _infoResult?.ToString()));
             }
 
-            return new UpgradeStepApplyResult(UpgradeStepStatus.Complete, $".NET MAUI workload installation succeeded.");
+            return context.CreateAndAddStepApplyResult(this, UpgradeStepStatus.Complete, ".NET MAUI workload installation succeeded");
         }
 
         // Check if the right MAUI workload is installed
@@ -87,10 +92,17 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
             var components = await project.GetComponentsAsync(token).ConfigureAwait(false);
             var workloads = ProjectComponents.None;
 
-            if (!_infoSucceeded.HasValue)
+            if (_infoResult == null)
             {
+                _infoResult = new();
+
                 // We only need to display the dotnet info debug information once
-                _infoSucceeded = await RunDotnetCommandAsync(context, "--info", (_, message) => LogLevel.Debug, token).ConfigureAwait(false);
+                // Save the output to add to result details in case of a workload install failure
+                await RunDotnetCommandAsync(context, "--info", (_, message) =>
+                {
+                    _infoResult.AppendLine(message);
+                    return LogLevel.Debug;
+                }, token).ConfigureAwait(false);
             }
 
             var result = await RunDotnetCommandAsync(context, "workload list", (_, message) =>
@@ -126,6 +138,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
         {
             if (context?.CurrentProject is null)
             {
+                return false;
+            }
+
+            if (_installSucceeded.HasValue)
+            {
+                // Only need to attempt this once per session
                 return false;
             }
 

--- a/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiWorkloadUpgradeStep.cs
+++ b/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiWorkloadUpgradeStep.cs
@@ -139,10 +139,10 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
         // Check if this is a MAUI conversion
         protected override async Task<bool> IsApplicableImplAsync(IUpgradeContext context, CancellationToken token)
         {
-            if (_testOptions.Value.IsRunningTest)
-            {
-                return false;
-            }
+            //if (_testOptions.Value.IsRunningTest)
+            //{
+            //    return false;
+            //}
 
             if (context?.CurrentProject is null)
             {

--- a/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiWorkloadUpgradeStep.cs
+++ b/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiWorkloadUpgradeStep.cs
@@ -86,6 +86,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
                 throw new ArgumentNullException(nameof(context));
             }
 
+            if (_testOptions.Value.IsRunningTest)
+            {
+                return new UpgradeStepInitializeResult(UpgradeStepStatus.Skipped, ".NET MAUI workload install not performed during test", BuildBreakRisk.High);
+            }
+
             if (_installSucceeded.HasValue)
             {
                 return new UpgradeStepInitializeResult(UpgradeStepStatus.Skipped, ".NET MAUI workload install has already been run", _installSucceeded.Value ? BuildBreakRisk.None : BuildBreakRisk.High);
@@ -139,11 +144,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
         // Check if this is a MAUI conversion
         protected override async Task<bool> IsApplicableImplAsync(IUpgradeContext context, CancellationToken token)
         {
-            /* if (_testOptions.Value.IsRunningTest)
-            {
-                return false;
-            }*/
-
             if (context?.CurrentProject is null)
             {
                 return false;

--- a/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiWorkloadUpgradeStep.cs
+++ b/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiWorkloadUpgradeStep.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using static System.FormattableString;
 
 namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
@@ -23,15 +24,17 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
 
         private static StringBuilder? _infoResult;
         private static bool? _installSucceeded;
+        private readonly IOptions<TestOptions> _testOptions;
         private readonly IProcessRunner _runner;
 
         public override string Title => "Install .NET MAUI Workload";
 
         public override string Description => "Check the .NET SDK for the MAUI workload and install it if necessary.";
 
-        public MauiWorkloadUpgradeStep(ILogger<MauiWorkloadUpgradeStep> logger, IProcessRunner runner)
+        public MauiWorkloadUpgradeStep(IOptions<TestOptions> testOptions, ILogger<MauiWorkloadUpgradeStep> logger, IProcessRunner runner)
             : base(logger)
         {
+            _testOptions = testOptions;
             _runner = runner ?? throw new ArgumentNullException(nameof(runner));
         }
 
@@ -136,6 +139,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
         // Check if this is a MAUI conversion
         protected override async Task<bool> IsApplicableImplAsync(IUpgradeContext context, CancellationToken token)
         {
+            if (_testOptions.Value.IsRunningTest)
+            {
+                return false;
+            }
+
             if (context?.CurrentProject is null)
             {
                 return false;

--- a/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/XamlNamespaceUpgradeStep.cs
+++ b/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/XamlNamespaceUpgradeStep.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
                 await projectFile.SaveAsync(token).ConfigureAwait(false);
             }
 
-            return new UpgradeStepApplyResult(status, $"Updated XAML namespaces to .NET MAUI");
+            return context.CreateAndAddStepApplyResult(this, status, "Updated XAML namespaces to .NET MAUI");
         }
 
         protected override async Task<UpgradeStepInitializeResult> InitializeImplAsync(IUpgradeContext context, CancellationToken token)
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
                     Logger.LogInformation(".NET MAUI project does not contain any XAML files");
                     return new UpgradeStepInitializeResult(UpgradeStepStatus.Complete, ".NET MAUI project does not contain any XAML files", BuildBreakRisk.None);
                 }
-            });
+            }).ConfigureAwait(false);
         }
 
         protected override async Task<bool> IsApplicableImplAsync(IUpgradeContext context, CancellationToken token)

--- a/src/extensions/try-convert/Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert/SdkStyleConversionSolutionWideStep.cs
+++ b/src/extensions/try-convert/Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert/SdkStyleConversionSolutionWideStep.cs
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert
             public override string Description => $"Convert {_project.Name} from old-style project format to SDK style project.";
 
             protected override Task<UpgradeStepApplyResult> ApplyImplAsync(IUpgradeContext context, CancellationToken token)
-                => _runner.ApplyAsync(context, context.GetProject(_project.FullName), token);
+                => _runner.ApplyAsync(this, context, context.GetProject(_project.FullName), token);
 
             protected override Task<UpgradeStepInitializeResult> InitializeImplAsync(IUpgradeContext context, CancellationToken token)
                 => _runner.InitializeAsync(context.GetProject(_project.FullName), token);

--- a/src/extensions/try-convert/Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert/TryConvertProjectConverterStep.cs
+++ b/src/extensions/try-convert/Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert/TryConvertProjectConverterStep.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return _runner.ApplyAsync(context, context.CurrentProject.Required(), token);
+            return _runner.ApplyAsync(this, context, context.CurrentProject.Required(), token);
         }
 
         protected override Task<UpgradeStepInitializeResult> InitializeImplAsync(IUpgradeContext context, CancellationToken token)

--- a/src/extensions/try-convert/Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert/TryConvertRunner.cs
+++ b/src/extensions/try-convert/Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert/TryConvertRunner.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert
             _logger = logger;
         }
 
-        public string VersionString => _tool?.Version is null ? string.Empty : $", version {_tool.Version}";
+        public string VersionString => _tool?.Version is null ? string.Empty : $", Version={_tool.Version}";
 
         public string Path => _tool.Path;
 

--- a/src/extensions/try-convert/Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert/TryConvertRunner.cs
+++ b/src/extensions/try-convert/Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert/TryConvertRunner.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert
 
         public string Path => _tool.Path;
 
-        public async Task<UpgradeStepApplyResult> ApplyAsync(IUpgradeContext context, IProject project, CancellationToken token)
+        public async Task<UpgradeStepApplyResult> ApplyAsync(UpgradeStep step, IUpgradeContext context, IProject project, CancellationToken token)
         {
             if (context is null)
             {
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert
                 context.Properties.SetPropertyValue("componentFlag", components.ToString(), true);
             }
 
-            var result = await RunTryConvertAsync(context, project, token).ConfigureAwait(false);
+            var result = await RunTryConvertAsync(step, context, project, token).ConfigureAwait(false);
 
             await _restorer.RestorePackagesAsync(context, project, token).ConfigureAwait(false);
 
@@ -85,13 +85,12 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert
             }
         }
 
-        private void AddResultToContext(IUpgradeContext context, UpgradeStepStatus status, string resultMessage)
+        private static void AddResultToContext(UpgradeStep step, IUpgradeContext context, UpgradeStepStatus status, string resultMessage)
         {
-            context.AddResult(TryConvertProjectConverterStep.StepTitle, context.CurrentProject?.GetFile()?.FilePath ?? string.Empty,
-                WellKnownStepIds.TryConvertProjectConverterStepId, status, resultMessage);
+            context.AddResultForStep(step, context.CurrentProject?.GetFile()?.FilePath ?? string.Empty, status, resultMessage);
         }
 
-        private async Task<UpgradeStepApplyResult> RunTryConvertAsync(IUpgradeContext context, IProject project, CancellationToken token)
+        private async Task<UpgradeStepApplyResult> RunTryConvertAsync(UpgradeStep step, IUpgradeContext context, IProject project, CancellationToken token)
         {
             _logger.LogInformation($"Converting project file format with try-convert{VersionString}");
 
@@ -105,14 +104,14 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.TryConvert
             {
                 var description = "Conversion with try-convert failed.";
                 _logger.LogCritical(description);
-                AddResultToContext(context, UpgradeStepStatus.Failed, description);
+                AddResultToContext(step, context, UpgradeStepStatus.Failed, description);
                 return new UpgradeStepApplyResult(UpgradeStepStatus.Failed, description);
             }
             else
             {
                 var description = "Project file converted successfully! The project may require additional changes to build successfully against the new .NET target.";
                 _logger.LogInformation(description);
-                AddResultToContext(context, UpgradeStepStatus.Complete, description);
+                AddResultToContext(step, context, UpgradeStepStatus.Complete, description);
                 return new UpgradeStepApplyResult(UpgradeStepStatus.Complete, "Project file converted successfully");
             }
         }

--- a/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/WebProjectTargetFrameworkSelectorFilter.cs
+++ b/src/extensions/web/Microsoft.DotNet.UpgradeAssistant.Extensions.Web/WebProjectTargetFrameworkSelectorFilter.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Web
             {
                 if (tfm.TryUpdate(tfm.AppBase))
                 {
-                    _logger.LogInformation("Recommending executable TFM {TFM} because the project builds to a web app", tfm.AppBase);
+                    _logger.LogInformation("Recommending executable TFM {TFM} for project {Name} because the project builds to a web app", tfm.AppBase, tfm.Project);
                 }
             }
         }

--- a/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/WindowsDesktopUpdaterSubStep.cs
+++ b/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/WindowsDesktopUpdaterSubStep.cs
@@ -108,6 +108,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Windows
                 : ImmutableList.Create(context.CurrentProject!.GetFile().FilePath);
             var results = fileLocations.Select(location => new OutputResult()
             {
+                Level = updaterResult.Result ? OutputLevel.Info : OutputLevel.Error,
                 FileLocation = location,
                 RuleId = updaterResult.RuleId,
                 ResultMessage = $"{(updaterResult.Result ? "Success" : "Failed")}: {updaterResult.Message}",

--- a/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/WindowsSdkTargetFrameworkSelectorFilter.cs
+++ b/src/extensions/windows/Microsoft.DotNet.UpgradeAssistant.Extensions.Windows/WindowsSdkTargetFrameworkSelectorFilter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Windows
             {
                 if (tfm.TryUpdate(result))
                 {
-                    _logger.LogInformation("Recommending Windows TFM {TFM} because the project either has Windows-specific dependencies or builds to a WinExe", result);
+                    _logger.LogInformation("Recommending Windows TFM {TFM} for project {Name} because the project either has Windows-specific dependencies or builds to a WinExe", result, tfm.Project);
                 }
             }
         }

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Analysis.Tests/SarifAnalyzeResultWriterTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Analysis.Tests/SarifAnalyzeResultWriterTests.cs
@@ -76,7 +76,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.Analysis.Tests
             Assert.Equal(analyzeResult.RuleId, result.RuleId);
             Assert.Equal(analyzeResult.ResultMessage, result.Message.Text);
             Assert.Equal(FailureLevel.Error, result.Level);
-
         }
 
         [Fact]

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Analysis.Tests/SarifAnalyzeResultWriterTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Analysis.Tests/SarifAnalyzeResultWriterTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Analysis.Tests
             {
                 new OutputResult
                 {
+                    Level = OutputLevel.Error,
                     FileLocation = "some-file-path",
                     LineNumber = 1,
                     ResultMessage = "some result message",
@@ -71,6 +72,11 @@ namespace Microsoft.DotNet.UpgradeAssistant.Analysis.Tests
             Assert.Equal(analyzeResult.RuleName, rule.Name);
             Assert.Equal(analyzeResult.FullDescription, rule.FullDescription.Text);
             Assert.Equal(analyzeResult.HelpUri, rule.HelpUri);
+            var result = sarifLog.Runs[0].Results.First();
+            Assert.Equal(analyzeResult.RuleId, result.RuleId);
+            Assert.Equal(analyzeResult.ResultMessage, result.Message.Text);
+            Assert.Equal(FailureLevel.Error, result.Level);
+
         }
 
         [Fact]

--- a/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/UpgraderTests.cs
+++ b/tests/components/Microsoft.DotNet.UpgradeAssistant.Tests/UpgraderTests.cs
@@ -74,6 +74,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Tests
             using var mock = AutoMock.GetLoose(b => b.RegisterInstance(GetOrderer(steps)));
             var upgrader = mock.Create<UpgraderManager>();
 
+            mock.Mock<IUserInput>().Setup(u => u.IsInteractive).Returns(true);
+
             var context = mock.Mock<IUpgradeContext>();
             context.SetupProperty(c => c.CurrentStep);
 
@@ -98,6 +100,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Tests
 
             using var mock = AutoMock.GetLoose(b => b.RegisterInstance(GetOrderer(steps)));
             var upgrader = mock.Create<UpgraderManager>();
+
+            mock.Mock<IUserInput>().Setup(u => u.IsInteractive).Returns(true);
 
             var context = mock.Mock<IUpgradeContext>();
             context.SetupProperty(c => c.CurrentStep);

--- a/tests/tool/Integration.Tests/E2ETest.cs
+++ b/tests/tool/Integration.Tests/E2ETest.cs
@@ -46,8 +46,10 @@ namespace Integration.Tests
         */
         [InlineData("WpfSample/vb", "WpfApp1.sln", "")]
         [InlineData("WCFSample", "ConsoleApp.csproj", "")]
-        [InlineData("MauiSample/droid", "EwDavidForms.sln", "EwDavidForms.Android.csproj")]
-        [InlineData("MauiSample/ios", "EwDavidForms.sln", "EwDavidForms.iOS.csproj")]
+
+        // TODO: [mgoertz] Re-enable after MAUI workloads are installed on test machines
+        // [InlineData("MauiSample/droid", "EwDavidForms.sln", "EwDavidForms.Android.csproj")]
+        // [InlineData("MauiSample/ios", "EwDavidForms.sln", "EwDavidForms.iOS.csproj")]
         [Theory]
         public async Task UpgradeTest(string scenarioPath, string inputFileName, string entrypoint)
         {

--- a/tests/tool/Integration.Tests/E2ETest.cs
+++ b/tests/tool/Integration.Tests/E2ETest.cs
@@ -39,16 +39,14 @@ namespace Integration.Tests
 
         [InlineData("PCL", "SamplePCL.csproj", "")]
         [InlineData("WpfSample/csharp", "BeanTrader.sln", "BeanTraderClient.csproj")]
-/*
-        [InlineData("WebLibrary/csharp", "WebLibrary.csproj", "")]
-        [InlineData("AspNetSample/csharp", "TemplateMvc.csproj", "")]
-*/
+        /*
+                [InlineData("WebLibrary/csharp", "WebLibrary.csproj", "")]
+                [InlineData("AspNetSample/csharp", "TemplateMvc.csproj", "")]
+        */
         [InlineData("WpfSample/vb", "WpfApp1.sln", "")]
         [InlineData("WCFSample", "ConsoleApp.csproj", "")]
-
-        // TODO: [mgoertz] Re-enable after .NET 7 GA
-        // [InlineData("MauiSample/droid", "EwDavidForms.sln", "EwDavidForms.Android.csproj")]
-        // [InlineData("MauiSample/ios", "EwDavidForms.sln", "EwDavidForms.iOS.csproj")]
+        [InlineData("MauiSample/droid", "EwDavidForms.sln", "EwDavidForms.Android.csproj")]
+        [InlineData("MauiSample/ios", "EwDavidForms.sln", "EwDavidForms.iOS.csproj")]
         [Theory]
         public async Task UpgradeTest(string scenarioPath, string inputFileName, string entrypoint)
         {

--- a/tests/tool/Integration.Tests/E2ETest.cs
+++ b/tests/tool/Integration.Tests/E2ETest.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using AutoMapper.Configuration.Annotations;
+using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.DotNet.UpgradeAssistant;
 using Microsoft.DotNet.UpgradeAssistant.Cli;
 using Xunit;
@@ -133,7 +134,8 @@ namespace Integration.Tests
                         .Replace(actualDir.Replace("\\", "/"), "[ACTUAL_PROJECT_ROOT]")
                         .Replace(Directory.GetCurrentDirectory().Replace("\\", "/"), "[UA_PROJECT_BIN]");
 
-                    actualText = Regex.Replace(actualText, "Version=(\\d+\\.){3}([\\da-zA-Z\\-])+", "[VERSION]");
+                    // Replace version strings, such as "Version=42.42.42.42" or "Version=0.4.0-dev"
+                    actualText = Regex.Replace(actualText, @"Version=\d+(\.\d+){2}(((\.\d+){1})|([\da-zA-Z\-])*)", "[VERSION]");
                 }
 
                 if (!string.Equals(expectedText, actualText, StringComparison.Ordinal))

--- a/tests/tool/Integration.Tests/IntegrationScenarios/AspNetSample/csharp/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/AspNetSample/csharp/Upgraded/UpgradeReport.sarif
@@ -12,7 +12,7 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
               "fullDescription": {
-                "text": "Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
+                "text": "Use the try-convert tool (, [VERSION]) to convert the project file to an SDK-style csproj"
               },
               "helpUri": "about:blank"
             }

--- a/tests/tool/Integration.Tests/IntegrationScenarios/MauiSample/droid/Upgraded/EwDavidForms/EwDavidForms/EwDavidForms.csproj
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/MauiSample/droid/Upgraded/EwDavidForms/EwDavidForms/EwDavidForms.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <UseMaui>true</UseMaui>
-    <TargetFrameworks>net6.0-android;net6.0-ios</TargetFrameworks>
+    <TargetFrameworks>net7.0-android;net7.0-ios</TargetFrameworks>
     <OutputType>Library</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/tool/Integration.Tests/IntegrationScenarios/MauiSample/droid/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/MauiSample/droid/Upgraded/UpgradeReport.sarif
@@ -546,7 +546,7 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
               "fullDescription": {
-                "text": "Use the try-convert tool (, version 0.4.0-dev) to convert the project file to an SDK-style csproj"
+                "text": "Use the try-convert tool (, [VERSION]) to convert the project file to an SDK-style csproj"
               }
             }
           ]

--- a/tests/tool/Integration.Tests/IntegrationScenarios/MauiSample/droid/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/MauiSample/droid/Upgraded/UpgradeReport.sarif
@@ -5,16 +5,49 @@
     {
       "tool": {
         "driver": {
+          "name": "Add TargetFramework for .NET MAUI Project",
+          "semanticVersion": "",
+          "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
+          "rules": [
+            {
+              "id": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiPlatformTargetFrameworkUpgradeStep",
+              "fullDescription": {
+                "text": "Add Platform TargetFramework for XamarinForms projects being converted"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiPlatformTargetFrameworkUpgradeStep",
+          "level": "note",
+          "message": {
+            "text": "Complete: Added TFMs to .NET MAUI project EwDavidForms.csproj"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///[ACTUAL_PROJECT_ROOT]/EwDavidForms/EwDavidForms/EwDavidForms.csproj"
+                },
+                "region": {}
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    },
+    {
+      "tool": {
+        "driver": {
           "name": "Remove package 'Microsoft.AppCenter.Analytics'",
           "semanticVersion": "",
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Microsoft.AppCenter.Analytics'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -22,6 +55,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.AppCenter.Analytics'"
           },
@@ -47,11 +81,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Microsoft.AppCenter.Crashes'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -59,6 +89,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.AppCenter.Crashes'"
           },
@@ -84,11 +115,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.CommunityToolkit'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -96,6 +123,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.CommunityToolkit'"
           },
@@ -121,11 +149,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.Forms'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -133,6 +157,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.Forms'"
           },
@@ -158,11 +183,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.Essentials'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -170,6 +191,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.Essentials'"
           },
@@ -195,11 +217,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'CommunityToolkit.Maui'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -207,6 +225,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'CommunityToolkit.Maui'"
           },
@@ -232,11 +251,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -244,8 +259,46 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///[ACTUAL_PROJECT_ROOT]/EwDavidForms/EwDavidForms/EwDavidForms.csproj"
+                },
+                "region": {}
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "Update Project Properties for .NET MAUI Project",
+          "semanticVersion": "",
+          "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
+          "rules": [
+            {
+              "id": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiAddProjectPropertiesStep",
+              "fullDescription": {
+                "text": "Updates the platform-specific project properties for a .NET MAUI project"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiAddProjectPropertiesStep",
+          "level": "note",
+          "message": {
+            "text": "Complete: Updated Maui project properties for .NET MAUI project EwDavidForms.csproj"
           },
           "locations": [
             {
@@ -271,9 +324,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Templates.TemplateInserterStep",
               "fullDescription": {
-                "text": "Added template file MauiProgram.cs"
-              },
-              "helpUri": "about:blank"
+                "text": "Add template files (for startup code paths, for example) based on template files described in: Program.cs, Startup.cs, appsettings.json, appsettings.Development.json, Program.vb, Startup.vb, appsettings.json, appsettings.Development.json, app.manifest, Properties\\launchSettings.json, Properties\\PublishProfiles\\win10-arm64.pubxml, Properties\\PublishProfiles\\win10-x64.pubxml, Properties\\PublishProfiles\\win10-x86.pubxml, App.xaml.cs, MainWindow.xaml.cs, MainWindow.xaml, UWPToWinAppSDKUpgradeHelpers.cs, MainApplication.cs, MauiProgram.cs"
+              }
             }
           ]
         }
@@ -281,6 +333,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Templates.TemplateInserterStep",
+          "level": "note",
           "message": {
             "text": "Complete: Added template file MauiProgram.cs"
           },
@@ -301,6 +354,43 @@
     {
       "tool": {
         "driver": {
+          "name": "Update XAML Namespaces",
+          "semanticVersion": "",
+          "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
+          "rules": [
+            {
+              "id": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.XamlNamespaceUpgradeStep",
+              "fullDescription": {
+                "text": "Updates XAML namespaces to .NET MAUI"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.XamlNamespaceUpgradeStep",
+          "level": "note",
+          "message": {
+            "text": "Complete: Updated XAML namespaces to .NET MAUI"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///[ACTUAL_PROJECT_ROOT]/EwDavidForms/EwDavidForms/EwDavidForms.csproj"
+                },
+                "region": {}
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    },
+    {
+      "tool": {
+        "driver": {
           "name": "Apply fix for UA0014: .NET MAUI projects should not reference Xamarin.Forms namespaces",
           "semanticVersion": "",
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
@@ -308,9 +398,8 @@
             {
               "id": "UA0014",
               "fullDescription": {
-                "text": "Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\App.xaml.cs"
-              },
-              "helpUri": "about:blank"
+                "text": "Update source files to automatically fix upgrade analyzer UA0014"
+              }
             }
           ]
         }
@@ -318,6 +407,7 @@
       "results": [
         {
           "ruleId": "UA0014",
+          "level": "note",
           "message": {
             "text": "Complete: Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\App.xaml.cs"
           },
@@ -345,9 +435,8 @@
             {
               "id": "UA0014",
               "fullDescription": {
-                "text": "Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\AssemblyInfo.cs"
-              },
-              "helpUri": "about:blank"
+                "text": "Update source files to automatically fix upgrade analyzer UA0014"
+              }
             }
           ]
         }
@@ -355,6 +444,7 @@
       "results": [
         {
           "ruleId": "UA0014",
+          "level": "note",
           "message": {
             "text": "Complete: Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\AssemblyInfo.cs"
           },
@@ -382,9 +472,8 @@
             {
               "id": "UA0014",
               "fullDescription": {
-                "text": "Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\MainPage.xaml.cs"
-              },
-              "helpUri": "about:blank"
+                "text": "Update source files to automatically fix upgrade analyzer UA0014"
+              }
             }
           ]
         }
@@ -392,6 +481,7 @@
       "results": [
         {
           "ruleId": "UA0014",
+          "level": "note",
           "message": {
             "text": "Complete: Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\MainPage.xaml.cs"
           },
@@ -419,9 +509,8 @@
             {
               "id": "UA0014",
               "fullDescription": {
-                "text": "Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\App.xaml.cs"
-              },
-              "helpUri": "about:blank"
+                "text": "Update source files to automatically fix upgrade analyzer UA0014"
+              }
             }
           ]
         }
@@ -429,6 +518,7 @@
       "results": [
         {
           "ruleId": "UA0014",
+          "level": "note",
           "message": {
             "text": "Complete: Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\App.xaml.cs"
           },
@@ -456,9 +546,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
               "fullDescription": {
-                "text": "Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
-              },
-              "helpUri": "about:blank"
+                "text": "Use the try-convert tool (, version 0.4.0-dev) to convert the project file to an SDK-style csproj"
+              }
             }
           ]
         }
@@ -466,8 +555,46 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
+          "level": "note",
           "message": {
             "text": "Complete: Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///[ACTUAL_PROJECT_ROOT]/EwDavidForms/EwDavidForms.Android/EwDavidForms.Android.csproj"
+                },
+                "region": {}
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "Add TargetFramework for .NET MAUI Project",
+          "semanticVersion": "",
+          "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
+          "rules": [
+            {
+              "id": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiPlatformTargetFrameworkUpgradeStep",
+              "fullDescription": {
+                "text": "Add Platform TargetFramework for XamarinForms projects being converted"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiPlatformTargetFrameworkUpgradeStep",
+          "level": "note",
+          "message": {
+            "text": "Complete: Added TFM net7.0-android to .NET MAUI head project EwDavidForms.Android.csproj"
           },
           "locations": [
             {
@@ -491,11 +618,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Microsoft.AppCenter.Analytics'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -503,6 +626,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.AppCenter.Analytics'"
           },
@@ -528,11 +652,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Microsoft.AppCenter.Crashes'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -540,6 +660,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.AppCenter.Crashes'"
           },
@@ -565,11 +686,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.CommunityToolkit'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -577,6 +694,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.CommunityToolkit'"
           },
@@ -602,11 +720,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.Forms'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -614,6 +728,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.Forms'"
           },
@@ -639,11 +754,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.Essentials'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -651,6 +762,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.Essentials'"
           },
@@ -676,11 +788,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.Android.Support.Design'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -688,6 +796,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.Android.Support.Design'"
           },
@@ -713,11 +822,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.Android.Support.v7.AppCompat'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -725,6 +830,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.Android.Support.v7.AppCompat'"
           },
@@ -750,11 +856,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.Android.Support.v4'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -762,6 +864,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.Android.Support.v4'"
           },
@@ -787,11 +890,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'CommunityToolkit.Maui'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -799,6 +898,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'CommunityToolkit.Maui'"
           },
@@ -824,11 +924,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -836,6 +932,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
           },
@@ -856,25 +953,25 @@
     {
       "tool": {
         "driver": {
-          "name": "Update TFM",
+          "name": "Update Project Properties for .NET MAUI Project",
           "semanticVersion": "",
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.SetTFMStep",
+              "id": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiAddProjectPropertiesStep",
               "fullDescription": {
-                "text": "Updated TFM to net7.0-android"
-              },
-              "helpUri": "about:blank"
+                "text": "Updates the platform-specific project properties for a .NET MAUI project"
+              }
             }
           ]
         }
       },
       "results": [
         {
-          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.SetTFMStep",
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiAddProjectPropertiesStep",
+          "level": "note",
           "message": {
-            "text": "Complete: Updated TFM to net7.0-android"
+            "text": "Complete: Updated MauiAndroid project properties for .NET MAUI project EwDavidForms.Android.csproj"
           },
           "locations": [
             {
@@ -900,9 +997,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Templates.TemplateInserterStep",
               "fullDescription": {
-                "text": "Added template file MainApplication.cs"
-              },
-              "helpUri": "about:blank"
+                "text": "Add template files (for startup code paths, for example) based on template files described in: Program.cs, Startup.cs, appsettings.json, appsettings.Development.json, Program.vb, Startup.vb, appsettings.json, appsettings.Development.json, app.manifest, Properties\\launchSettings.json, Properties\\PublishProfiles\\win10-arm64.pubxml, Properties\\PublishProfiles\\win10-x64.pubxml, Properties\\PublishProfiles\\win10-x86.pubxml, App.xaml.cs, MainWindow.xaml.cs, MainWindow.xaml, UWPToWinAppSDKUpgradeHelpers.cs, MainApplication.cs, MauiProgram.cs"
+              }
             }
           ]
         }
@@ -910,6 +1006,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Templates.TemplateInserterStep",
+          "level": "note",
           "message": {
             "text": "Complete: Added template file MainApplication.cs"
           },

--- a/tests/tool/Integration.Tests/IntegrationScenarios/MauiSample/ios/Upgraded/EwDavidForms/EwDavidForms/EwDavidForms.csproj
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/MauiSample/ios/Upgraded/EwDavidForms/EwDavidForms/EwDavidForms.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <UseMaui>true</UseMaui>
-    <TargetFrameworks>net6.0-android;net6.0-ios</TargetFrameworks>
+    <TargetFrameworks>net7.0-android;net7.0-ios</TargetFrameworks>
     <OutputType>Library</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/tool/Integration.Tests/IntegrationScenarios/MauiSample/ios/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/MauiSample/ios/Upgraded/UpgradeReport.sarif
@@ -5,16 +5,49 @@
     {
       "tool": {
         "driver": {
+          "name": "Add TargetFramework for .NET MAUI Project",
+          "semanticVersion": "",
+          "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
+          "rules": [
+            {
+              "id": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiPlatformTargetFrameworkUpgradeStep",
+              "fullDescription": {
+                "text": "Add Platform TargetFramework for XamarinForms projects being converted"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiPlatformTargetFrameworkUpgradeStep",
+          "level": "note",
+          "message": {
+            "text": "Complete: Added TFMs to .NET MAUI project EwDavidForms.csproj"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///[ACTUAL_PROJECT_ROOT]/EwDavidForms/EwDavidForms/EwDavidForms.csproj"
+                },
+                "region": {}
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    },
+    {
+      "tool": {
+        "driver": {
           "name": "Remove package 'Microsoft.AppCenter.Analytics'",
           "semanticVersion": "",
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Microsoft.AppCenter.Analytics'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -22,6 +55,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.AppCenter.Analytics'"
           },
@@ -47,11 +81,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Microsoft.AppCenter.Crashes'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -59,6 +89,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.AppCenter.Crashes'"
           },
@@ -84,11 +115,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.CommunityToolkit'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -96,6 +123,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.CommunityToolkit'"
           },
@@ -121,11 +149,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.Forms'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -133,6 +157,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.Forms'"
           },
@@ -158,11 +183,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.Essentials'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -170,6 +191,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.Essentials'"
           },
@@ -195,11 +217,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'CommunityToolkit.Maui'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -207,6 +225,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'CommunityToolkit.Maui'"
           },
@@ -232,11 +251,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -244,8 +259,46 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///[ACTUAL_PROJECT_ROOT]/EwDavidForms/EwDavidForms/EwDavidForms.csproj"
+                },
+                "region": {}
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "Update Project Properties for .NET MAUI Project",
+          "semanticVersion": "",
+          "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
+          "rules": [
+            {
+              "id": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiAddProjectPropertiesStep",
+              "fullDescription": {
+                "text": "Updates the platform-specific project properties for a .NET MAUI project"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiAddProjectPropertiesStep",
+          "level": "note",
+          "message": {
+            "text": "Complete: Updated Maui project properties for .NET MAUI project EwDavidForms.csproj"
           },
           "locations": [
             {
@@ -271,9 +324,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Templates.TemplateInserterStep",
               "fullDescription": {
-                "text": "Added template file MauiProgram.cs"
-              },
-              "helpUri": "about:blank"
+                "text": "Add template files (for startup code paths, for example) based on template files described in: Program.cs, Startup.cs, appsettings.json, appsettings.Development.json, Program.vb, Startup.vb, appsettings.json, appsettings.Development.json, app.manifest, Properties\\launchSettings.json, Properties\\PublishProfiles\\win10-arm64.pubxml, Properties\\PublishProfiles\\win10-x64.pubxml, Properties\\PublishProfiles\\win10-x86.pubxml, App.xaml.cs, MainWindow.xaml.cs, MainWindow.xaml, UWPToWinAppSDKUpgradeHelpers.cs, MainApplication.cs, MauiProgram.cs"
+              }
             }
           ]
         }
@@ -281,6 +333,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Templates.TemplateInserterStep",
+          "level": "note",
           "message": {
             "text": "Complete: Added template file MauiProgram.cs"
           },
@@ -301,6 +354,43 @@
     {
       "tool": {
         "driver": {
+          "name": "Update XAML Namespaces",
+          "semanticVersion": "",
+          "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
+          "rules": [
+            {
+              "id": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.XamlNamespaceUpgradeStep",
+              "fullDescription": {
+                "text": "Updates XAML namespaces to .NET MAUI"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.XamlNamespaceUpgradeStep",
+          "level": "note",
+          "message": {
+            "text": "Complete: Updated XAML namespaces to .NET MAUI"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///[ACTUAL_PROJECT_ROOT]/EwDavidForms/EwDavidForms/EwDavidForms.csproj"
+                },
+                "region": {}
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    },
+    {
+      "tool": {
+        "driver": {
           "name": "Apply fix for UA0014: .NET MAUI projects should not reference Xamarin.Forms namespaces",
           "semanticVersion": "",
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
@@ -308,9 +398,8 @@
             {
               "id": "UA0014",
               "fullDescription": {
-                "text": "Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\App.xaml.cs"
-              },
-              "helpUri": "about:blank"
+                "text": "Update source files to automatically fix upgrade analyzer UA0014"
+              }
             }
           ]
         }
@@ -318,6 +407,7 @@
       "results": [
         {
           "ruleId": "UA0014",
+          "level": "note",
           "message": {
             "text": "Complete: Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\App.xaml.cs"
           },
@@ -345,9 +435,8 @@
             {
               "id": "UA0014",
               "fullDescription": {
-                "text": "Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\AssemblyInfo.cs"
-              },
-              "helpUri": "about:blank"
+                "text": "Update source files to automatically fix upgrade analyzer UA0014"
+              }
             }
           ]
         }
@@ -355,6 +444,7 @@
       "results": [
         {
           "ruleId": "UA0014",
+          "level": "note",
           "message": {
             "text": "Complete: Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\AssemblyInfo.cs"
           },
@@ -382,9 +472,8 @@
             {
               "id": "UA0014",
               "fullDescription": {
-                "text": "Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\MainPage.xaml.cs"
-              },
-              "helpUri": "about:blank"
+                "text": "Update source files to automatically fix upgrade analyzer UA0014"
+              }
             }
           ]
         }
@@ -392,6 +481,7 @@
       "results": [
         {
           "ruleId": "UA0014",
+          "level": "note",
           "message": {
             "text": "Complete: Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\MainPage.xaml.cs"
           },
@@ -419,9 +509,8 @@
             {
               "id": "UA0014",
               "fullDescription": {
-                "text": "Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\App.xaml.cs"
-              },
-              "helpUri": "about:blank"
+                "text": "Update source files to automatically fix upgrade analyzer UA0014"
+              }
             }
           ]
         }
@@ -429,6 +518,7 @@
       "results": [
         {
           "ruleId": "UA0014",
+          "level": "note",
           "message": {
             "text": "Complete: Diagnostic UA0014 fixed in [ACTUAL_PROJECT_ROOT]\\EwDavidForms\\EwDavidForms\\App.xaml.cs"
           },
@@ -456,9 +546,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
               "fullDescription": {
-                "text": "Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
-              },
-              "helpUri": "about:blank"
+                "text": "Use the try-convert tool (, version 0.4.0-dev) to convert the project file to an SDK-style csproj"
+              }
             }
           ]
         }
@@ -466,8 +555,46 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
+          "level": "note",
           "message": {
             "text": "Complete: Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///[ACTUAL_PROJECT_ROOT]/EwDavidForms/EwDavidForms.iOS/EwDavidForms.iOS.csproj"
+                },
+                "region": {}
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "Add TargetFramework for .NET MAUI Project",
+          "semanticVersion": "",
+          "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
+          "rules": [
+            {
+              "id": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiPlatformTargetFrameworkUpgradeStep",
+              "fullDescription": {
+                "text": "Add Platform TargetFramework for XamarinForms projects being converted"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiPlatformTargetFrameworkUpgradeStep",
+          "level": "note",
+          "message": {
+            "text": "Complete: Added TFM net7.0-ios to .NET MAUI head project EwDavidForms.iOS.csproj"
           },
           "locations": [
             {
@@ -491,11 +618,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Microsoft.AppCenter.Analytics'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -503,6 +626,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.AppCenter.Analytics'"
           },
@@ -528,11 +652,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Microsoft.AppCenter.Crashes'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -540,6 +660,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.AppCenter.Crashes'"
           },
@@ -565,11 +686,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.CommunityToolkit'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -577,6 +694,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.CommunityToolkit'"
           },
@@ -602,11 +720,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.Forms'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -614,6 +728,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.Forms'"
           },
@@ -639,11 +754,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Xamarin.Essentials'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -651,6 +762,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Xamarin.Essentials'"
           },
@@ -676,11 +788,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'CommunityToolkit.Maui'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -688,6 +796,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'CommunityToolkit.Maui'"
           },
@@ -713,11 +822,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -725,6 +830,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
           },
@@ -745,25 +851,25 @@
     {
       "tool": {
         "driver": {
-          "name": "Update TFM",
+          "name": "Update Project Properties for .NET MAUI Project",
           "semanticVersion": "",
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.SetTFMStep",
+              "id": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiAddProjectPropertiesStep",
               "fullDescription": {
-                "text": "Updated TFM to net7.0-ios"
-              },
-              "helpUri": "about:blank"
+                "text": "Updates the platform-specific project properties for a .NET MAUI project"
+              }
             }
           ]
         }
       },
       "results": [
         {
-          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.SetTFMStep",
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Extensions.Maui.MauiAddProjectPropertiesStep",
+          "level": "note",
           "message": {
-            "text": "Complete: Updated TFM to net7.0-ios"
+            "text": "Complete: Updated MauiiOS project properties for .NET MAUI project EwDavidForms.iOS.csproj"
           },
           "locations": [
             {

--- a/tests/tool/Integration.Tests/IntegrationScenarios/MauiSample/ios/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/MauiSample/ios/Upgraded/UpgradeReport.sarif
@@ -546,7 +546,7 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
               "fullDescription": {
-                "text": "Use the try-convert tool (, version 0.4.0-dev) to convert the project file to an SDK-style csproj"
+                "text": "Use the try-convert tool (, [VERSION]) to convert the project file to an SDK-style csproj"
               }
             }
           ]

--- a/tests/tool/Integration.Tests/IntegrationScenarios/PCL/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/PCL/Upgraded/UpgradeReport.sarif
@@ -12,7 +12,7 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
               "fullDescription": {
-                "text": "Use the try-convert tool (, version 0.4.0-dev) to convert the project file to an SDK-style csproj"
+                "text": "Use the try-convert tool (, [VERSION]) to convert the project file to an SDK-style csproj"
               }
             }
           ]
@@ -47,7 +47,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -81,7 +81,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -115,7 +115,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -149,7 +149,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -184,6 +184,9 @@
           "rules": [
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+              "fullDescription": {
+                "text": "Package Newtonsoft.Json, Version=8.0.1 does not support the target(s) netstandard1.1 but a newer version (9.0.1) does.  Package Newtonsoft.Json needs to be upgraded across major versions (8.0.1 -> 9.0.1) which may introduce breaking changes."
+              }
             }
           ]
         }
@@ -218,6 +221,9 @@
           "rules": [
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+              "fullDescription": {
+                "text": "Package Newtonsoft.Json, Version=8.0.1 does not support the target(s) netstandard1.1 but a newer version (9.0.1) does.  Package Newtonsoft.Json needs to be upgraded across major versions (8.0.1 -> 9.0.1) which may introduce breaking changes."
+              }
             }
           ]
         }
@@ -251,7 +257,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }

--- a/tests/tool/Integration.Tests/IntegrationScenarios/PCL/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/PCL/Upgraded/UpgradeReport.sarif
@@ -12,9 +12,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
               "fullDescription": {
-                "text": "Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
-              },
-              "helpUri": "about:blank"
+                "text": "Use the try-convert tool (, version 0.4.0-dev) to convert the project file to an SDK-style csproj"
+              }
             }
           ]
         }
@@ -22,6 +21,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
+          "level": "note",
           "message": {
             "text": "Complete: Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
           },
@@ -48,10 +48,6 @@
           "rules": [
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Microsoft.Bcl'"
-              },
-              "helpUri": "about:blank"
             }
           ]
         }
@@ -59,6 +55,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.Bcl'"
           },
@@ -85,10 +82,6 @@
           "rules": [
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Microsoft.Bcl.Build'"
-              },
-              "helpUri": "about:blank"
             }
           ]
         }
@@ -96,6 +89,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.Bcl.Build'"
           },
@@ -122,10 +116,6 @@
           "rules": [
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Microsoft.Net.Http'"
-              },
-              "helpUri": "about:blank"
             }
           ]
         }
@@ -133,6 +123,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.Net.Http'"
           },
@@ -159,10 +150,6 @@
           "rules": [
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.Net.Http'"
-              },
-              "helpUri": "about:blank"
             }
           ]
         }
@@ -170,6 +157,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.Net.Http'"
           },
@@ -196,10 +184,6 @@
           "rules": [
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Newtonsoft.Json'"
-              },
-              "helpUri": "about:blank"
             }
           ]
         }
@@ -207,6 +191,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Newtonsoft.Json'"
           },
@@ -233,10 +218,6 @@
           "rules": [
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'Newtonsoft.Json'"
-              },
-              "helpUri": "about:blank"
             }
           ]
         }
@@ -244,6 +225,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Newtonsoft.Json'"
           },
@@ -270,10 +252,6 @@
           "rules": [
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
-              },
-              "helpUri": "about:blank"
             }
           ]
         }
@@ -281,6 +259,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
           },

--- a/tests/tool/Integration.Tests/IntegrationScenarios/PCL/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/PCL/Upgraded/UpgradeReport.sarif
@@ -185,7 +185,7 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Package Newtonsoft.Json, Version=8.0.1 does not support the target(s) netstandard1.1 but a newer version (9.0.1) does.  Package Newtonsoft.Json needs to be upgraded across major versions (8.0.1 -> 9.0.1) which may introduce breaking changes."
+                "text": "Package Newtonsoft.Json, [VERSION] does not support the target(s) netstandard1.1 but a newer version (9.0.1) does.  Package Newtonsoft.Json needs to be upgraded across major versions (8.0.1 -> 9.0.1) which may introduce breaking changes."
               }
             }
           ]
@@ -222,7 +222,7 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Package Newtonsoft.Json, Version=8.0.1 does not support the target(s) netstandard1.1 but a newer version (9.0.1) does.  Package Newtonsoft.Json needs to be upgraded across major versions (8.0.1 -> 9.0.1) which may introduce breaking changes."
+                "text": "Package Newtonsoft.Json, [VERSION] does not support the target(s) netstandard1.1 but a newer version (9.0.1) does.  Package Newtonsoft.Json needs to be upgraded across major versions (8.0.1 -> 9.0.1) which may introduce breaking changes."
               }
             }
           ]

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WCFSample/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WCFSample/Upgraded/UpgradeReport.sarif
@@ -12,9 +12,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
               "fullDescription": {
-                "text": "Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
-              },
-              "helpUri": "about:blank"
+                "text": "Use the try-convert tool (, [VERSION]) to convert the project file to an SDK-style csproj"
+              }
             }
           ]
         }
@@ -22,6 +21,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
+          "level": "note",
           "message": {
             "text": "Complete: Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
           },
@@ -47,11 +47,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove reference 'System.ServiceModel'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -59,6 +55,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove reference 'System.ServiceModel'"
           },
@@ -84,11 +81,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -96,6 +89,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
           },
@@ -123,9 +117,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.SetTFMStep",
               "fullDescription": {
-                "text": "Updated TFM to net7.0"
-              },
-              "helpUri": "about:blank"
+                "text": "Update TFM for current project"
+              }
             }
           ]
         }
@@ -133,6 +126,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.SetTFMStep",
+          "level": "note",
           "message": {
             "text": "Complete: Updated TFM to net7.0"
           },

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WpfSample/csharp/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WpfSample/csharp/Upgraded/UpgradeReport.sarif
@@ -12,9 +12,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
               "fullDescription": {
-                "text": "Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
-              },
-              "helpUri": "about:blank"
+                "text": "Use the try-convert tool (, [VERSION]) to convert the project file to an SDK-style csproj"
+              }
             }
           ]
         }
@@ -493,9 +492,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
               "fullDescription": {
-                "text": "Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
-              },
-              "helpUri": "about:blank"
+                "text": "Use the try-convert tool (, [VERSION]) to convert the project file to an SDK-style csproj"
+              }
             }
           ]
         }

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WpfSample/csharp/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WpfSample/csharp/Upgraded/UpgradeReport.sarif
@@ -21,6 +21,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
+          "level": "note",
           "message": {
             "text": "Complete: Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
           },
@@ -46,11 +47,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove reference 'System.ServiceModel'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -58,6 +55,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove reference 'System.ServiceModel'"
           },
@@ -83,11 +81,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.ServiceModel.Primitives'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -95,6 +89,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.ServiceModel.Primitives'"
           },
@@ -120,11 +115,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.ServiceModel.Http'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -132,6 +123,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.ServiceModel.Http'"
           },
@@ -157,11 +149,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.ServiceModel.Duplex'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -169,6 +157,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.ServiceModel.Duplex'"
           },
@@ -194,11 +183,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.ServiceModel.NetTcp'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -206,6 +191,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.ServiceModel.NetTcp'"
           },
@@ -231,11 +217,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.ServiceModel.Security'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -243,6 +225,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.ServiceModel.Security'"
           },
@@ -268,11 +251,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.ServiceModel.Federation'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -280,6 +259,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.ServiceModel.Federation'"
           },
@@ -305,11 +285,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -317,6 +293,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
           },
@@ -344,9 +321,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'System.ServiceModel.Primitives'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package System.ServiceModel.Primitives needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -354,6 +330,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'System.ServiceModel.Primitives'"
           },
@@ -381,9 +358,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'System.ServiceModel.Http'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package System.ServiceModel.Http needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -391,6 +367,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'System.ServiceModel.Http'"
           },
@@ -418,9 +395,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'System.ServiceModel.Security'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package System.ServiceModel.Security needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -428,6 +404,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'System.ServiceModel.Security'"
           },
@@ -455,9 +432,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.SetTFMStep",
               "fullDescription": {
-                "text": "Updated TFM to netstandard2.0"
-              },
-              "helpUri": "about:blank"
+                "text": "Update TFM for current project"
+              }
             }
           ]
         }
@@ -465,6 +441,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.SetTFMStep",
+          "level": "note",
           "message": {
             "text": "Complete: Updated TFM to netstandard2.0"
           },
@@ -501,6 +478,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
+          "level": "note",
           "message": {
             "text": "Complete: Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
           },
@@ -526,11 +504,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove reference 'System.Configuration'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -538,6 +512,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove reference 'System.Configuration'"
           },
@@ -563,11 +538,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove reference 'System.Net.Http.WebRequest'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -575,6 +546,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove reference 'System.Net.Http.WebRequest'"
           },
@@ -600,11 +572,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove reference 'System.ServiceModel'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -612,6 +580,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.Reference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove reference 'System.ServiceModel'"
           },
@@ -637,11 +606,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Remove package 'Microsoft.Net.Http'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -649,6 +614,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.Net.Http'"
           },
@@ -674,11 +640,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.Net.Http'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -686,6 +648,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.Net.Http'"
           },
@@ -711,11 +674,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.Configuration.ConfigurationManager'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -723,6 +682,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.Configuration.ConfigurationManager'"
           },
@@ -748,11 +708,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.ServiceModel.Primitives'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -760,6 +716,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.ServiceModel.Primitives'"
           },
@@ -785,11 +742,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.ServiceModel.Http'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -797,6 +750,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.ServiceModel.Http'"
           },
@@ -822,11 +776,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.ServiceModel.Duplex'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -834,6 +784,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.ServiceModel.Duplex'"
           },
@@ -859,11 +810,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.ServiceModel.NetTcp'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -871,6 +818,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.ServiceModel.NetTcp'"
           },
@@ -896,11 +844,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.ServiceModel.Security'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -908,6 +852,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.ServiceModel.Security'"
           },
@@ -933,11 +878,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'System.ServiceModel.Federation'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -945,6 +886,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'System.ServiceModel.Federation'"
           },
@@ -970,11 +912,7 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
-              },
-              "helpUri": "about:blank"
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
@@ -982,6 +920,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
           },
@@ -1009,9 +948,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Castle.Core'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Castle.Core needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1019,6 +957,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Castle.Core'"
           },
@@ -1046,9 +985,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'ControlzEx'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package ControlzEx needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1056,6 +994,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'ControlzEx'"
           },
@@ -1083,9 +1022,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Microsoft.Bcl'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Microsoft.Bcl needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1093,6 +1031,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.Bcl'"
           },
@@ -1120,9 +1059,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Microsoft.Bcl.Async'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Microsoft.Bcl.Async needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1130,6 +1068,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.Bcl.Async'"
           },
@@ -1157,9 +1096,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Microsoft.Bcl.Build'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Microsoft.Bcl.Build needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1167,6 +1105,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.Bcl.Build'"
           },
@@ -1194,9 +1133,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Microsoft.CodeQuality.Analyzers'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Microsoft.CodeQuality.Analyzers needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1204,6 +1142,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.CodeQuality.Analyzers'"
           },
@@ -1231,9 +1170,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Microsoft.NetCore.Analyzers'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Microsoft.NetCore.Analyzers needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1241,6 +1179,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.NetCore.Analyzers'"
           },
@@ -1268,9 +1207,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Microsoft.NetFramework.Analyzers'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Microsoft.NetFramework.Analyzers needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1278,6 +1216,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.NetFramework.Analyzers'"
           },
@@ -1305,9 +1244,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Microsoft.Rest.ClientRuntime'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Microsoft.Rest.ClientRuntime needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1315,6 +1253,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Microsoft.Rest.ClientRuntime'"
           },
@@ -1342,9 +1281,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'System.Security.Cryptography.X509Certificates'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package System.Security.Cryptography.X509Certificates needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1352,6 +1290,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'System.Security.Cryptography.X509Certificates'"
           },
@@ -1379,9 +1318,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Text.Analyzers'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Text.Analyzers needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1389,6 +1327,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Text.Analyzers'"
           },
@@ -1416,9 +1355,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'System.ServiceModel.Primitives'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package System.ServiceModel.Primitives needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1426,6 +1364,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'System.ServiceModel.Primitives'"
           },
@@ -1453,9 +1392,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'System.ServiceModel.Http'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package System.ServiceModel.Http needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1463,6 +1401,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'System.ServiceModel.Http'"
           },
@@ -1490,9 +1429,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'System.ServiceModel.Security'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package System.ServiceModel.Security needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1500,6 +1438,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'System.ServiceModel.Security'"
           },
@@ -1527,9 +1466,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.SetTFMStep",
               "fullDescription": {
-                "text": "Updated TFM to net7.0-windows"
-              },
-              "helpUri": "about:blank"
+                "text": "Update TFM for current project"
+              }
             }
           ]
         }
@@ -1537,6 +1475,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.SetTFMStep",
+          "level": "note",
           "message": {
             "text": "Complete: Updated TFM to net7.0-windows"
           },
@@ -1564,9 +1503,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Hyak.Common'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Hyak.Common, [VERSION] does not support the target(s) net7.0-windows but a newer version (1.2.2) does.  Package Hyak.Common needs to be upgraded from 1.0.2 to 1.2.2."
+              }
             }
           ]
         }
@@ -1574,6 +1512,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Hyak.Common'"
           },
@@ -1601,9 +1540,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'MahApps.Metro'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package MahApps.Metro, [VERSION] does not support the target(s) net7.0-windows but a newer version (2.4.4) does.  Package MahApps.Metro needs to be upgraded across major versions (1.6.5 -> 2.4.4) which may introduce breaking changes."
+              }
             }
           ]
         }
@@ -1611,6 +1549,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'MahApps.Metro'"
           },
@@ -1638,9 +1577,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Newtonsoft.Json'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Newtonsoft.Json, [VERSION] does not support the target(s) net7.0-windows but a newer version (9.0.1) does.  Package Newtonsoft.Json needs to be upgraded across major versions (7.0.1 -> 9.0.1) which may introduce breaking changes."
+              }
             }
           ]
         }
@@ -1648,6 +1586,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Newtonsoft.Json'"
           },
@@ -1675,9 +1614,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Nito.AsyncEx'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Nito.AsyncEx, [VERSION] does not support the target(s) net7.0-windows but a newer version (5.1.0) does.  Package Nito.AsyncEx needs to be upgraded across major versions (4.0.1 -> 5.1.0) which may introduce breaking changes."
+              }
             }
           ]
         }
@@ -1685,6 +1623,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Nito.AsyncEx'"
           },
@@ -1712,9 +1651,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Add package 'Hyak.Common'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Hyak.Common, [VERSION] does not support the target(s) net7.0-windows but a newer version (1.2.2) does.  Package Hyak.Common needs to be upgraded from 1.0.2 to 1.2.2."
+              }
             }
           ]
         }
@@ -1722,6 +1660,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Hyak.Common'"
           },
@@ -1749,9 +1688,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Add package 'MahApps.Metro'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package MahApps.Metro, [VERSION] does not support the target(s) net7.0-windows but a newer version (2.4.4) does.  Package MahApps.Metro needs to be upgraded across major versions (1.6.5 -> 2.4.4) which may introduce breaking changes."
+              }
             }
           ]
         }
@@ -1759,6 +1697,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'MahApps.Metro'"
           },
@@ -1786,9 +1725,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Add package 'Newtonsoft.Json'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Newtonsoft.Json, [VERSION] does not support the target(s) net7.0-windows but a newer version (9.0.1) does.  Package Newtonsoft.Json needs to be upgraded across major versions (7.0.1 -> 9.0.1) which may introduce breaking changes."
+              }
             }
           ]
         }
@@ -1796,6 +1734,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Newtonsoft.Json'"
           },
@@ -1823,9 +1762,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Add package 'Nito.AsyncEx'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Nito.AsyncEx, [VERSION] does not support the target(s) net7.0-windows but a newer version (5.1.0) does.  Package Nito.AsyncEx needs to be upgraded across major versions (4.0.1 -> 5.1.0) which may introduce breaking changes."
+              }
             }
           ]
         }
@@ -1833,6 +1771,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Nito.AsyncEx'"
           },
@@ -1860,9 +1799,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Add package 'Microsoft.Windows.Compatibility'"
-              },
-              "helpUri": "about:blank"
+                "text": "Adding Microsoft.Windows.Compatibility 5.0.2 helps with speeding up the upgrade process for Windows-based APIs"
+              }
             }
           ]
         }
@@ -1870,6 +1808,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.Windows.Compatibility'"
           },
@@ -1897,9 +1836,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'System.Data.DataSetExtensions'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package System.Data.DataSetExtensions needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1907,6 +1845,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'System.Data.DataSetExtensions'"
           },
@@ -1934,9 +1873,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'System.Configuration.ConfigurationManager'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package System.Configuration.ConfigurationManager needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1944,6 +1882,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'System.Configuration.ConfigurationManager'"
           },
@@ -1971,9 +1910,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'Newtonsoft.Json'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package Newtonsoft.Json needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
@@ -1981,6 +1919,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'Newtonsoft.Json'"
           },
@@ -2010,8 +1949,7 @@
               "name": "Microsoft.DotNet.UpgradeAssistant.Extensions.Windows.WinformsDefaultFontUpdater",
               "fullDescription": {
                 "text": "Default Font API Alert"
-              },
-              "helpUri": "about:blank"
+              }
             }
           ]
         }
@@ -2019,6 +1957,7 @@
       "results": [
         {
           "ruleId": "UA209",
+          "level": "note",
           "message": {
             "text": "Success: Default font in Windows Forms has been changed from Microsoft Sans Serif to Seg Segoe UI, in order to change the default font use the API - Application.SetDefaultFont(Font font). For more details see here - https://devblogs.microsoft.com/dotnet/whats-new-in-windows-forms-in-net-6-0-preview-5/#application-wide-default-font."
           },

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WpfSample/vb/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WpfSample/vb/Upgraded/UpgradeReport.sarif
@@ -12,9 +12,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
               "fullDescription": {
-                "text": "Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
-              },
-              "helpUri": "about:blank"
+                "text": "Use the try-convert tool (, version 0.4.0-dev) to convert the project file to an SDK-style csproj"
+              }
             }
           ]
         }
@@ -22,6 +21,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
+          "level": "note",
           "message": {
             "text": "Complete: Project file converted successfully! The project may require additional changes to build successfully against the new .NET target."
           },
@@ -48,17 +48,14 @@
           "rules": [
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-              "fullDescription": {
-                "text": "Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
-              },
-              "helpUri": "about:blank"
             }
           ]
         }
       },
       "results": [
         {
-          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, Version=42.42.42.42, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
           },
@@ -86,9 +83,8 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.SetTFMStep",
               "fullDescription": {
-                "text": "Updated TFM to net7.0-windows"
-              },
-              "helpUri": "about:blank"
+                "text": "Update TFM for current project"
+              }
             }
           ]
         }
@@ -96,6 +92,7 @@
       "results": [
         {
           "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.SetTFMStep",
+          "level": "note",
           "message": {
             "text": "Complete: Updated TFM to net7.0-windows"
           },
@@ -123,16 +120,16 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Add package 'Microsoft.Windows.Compatibility'"
-              },
-              "helpUri": "about:blank"
+                "text": "Adding Microsoft.Windows.Compatibility 5.0.2 helps with speeding up the upgrade process for Windows-based APIs"
+              }
             }
           ]
         }
       },
       "results": [
         {
-          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, Version=42.42.42.42, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.Windows.Compatibility'"
           },
@@ -160,16 +157,16 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
               "fullDescription": {
-                "text": "Remove package 'System.Data.DataSetExtensions'"
-              },
-              "helpUri": "about:blank"
+                "text": "Package System.Data.DataSetExtensions needs to be removed as its a transitive dependency that is not required"
+              }
             }
           ]
         }
       },
       "results": [
         {
-          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, Version=42.42.42.42, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "level": "note",
           "message": {
             "text": "Complete: Remove package 'System.Data.DataSetExtensions'"
           },

--- a/tests/tool/Integration.Tests/IntegrationScenarios/WpfSample/vb/Upgraded/UpgradeReport.sarif
+++ b/tests/tool/Integration.Tests/IntegrationScenarios/WpfSample/vb/Upgraded/UpgradeReport.sarif
@@ -12,7 +12,7 @@
             {
               "id": "Microsoft.DotNet.UpgradeAssistant.Steps.ProjectFormat.TryConvertProjectConverterStep",
               "fullDescription": {
-                "text": "Use the try-convert tool (, version 0.4.0-dev) to convert the project file to an SDK-style csproj"
+                "text": "Use the try-convert tool (, [VERSION]) to convert the project file to an SDK-style csproj"
               }
             }
           ]
@@ -47,14 +47,14 @@
           "informationUri": "https://github.com/dotnet/upgrade-assistant#usage",
           "rules": [
             {
-              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+              "id": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]"
             }
           ]
         }
       },
       "results": [
         {
-          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, Version=42.42.42.42, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
           "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers'"
@@ -128,7 +128,7 @@
       },
       "results": [
         {
-          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, Version=42.42.42.42, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
           "level": "note",
           "message": {
             "text": "Complete: Add package 'Microsoft.Windows.Compatibility'"
@@ -165,7 +165,7 @@
       },
       "results": [
         {
-          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, Version=42.42.42.42, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+          "ruleId": "Microsoft.DotNet.UpgradeAssistant.Steps.Packages.PackageUpdaterStep+PackageManipulationStep`1[[Microsoft.DotNet.UpgradeAssistant.NuGetReference, Microsoft.DotNet.UpgradeAssistant.Abstractions, [VERSION], Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
           "level": "note",
           "message": {
             "text": "Complete: Remove package 'System.Data.DataSetExtensions'"

--- a/tests/tool/Integration.Tests/UpgradeRunner.cs
+++ b/tests/tool/Integration.Tests/UpgradeRunner.cs
@@ -40,7 +40,7 @@ namespace Integration.Tests
             var project = new FileInfo(inputPath);
             using var cts = new CancellationTokenSource(maxDuration);
 
-            var options = new TestOptions(project);
+            var options = new IntegrationTestOptions(project);
             var status = await Host.CreateDefaultBuilder()
                 .UseEnvironment(Environments.Development)
                 .UseUpgradeAssistant<ConsoleUpgrade>(options)
@@ -50,6 +50,7 @@ namespace Integration.Tests
 
                     services.AddNonInteractive(options => options.Wait = TimeSpan.Zero, true);
                     services.AddKnownExtensionOptions(new() { Entrypoints = new[] { entrypoint }, SkipBackup = true });
+                    services.AddOptions<TestOptions>().Configure(options => options.IsRunningTest = true);
                 })
                 .ConfigureContainer<ContainerBuilder>(builder =>
                 {
@@ -75,9 +76,9 @@ namespace Integration.Tests
             return status;
         }
 
-        private class TestOptions : UpgradeAssistantCommandOptions
+        private class IntegrationTestOptions : UpgradeAssistantCommandOptions
         {
-            public TestOptions(FileInfo project)
+            public IntegrationTestOptions(FileInfo project)
             {
                 this.Project = project;
                 this.Verbose = true;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- IMPORTANT -->
**For PRs which target a specific extension within UA, changes won't be approved by a member of the `dotnet-upgrade-assistant-admin` group until a member of the code owners of the extension has approved, when required.**

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description
* Allow any version of .NetStandard to be migrated to MAUI
* Avoid unnecessary TFM merges for MAUI TFM SelectorFilter
* Always show 'dotnet --info' in case of workload install failure
* Added more information to log messages, such as project names
* Added MAUI step results to SARIF output
* Prevent endless failed step repetitions by adding Failed to IsDone
* Added failure level info to SARIF output using Note as default
* Added additional optional failure details to SARIF output
* Removed about:blank default which caused empty browser windows on click
* Fixed a few grammar and spelling issues

Addresses #1359
Addresses #988
