### PR TITLE
Update modernize-dotnet plugin to 1.0.1037-preview1

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "modernize-dotnet-plugins",
   "metadata": {
     "description": ".NET Upgrade Assistant plugins for GitHub Copilot",
-    "version": "1.0.1026-preview1"
+    "version": "1.0.1037-preview1"
   },
   "owner": {
     "name": "Microsoft"
@@ -12,7 +12,7 @@
       "name": "modernize-dotnet",
       "source": "./plugins/modernize-dotnet",
       "description": "AI-powered .NET modernization and upgrade assistant. Helps upgrade .NET Framework and .NET applications to the latest versions of .NET.",
-      "version": "1.0.1026-preview1"
+      "version": "1.0.1037-preview1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This changelog applies to the custom agent available in this repo for Copilot CLI and Copilot Coding Agent as well as in the Visual Studio Code extension
 
+## 1.0.1037-preview1
+
+### Added
+- Added OpenTelemetry tracing support for MCP server and Copilot CLI
+
+### Changed
+- Removed deprecated o1 and o3 LLM model options
+- Improved repository root detection during state initialization
+- Improved context detection for Copilot Coding Agent
+
 ## 1.0.1026-preview1
 
 ### Added

--- a/plugins/modernize-dotnet/.github/plugin/plugin.json
+++ b/plugins/modernize-dotnet/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "modernize-dotnet",
-  "version": "1.0.1026-preview1",
+  "version": "1.0.1037-preview1",
   "description": "AI-powered .NET modernization and upgrade assistant. Helps upgrade .NET Framework and .NET applications to the latest versions of .NET.",
   "author": {
     "name": "Microsoft"


### PR DESCRIPTION
Automated update of modernize-dotnet plugin from UpgradeAssistant build main-20260410.2 (version 1.0.1037-preview1).