### PR TITLE
Timestamp NuGet packages

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);TimestampNugetPackage</GenerateNuspecDependsOn>
+
+    <!-- Enable package timestamping by default -->
+    <TimestampPackage Condition=" '$(TimestampPackage)' == ''">true</TimestampPackage>
+  </PropertyGroup>
+
+  <Target Name="TimestampNugetPackage">
+    <PropertyGroup>
+      <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd-HHmm))</CurrentDate>
+      <PackageVersion Condition="'$(TimestampPackage)' == 'true'">$(PackageVersion)-CI-$(CurrentDate)</PackageVersion>
+      <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,7 +10,7 @@
   <Target Name="TimestampNugetPackage">
     <PropertyGroup>
       <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd-HHmm))</CurrentDate>
-      <PackageVersion Condition="'$(TimestampPackage)' == 'true'">$(PackageVersion)-CI-$(CurrentDate)</PackageVersion>
+      <PackageVersion Condition="'$(TimestampPackage)' == 'true'">$(PackageVersion)-preview.$(CurrentDate)</PackageVersion>
       <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
     </PropertyGroup>
   </Target>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.0",
+  "version": "1.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Several people have been bitten while testing the UpgradeAssistant with local builds of the Mappings nuget package because every build produces the same versioned package and if they forget to delete the cached version in the NuGet cache directory, then their changes will appear to not take affect because UA is using an old version of their changes.

Also modified the Nerdbank.GitVersioning version.json file to use a base of "1.0" instead of "1.0.0".
