### PR TITLE
Fix the wildcards used to determine unit test assembly names

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -84,9 +84,7 @@ extends:
           displayName: Run Unit Tests
           inputs:
             testAssemblyVer2: |-
-              **\*UnitTests.dll
-              !**\*TestAdapter.dll
-              !**\obj\**
+              **\UpgradeAssistant.*.Tests.dll
         - task: VSBuild@1
           displayName: Build Mappings NuGet package
           inputs:


### PR DESCRIPTION
This will hopefully fix the Azure pipeline logic for running the unit tests.


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the upgrade-assistant repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- IMPORTANT -->
**For PRs which target a specific extension within UA, changes won't be approved by a member of the `dotnet-upgrade-assistant-admin` group until a member of the code owners of the extension has approved, when required.**

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description
Detail 1
Detail 2

Addresses #bugnumber (in this specific format)
