### PR TITLE
Fix android/ios.csproj target framework assignments

### DIFF
--- a/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiPlatformTargetFrameworkUpgradeStep.cs
+++ b/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiPlatformTargetFrameworkUpgradeStep.cs
@@ -126,15 +126,19 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
 
         private static TargetFrameworkMoniker GetExpectedTargetFramework(string componentFlagProperty)
         {
-            var propertyValue = (ProjectComponents)Enum.Parse(typeof(ProjectComponents), componentFlagProperty);
-            if (propertyValue.HasFlag(ProjectComponents.XamarinAndroid))
+            if (Enum.TryParse<ProjectComponents>(componentFlagProperty, out var propertyValue))
             {
-                return TargetFrameworkMoniker.Net70_Android;
+                if (propertyValue.HasFlag(ProjectComponents.XamarinAndroid))
+                {
+                    return TargetFrameworkMoniker.Net70_Android;
+                }
+                else
+                {
+                    return TargetFrameworkMoniker.Net70_iOS;
+                }
             }
-            else
-            {
-                return TargetFrameworkMoniker.Net70_iOS;
-            }
+
+            throw new ArgumentException(componentFlagProperty);
         }
 
         protected override async Task<bool> IsApplicableImplAsync(IUpgradeContext context, CancellationToken token)

--- a/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiPlatformTargetFrameworkUpgradeStep.cs
+++ b/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiPlatformTargetFrameworkUpgradeStep.cs
@@ -126,8 +126,8 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
 
         private static TargetFrameworkMoniker GetExpectedTargetFramework(string componentFlagProperty)
         {
-            var propertyValue = Enum.Parse(typeof(ProjectComponents), componentFlagProperty);
-            if (ProjectComponents.XamarinAndroid.CompareTo(propertyValue) == 0)
+            var propertyValue = (ProjectComponents)Enum.Parse(typeof(ProjectComponents), componentFlagProperty);
+            if (propertyValue.HasFlag(ProjectComponents.XamarinAndroid))
             {
                 return TargetFrameworkMoniker.Net70_Android;
             }

--- a/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiPlatformTargetFrameworkUpgradeStep.cs
+++ b/src/extensions/maui/Microsoft.DotNet.UpgradeAssistant.Extensions.Maui/MauiPlatformTargetFrameworkUpgradeStep.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
             var targetTfm = GetExpectedTargetFramework(componentFlagProperty);
             if (targetTfm is null)
             {
-                return context.CreateAndAddStepApplyResult(this, UpgradeStepStatus.Failed, $"targetTfm componentFlag in Context property was null");
+                return context.CreateAndAddStepApplyResult(this, UpgradeStepStatus.Failed, $"Failed to retrieve target TFM from component flag context property: '{componentFlagProperty}'");
             }
 
             file.SetTFM(targetTfm);
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.UpgradeAssistant.Extensions.Maui
             var targetTfm = GetExpectedTargetFramework(componentFlagProperty);
             if (targetTfm is null)
             {
-                return new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"targetTfm or componentFlag Property in Context was null.", BuildBreakRisk.High);
+                return new UpgradeStepInitializeResult(UpgradeStepStatus.Incomplete, $"Failed to retrieve target TFM from component flag context property: '{componentFlagProperty}'", BuildBreakRisk.High);
             }
 
             if (project.TargetFrameworks.Any(tfm => tfm == targetTfm))

--- a/src/extensions/try-convert/MSBuild.Abstractions/BaselineProject.cs
+++ b/src/extensions/try-convert/MSBuild.Abstractions/BaselineProject.cs
@@ -75,7 +75,7 @@ namespace MSBuild.Abstractions
             }
 
             // MSBuildHelpers.IsWindows(rawTFM) can happen when coverting a UWP
-            return MSBuildHelpers.IsNotNetFramework(rawTFM) && !MSBuildHelpers.IsWindows(rawTFM) && !MSBuildHelpers.IsMobileAppSDK(rawTFM)
+            return MSBuildHelpers.IsNotNetFramework(rawTFM) && !MSBuildHelpers.IsWindows(rawTFM) && !MSBuildHelpers.IsMobile(rawTFM)
                 ? StripDecimals(rawTFM) : rawTFM;
 
             static string StripDecimals(string tfm)

--- a/src/extensions/try-convert/MSBuild.Abstractions/BaselineProject.cs
+++ b/src/extensions/try-convert/MSBuild.Abstractions/BaselineProject.cs
@@ -75,7 +75,8 @@ namespace MSBuild.Abstractions
             }
 
             // MSBuildHelpers.IsWindows(rawTFM) can happen when coverting a UWP
