### PR TITLE
Update modernize-dotnet plugin to 1.0.1026-preview1

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "modernize-dotnet-plugins",
   "metadata": {
     "description": ".NET Upgrade Assistant plugins for GitHub Copilot",
-    "version": "1.0.1017-preview1"
+    "version": "1.0.1026-preview1"
   },
   "owner": {
     "name": "Microsoft"
@@ -12,7 +12,7 @@
       "name": "modernize-dotnet",
       "source": "./plugins/modernize-dotnet",
       "description": "AI-powered .NET modernization and upgrade assistant. Helps upgrade .NET Framework and .NET applications to the latest versions of .NET.",
-      "version": "1.0.1017-preview1"
+      "version": "1.0.1026-preview1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This changelog applies to the custom agent available in this repo for Copilot CLI and Copilot Coding Agent as well as in the Visual Studio Code extension
 
+## 1.0.1026-preview1
+
+### Added
+- Added new Apire Integration scenario for adding Aspire support to existing applications for inner-loop and Azure deployment
+- Added new Aspire Version Upgrade scenario for upgrading Aspire applications to newer versions
+
+### Changed
+- Updated EF6 Code First migration, MVC configuration, Aspire integration, and .NET version upgrade skills
+
 ## 1.0.1017-preview1
 
 ### Added

--- a/plugins/modernize-dotnet/.github/plugin/plugin.json
+++ b/plugins/modernize-dotnet/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "modernize-dotnet",
-  "version": "1.0.1017-preview1",
+  "version": "1.0.1026-preview1",
   "description": "AI-powered .NET modernization and upgrade assistant. Helps upgrade .NET Framework and .NET applications to the latest versions of .NET.",
   "author": {
     "name": "Microsoft"


### PR DESCRIPTION
Automated update of modernize-dotnet plugin from UpgradeAssistant build main-20260406.1 (version 1.0.1026-preview1).