### PR TITLE
Use publishFeedCredentials instead of externalEndpoint for publishing

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -45,7 +45,7 @@ extends:
             packageParentPath: '$(Build.ArtifactStagingDirectory)\Packages'
             packagesToPush: $(Build.ArtifactStagingDirectory)\Packages\*.nupkg;!$(Build.ArtifactStagingDirectory)\Packages\*.symbols.nupkg
             nuGetFeedType: external
-            externalEndpoint: XamlBehaviors-NuGet.org
+            publishFeedCredentials: XamlBehaviors-NuGet.org
         steps:
         - checkout: self
           clean: true


### PR DESCRIPTION
The `externalEndpoint` property was an alias for `publishFeedCredentials`, but clearly doesn't work correctly in 1ES pipelines and we need to explicitly use `publishFeedCredentials`.