### PR TITLE
Use a hard-coded PackageId for Extensions.Default.Analyzers

### DIFF
--- a/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers.csproj
+++ b/src/extensions/default/analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers/Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- Avoid ID conflicts with the package project. -->
-    <PackageId>*$(MSBuildProjectFullPath)*</PackageId>
+    <PackageId>Real.Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers</PackageId>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="DefaultApiAlerts.apitargets" />


### PR DESCRIPTION
Don't use $(MSBuildProjectFullPath)* because it includes the full path and breaks NuGet caching logic on non-Windows platforms.


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the upgrade-assistant repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- IMPORTANT -->
**For PRs which target a specific extension within UA, changes won't be approved by a member of the `dotnet-upgrade-assistant-admin` group until a member of the code owners of the extension has approved, when required.**

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description
Detail 1
Detail 2

Addresses #bugnumber (in this specific format)
