### PR TITLE
Add step to copy README from modernize-dotnet repo

### DIFF
--- a/coding-agent/linux/copilot-setup-steps.yml
+++ b/coding-agent/linux/copilot-setup-steps.yml
@@ -15,5 +15,12 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - run: curl -fsSL -o README.md https://raw.githubusercontent.com/dotnet/modernize-dotnet/main/README.md
+      - run: |
+          mkdir -p .github/agents
+          cat > .github/agents/modernize-dotnet.agent.md << 'EOF'
+          ---
+          name: modernize-dotnet
+          ---
+          You are a test agent. When invoked, respond only with "Hello World!" and nothing else.
+          EOF
         shell: bash

--- a/coding-agent/linux/copilot-setup-steps.yml
+++ b/coding-agent/linux/copilot-setup-steps.yml
@@ -14,3 +14,13 @@ jobs:
       - uses: dotnet/modernize-dotnet-actions@main
         with:
           dotnet-version: '10.0.x'
+
+      - uses: actions/checkout@v4
+        with:
+          repository: dotnet/modernize-dotnet
+          path: _modernize-dotnet
+          sparse-checkout: |
+            README.md
+
+      - run: cp _modernize-dotnet/README.md ./
+        shell: bash

--- a/coding-agent/linux/copilot-setup-steps.yml
+++ b/coding-agent/linux/copilot-setup-steps.yml
@@ -15,12 +15,5 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - uses: actions/checkout@v4
-        with:
-          repository: dotnet/modernize-dotnet
-          path: _modernize-dotnet
-          sparse-checkout: |
-            README.md
-
-      - run: cp _modernize-dotnet/README.md ./
+      - run: curl -fsSL -o README.md https://raw.githubusercontent.com/dotnet/modernize-dotnet/main/README.md
         shell: bash

--- a/coding-agent/windows/copilot-setup-steps.yml
+++ b/coding-agent/windows/copilot-setup-steps.yml
@@ -16,3 +16,13 @@ jobs:
           dotnet-version: '10.0.x'
           #set 'true' to install .NET Framework SDK and targeting packs (4.7.1 – 4.8.1) on Windows runners, required for .NET Framework or desktop workloads
           install-framework-targeting-packs: 'true'
+
+      - run: |
+          New-Item -ItemType Directory -Force -Path .github\agents | Out-Null
+          @"
+          ---
+          name: modernize-dotnet
+          ---
+          You are a test agent. When invoked, respond only with "Hello World!" and nothing else.
+          "@ | Set-Content -Path .github\agents\modernize-dotnet.agent.md
+        shell: pwsh


### PR DESCRIPTION
Test PR to verify that a `copilot-setup-steps.yml` workflow can copy a file from this repo (`dotnet/modernize-dotnet`) into the user's repo workspace at runtime.

## Approach

Adds two steps after the existing `dotnet/modernize-dotnet-actions@main` setup:

1. **Sparse checkout** of this repo using `actions/checkout@v4`, pulling only `README.md` into a temporary `_modernize-dotnet/` directory.
2. **Copy** the file into the user's repo root.

This is a proof-of-concept -- if it works, the same pattern can be used to copy any file (e.g., config, templates) from this repo into the user's workspace during Copilot setup.