### PR TITLE
Pack UpgradeAssistant.Mappings w/o the dll

### DIFF
--- a/src/UpgradeAssistant.Mappings/UpgradeAssistant.Mappings.csproj
+++ b/src/UpgradeAssistant.Mappings/UpgradeAssistant.Mappings.csproj
@@ -16,6 +16,7 @@
     <RepositoryUrl>https://github.com/dotnet/upgrade-assistant</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Docs for this can be found here: https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets

Tested and here are the contents with this patch:

```
unzip -l src/UpgradeAssistant.Mappings/bin/Debug/Microsoft.UpgradeAssistant.Mappings.1.0.0-ga67b3de759.nupkg
Archive:  src/UpgradeAssistant.Mappings/bin/Debug/Microsoft.UpgradeAssistant.Mappings.1.0.0-ga67b3de759.nupkg
  Length      Date    Time    Name
---------  ---------- -----   ----
      529  2024-06-14 14:51   _rels/.rels
      899  2024-06-14 14:51   Microsoft.UpgradeAssistant.Mappings.nuspec
      118  2024-06-04 18:10   content/mappings/jsuarezruiz/AlohaKit.Animations/alohakit.animations.apimap.json
      253  2024-05-31 17:39   content/mappings/jsuarezruiz/AlohaKit.Animations/alohakit.animations.packagemap.json
       59  2024-05-31 17:39   content/mappings/jsuarezruiz/AlohaKit.Animations/metadata.json
     8336  2024-05-31 17:39   README.md
      528  2024-06-14 14:51   [Content_Types].xml
      717  2024-06-14 14:51   package/services/metadata/core-properties/40d1384873114959a95d7c100ce352e1.psmdcp
---------                     -------
    11439                     8 files
```