-            return MSBuildHelpers.IsNotNetFramework(rawTFM) && !MSBuildHelpers.IsWindows(rawTFM) ? StripDecimals(rawTFM) : rawTFM;
+            return MSBuildHelpers.IsNotNetFramework(rawTFM) && !MSBuildHelpers.IsWindows(rawTFM) && !MSBuildHelpers.IsMobileAppSDK(rawTFM)
+                ? StripDecimals(rawTFM) : rawTFM;
 
             static string StripDecimals(string tfm)
             {

--- a/src/extensions/try-convert/MSBuild.Abstractions/MSBuildHelpers.cs
+++ b/src/extensions/try-convert/MSBuild.Abstractions/MSBuildHelpers.cs
@@ -303,6 +303,13 @@ namespace MSBuild.Abstractions
             && !tfm.ContainsIgnoreCase(MSBuildFacts.NetstandardPrelude);
 
         /// <summary>
+        /// Checks if a given TFM has an Android or iOS suffix.
+        /// </summary>
+        public static bool IsMobileAppSDK(string tfm) =>
+            tfm.ContainsIgnoreCase(MSBuildFacts.iOSSuffix)
+            || tfm.ContainsIgnoreCase(MSBuildFacts.AndroidSuffix);
+
+        /// <summary>
         /// Checks if a given TFM include -windows.
         /// </summary>
         public static bool IsWindows(string tfm) =>

--- a/src/extensions/try-convert/MSBuild.Abstractions/MSBuildHelpers.cs
+++ b/src/extensions/try-convert/MSBuild.Abstractions/MSBuildHelpers.cs
@@ -306,7 +306,7 @@ namespace MSBuild.Abstractions
         /// Checks if a given TFM has an Android or iOS suffix.
         /// </summary>
         public static bool IsMobile(string tfm) =>
-            tfm.ContainsIgnoreCase(MSBuildFacts.iOSSuffix)
+            tfm.ContainsIgnoreCase(MSBuildFacts.IOSSuffix)
             || tfm.ContainsIgnoreCase(MSBuildFacts.AndroidSuffix);
 
         /// <summary>

--- a/src/extensions/try-convert/MSBuild.Abstractions/MSBuildHelpers.cs
+++ b/src/extensions/try-convert/MSBuild.Abstractions/MSBuildHelpers.cs
@@ -305,7 +305,7 @@ namespace MSBuild.Abstractions
         /// <summary>
         /// Checks if a given TFM has an Android or iOS suffix.
         /// </summary>
-        public static bool IsMobileAppSDK(string tfm) =>
+        public static bool IsMobile(string tfm) =>
             tfm.ContainsIgnoreCase(MSBuildFacts.iOSSuffix)
             || tfm.ContainsIgnoreCase(MSBuildFacts.AndroidSuffix);
 

--- a/src/extensions/try-convert/MSBuild.Conversion.Facts/MSBuildFacts.cs
+++ b/src/extensions/try-convert/MSBuild.Conversion.Facts/MSBuildFacts.cs
@@ -307,7 +307,7 @@ namespace MSBuild.Conversion.Facts
         public const string Net5 = "net5.0";
         public const string WindowsSuffix = "-windows";
         public const string AndroidSuffix = "-android";
-        public const string iOSSuffix = "-ios";
+        public const string IOSSuffix = "-ios";
         public const string Net5Windows = "net5.0-windows";
         public const string Net6 = "net6.0";
         public const string Net6Windows = "net6.0-windows";

--- a/src/extensions/try-convert/MSBuild.Conversion.Facts/MSBuildFacts.cs
+++ b/src/extensions/try-convert/MSBuild.Conversion.Facts/MSBuildFacts.cs
@@ -306,6 +306,8 @@ namespace MSBuild.Conversion.Facts
         public const string MonoAndroid = "MonoAndroid";
         public const string Net5 = "net5.0";
         public const string WindowsSuffix = "-windows";
+        public const string AndroidSuffix = "-android";
+        public const string iOSSuffix = "-ios";
         public const string Net5Windows = "net5.0-windows";
         public const string Net6 = "net6.0";
         public const string Net6Windows = "net6.0-windows";


### PR DESCRIPTION
## Description

- Fixes android <TargetFramework> to display "net7.0-android" instead of "net7.0-ios"
- Fixes the versioning for <TargetFramework> for android and ios to net7.0 instead of net70

Baseline project is used for the TryConvert step which is where the changes to the TargetFramework property are made. 

Addresses #1463, #1464 
