### PR TITLE
Fixed memory corruption in VisualStudioFinder

### DIFF
--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/VisualStudioFinder.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/VisualStudioFinder.cs
@@ -44,35 +44,34 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
         private (string? Path, int? Version) GetLatestVisualStudioPath(string? suppliedPath)
         {
-            var latest = GetLatestPath(suppliedPath);
+            var latest = GetLatestVisualStudio(suppliedPath);
 
-            if (latest is null)
+            if (latest.InstallPath is null)
             {
                 _logger.LogWarning("Did not find a Visual Studio instance");
                 return default;
             }
 
-            var version = Version.Parse(latest.GetInstallationVersion());
-            var installation = latest.GetInstallationPath();
+            _logger.LogError("InstallationPath:{InstallPath}  Version:{Version}", latest.InstallPath, latest.Version);
 
-            if (Directory.Exists(installation))
+            if (Directory.Exists(latest.InstallPath))
             {
-                _logger.LogDebug("Using Visual Studio v{VsVersion} [{VsPath}]", version, installation);
+                _logger.LogDebug("Using Visual Studio v{VsVersion} [{VsPath}]", latest.Version, latest.InstallPath);
 
-                return (installation, version?.Major);
+                return (latest.InstallPath, latest.Version.Major);
             }
             else
             {
-                _logger.LogWarning("Found Visual Studio {VsVersion}, but directory '{VsPath}' does not exist.", version, installation);
+                _logger.LogWarning("Found Visual Studio {VsVersion}, but directory '{VsPath}' does not exist.", latest.Version, latest.InstallPath);
 
                 return default;
             }
         }
 
-        private ISetupInstance2? GetLatestPath(string? suppliedPath)
+        private (string? InstallPath, Version Version) GetLatestVisualStudio(string? suppliedPath)
         {
-            var result = default(ISetupInstance2);
             var resultVersion = new Version(0, 0);
+            string? resultPath = null;
 
             try
             {
@@ -116,17 +115,19 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
 
                         if (instanceHasMSBuild && instance is not null)
                         {
-                            if (suppliedPath is not null && string.Equals(suppliedPath, instance.GetInstallationPath(), StringComparison.OrdinalIgnoreCase))
+                            var installPath = instance.GetInstallationPath();
+
+                            if (suppliedPath is not null && string.Equals(suppliedPath, installPath, StringComparison.OrdinalIgnoreCase))
                             {
                                 _logger.LogTrace("Identified supplied path for Visual Studio v{Version} [{Path}]", version, instance.GetInstallationPath());
 
-                                return instance;
+                                return (installPath, version);
                             }
                             else if (version > resultVersion)
                             {
                                 _logger.LogTrace("Found Visual Studio v{Version} [{Path}]", version, instance.GetInstallationPath());
 
-                                result = instance;
+                                resultPath = installPath;
                                 resultVersion = version;
                             }
                         }
@@ -142,7 +143,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 // This is OK, VS "15" or greater likely not installed.
             }
 
-            return result;
+            return (resultPath, resultVersion);
         }
 
         private static ISetupConfiguration GetQuery()

--- a/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/VisualStudioFinder.cs
+++ b/src/components/Microsoft.DotNet.UpgradeAssistant.MSBuild/VisualStudioFinder.cs
@@ -52,8 +52,6 @@ namespace Microsoft.DotNet.UpgradeAssistant.MSBuild
                 return default;
             }
 
-            _logger.LogError("InstallationPath:{InstallPath}  Version:{Version}", latest.InstallPath, latest.Version);
-
             if (Directory.Exists(latest.InstallPath))
             {
                 _logger.LogDebug("Using Visual Studio v{VsVersion} [{VsPath}]", latest.Version, latest.InstallPath);


### PR DESCRIPTION
VisualStudioFinder.GetLatestPath() uses COM to iterate over the install locations for Visual Studio but somehow, once the method returns to the caller (GetLatestVisualStudioPath), none of the methods can be relied on to return sane values.

Therefore, the easiest solution is to track the values we care about and just return them to our caller who can then avoid needing to re-make the same COM invocations a second time.


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the upgrade-assistant repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- IMPORTANT -->
**For PRs which target a specific extension within UA, changes won't be approved by a member of the `dotnet-upgrade-assistant-admin` group until a member of the code owners of the extension has approved, when required.**

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description
Detail 1
Detail 2

Addresses #bugnumber (in this specific format)
