### PR TITLE
Forward MODERNIZE_DOTNET_ACTIONS_SETUP env var to MCP server

### DIFF
--- a/coding-agent/modernize-dotnet.agent.md
+++ b/coding-agent/modernize-dotnet.agent.md
@@ -15,6 +15,7 @@ mcp-servers:
     tools: ['*']
     env:
       APPMOD_CALLER_TYPE: copilot-coding-agent
+      MODERNIZE_DOTNET_ACTIONS_SETUP: ${MODERNIZE_DOTNET_ACTIONS_SETUP}
 ---
 
 


### PR DESCRIPTION
## Summary

Adds `MODERNIZE_DOTNET_ACTIONS_SETUP` to the Modernization MCP server's `env` block in the agent frontmatter, so the server process can detect when the runner was set up by the `modernize-dotnet-actions` action.

## Changes

- **`coding-agent/modernize-dotnet.agent.md`**: Added `MODERNIZE_DOTNET_ACTIONS_SETUP: ${MODERNIZE_DOTNET_ACTIONS_SETUP}` to the MCP server's `env` configuration alongside the existing `APPMOD_CALLER_TYPE`.

## Context

The companion repo `dotnet/modernize-dotnet-actions` now exports `MODERNIZE_DOTNET_ACTIONS_SETUP=true` into `$GITHUB_ENV` during its setup step. This change forwards that env var into the MCP server config so it can be read by the server process at runtime.