### PR TITLE
Update modernize-dotnet plugin to 1.0.1161-preview1

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "modernize-dotnet-plugins",
   "metadata": {
     "description": ".NET Upgrade Assistant plugins for GitHub Copilot",
-    "version": "1.0.1157-preview1"
+    "version": "1.0.1161-preview1"
   },
   "owner": {
     "name": "Microsoft"
@@ -12,7 +12,7 @@
       "name": "modernize-dotnet",
       "source": "./plugins/modernize-dotnet",
       "description": "AI-powered .NET modernization and upgrade assistant. Helps upgrade .NET Framework and .NET applications to the latest versions of .NET.",
-      "version": "1.0.1157-preview1"
+      "version": "1.0.1161-preview1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog applies to the custom agent available in this repo for Copilot CLI and Copilot Coding Agent as well as in the Visual Studio Code extension
 
+## 1.0.1161-preview1
+
+### Deprecated
+- Added deprecation notices guiding users to migrate from `modernize-dotnet` to `upgrade-agent` (agent `@upgrade`). The plugin and agent still work, but new features and fixes now ship only to `upgrade-agent`.
+- The VS Code extension now shows a deprecation notice pointing users to the GitHub Copilot upgrade experience.
+
 ## 1.0.1157-preview1
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # .NET Modernization Agent
 
+> [!WARNING]
+> **`modernize-dotnet` is deprecated — it has moved to [`upgrade-agent`](https://github.com/microsoft/upgrade-agent-plugins).**
+> This plugin still works today, but new features and fixes now ship only to `upgrade-agent` (agent `@upgrade`). Please migrate:
+>
+> ```
+> /plugin marketplace add microsoft/upgrade-agent-plugins
+> /plugin install upgrade-agent@upgrade-agent-plugins
+> ```
+
 AI-powered agent for upgrading and modernizing .NET applications across multiple development environments.
 
 Use the modernize-dotnet agent to analyze your application, generate an upgrade plan, and apply changes to move to the latest .NET.

--- a/plugins/modernize-dotnet/.github/plugin/plugin.json
+++ b/plugins/modernize-dotnet/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "modernize-dotnet",
-  "version": "1.0.1157-preview1",
+  "version": "1.0.1161-preview1",
   "description": "AI-powered .NET modernization and upgrade assistant. Helps upgrade .NET Framework and .NET applications to the latest versions of .NET.",
   "author": {
     "name": "Microsoft"

--- a/plugins/modernize-dotnet/README.md
+++ b/plugins/modernize-dotnet/README.md
@@ -1,8 +1,19 @@
 # .NET Modernization Plugin
 
+> [!WARNING]
+> **`modernize-dotnet` is deprecated — it has moved to [`upgrade-agent`](https://github.com/microsoft/upgrade-agent-plugins).**
+> This plugin still works today, but new features and fixes now ship only to `upgrade-agent` (agent `@upgrade`). Please migrate:
+>
+> ```
+> /plugin marketplace add microsoft/upgrade-agent-plugins
+> /plugin install upgrade-agent@upgrade-agent-plugins
+> ```
+
 AI-powered assistance for upgrading and modernizing .NET applications. This plugin adds the **modernize-dotnet** agent to your Copilot CLI.
 
-## Installation
+## Legacy installation
+
+> This installs the **deprecated** `modernize-dotnet` plugin, which still works today. For new setups, use [`upgrade-agent`](https://github.com/microsoft/upgrade-agent-plugins) instead — see the deprecation notice above.
 
 Add the marketplace, then install the plugin:
 

--- a/plugins/modernize-dotnet/agents/modernize-dotnet.agent.md
+++ b/plugins/modernize-dotnet/agents/modernize-dotnet.agent.md
@@ -6,7 +6,7 @@ mcp-servers:
     type: 'local'
     command: 'dnx'
     args: [
-      'Microsoft.GitHubCopilot.Modernization.Mcp@1.0.1157-preview1',
+      'Microsoft.GitHubCopilot.Modernization.Mcp@1.0.1161-preview1',
       '--yes',
       '--ignore-failed-sources'
     ]
@@ -34,6 +34,19 @@ Never start upgrade/migration/modernization *work* based on your own knowledge o
 - **Name**: GitHub Copilot Modernization Agent
 - **Purpose**: Help developers upgrade .NET projects to newer frameworks, migrate legacy code, and modernize applications
 - **Approach**: Methodical, task-driven execution with validation at each step
+
+## Deprecation Notice
+
+The **`modernize-dotnet`** plugin (agent **`@modernize-dotnet`**) is **deprecated**. Its replacement is the **`upgrade-agent`** plugin (agent **`@upgrade`**), published at `microsoft/upgrade-agent-plugins`.
+
+In your **first** user-visible message of a session — after completing any mandatory `⚠️ STOP` workflow steps it requires (for example `get_state()`), and unless this notice already appears earlier in the conversation — briefly and politely tell the user:
+- `modernize-dotnet` is deprecated; **`upgrade-agent`** is the replacement.
+- To install it:
+  - `/plugin marketplace add microsoft/upgrade-agent-plugins`
+  - `/plugin install upgrade-agent@upgrade-agent-plugins`
+- This plugin still works, so you will continue with their request now.
+
+Then proceed with the normal workflow. This notice never precedes or overrides the `⚠️ STOP` steps above — complete those first, then include it in your first user-visible reply. Surface it **once per session** — if it already appears in the transcript (for example, on a resumed session), skip it. Never stop, block, or refuse work because of this notice.
 
 ## Core Tools
 


### PR DESCRIPTION
Automated update of modernize-dotnet plugin from UpgradeAssistant build main-20260715.2 (14667856) (version 1.0.1161-preview1).

<sub><em><img src="https://raw.githubusercontent.com/tlmii/tlmii/main/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;">&nbsp;&nbsp;Generated via Copilot (Claude Opus 4.8) on behalf of @tlmii</em></sub>